### PR TITLE
Add Franka RViz + ros2_control mock hardware example

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -83,6 +83,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.0-gpl_hbbdf940_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -473,6 +474,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.0-gpl_h0a60610_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -789,11 +791,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-hdf8817f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
@@ -861,9 +867,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.10.3-np20py311h2672b3f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -876,6 +884,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.1-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
@@ -883,14 +892,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.9-h86084c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -905,6 +923,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.19-h0804adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -935,9 +954,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.71-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-36_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_h99862b1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.1-ha55d5d9_1.conda
@@ -947,7 +967,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
@@ -958,16 +980,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
@@ -979,11 +1004,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-cmake2-2.17.2-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-math6-6.15.1-py311h4d89148_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-h6cb5226_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-36_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-36_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
@@ -1015,6 +1043,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.6-h3675c94_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h2fe6a88_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
@@ -1025,20 +1054,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.4-h3dc2cb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.20.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.4-h9a4d06a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.12-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.9-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.313.0-h5279c79_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
@@ -1052,6 +1080,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.6-py311h38be061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py311h0f3be63_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -1070,6 +1099,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.10.0-h84d6215_0.conda
@@ -1079,6 +1110,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-hecca717_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -1087,12 +1119,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h98278a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.7.0-py311hd79ae85_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.0-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py311h5956852_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -1107,19 +1143,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.1-py311h1ddb823_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.9.0-py311h0372a8f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ackermann-msgs-2.0.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ackermann-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-action-msgs-1.2.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-actionlib-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-admittance-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-cmake-1.3.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-cmake-auto-1.3.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-cmake-copyright-0.12.12-np126py311hbc2a38a_13.conda
@@ -1163,24 +1204,53 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-pep257-0.12.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-uncrustify-0.12.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-xmllint-0.12.12-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-angles-1.15.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-backward-ros-1.0.8-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-bicycle-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-builtin-interfaces-1.2.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-class-loader-2.2.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-common-interfaces-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-composition-interfaces-1.2.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-console-bridge-vendor-1.4.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-control-msgs-4.8.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-control-toolbox-3.6.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-interface-2.51.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-manager-2.51.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-manager-msgs-2.51.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-cyclonedds-0.10.5-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-diagnostic-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-diff-drive-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-domain-coordinator-0.10.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-effort-controllers-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-fastcdr-1.0.24-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-fastrtps-2.6.10-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-filters-2.2.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-force-torque-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-forward-command-controller-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-generate-parameter-library-0.5.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-geometry-msgs-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gmock-vendor-1.10.9006-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gpio-controllers-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gripper-controllers-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gtest-vendor-1.10.9006-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-hardware-interface-2.51.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-iceoryx-posh-2.0.5-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h58b36e0_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-image-transport-3.1.12-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-imu-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-interactive-markers-2.3.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-joint-state-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-joint-trajectory-controller-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-kdl-parser-2.6.4-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-kinematics-interface-0.4.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-laser-geometry-2.4.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-1.0.9-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-ros-0.19.10-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-testing-1.0.9-np126py311hbc2a38a_13.conda
@@ -1188,13 +1258,25 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-testing-ros-0.19.10-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-xml-1.0.9-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-yaml-1.0.9-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-libcurl-vendor-3.1.3-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-libstatistics-collector-1.3.4-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-libyaml-vendor-1.2.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-lifecycle-msgs-1.2.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-map-msgs-2.1.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-mecanum-drive-controller-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-message-filters-4.3.7-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-nav-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-osrf-pycommon-2.1.6-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-parameter-traits-0.5.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pid-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pluginlib-5.1.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pose-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-position-controllers-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pybind11-vendor-2.4.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-python-cmake-module-0.10.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-range-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcl-5.3.9-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcl-action-5.3.9-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcl-interfaces-1.2.1-np126py311hbc2a38a_13.conda
@@ -1209,6 +1291,8 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rclpy-3.3.16-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcpputils-2.4.5-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcutils-5.1.6-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-realtime-tools-2.14.0-np126py311h122846f_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-resource-retriever-3.1.3-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-6.1.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-connextdds-0.11.3-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311hbc2a38a_13.conda
@@ -1219,9 +1303,12 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-implementation-2.8.4-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-robot-state-publisher-3.0.3-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros-environment-3.2.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros-workspace-1.0.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2-controllers-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2action-0.18.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2cli-0.18.12-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311hbc2a38a_13.conda
@@ -1258,8 +1345,16 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rpyutils-0.2.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rsl-1.2.0-np126py311h58b36e0_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-common-11.2.18-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-default-plugins-11.2.18-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311h0de9e34_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-rendering-11.2.18-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz2-11.2.18-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-sensor-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-sensor-msgs-py-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-shape-msgs-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-spdlog-vendor-1.3.1-np126py311h11365e7_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-sros2-0.10.6-np126py311hbc2a38a_13.conda
@@ -1267,12 +1362,31 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-statistics-msgs-1.2.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-std-msgs-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-std-srvs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-steering-controllers-library-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-stereo-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tcb-span-1.0.2-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-eigen-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-kdl-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-msgs-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-py-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-ros-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-ros-py-0.25.14-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tinyxml-vendor-0.8.3-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311hbc2a38a_14.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tl-expected-1.0.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tracetools-4.1.1-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-trajectory-msgs-4.9.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tricycle-controller-2.48.0-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tricycle-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-uncrustify-vendor-2.0.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdf-2.6.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hbc2a38a_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdfdom-4.0.1-py311h82375c7_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdfdom-headers-1.0.6-py311h82375c7_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-velocity-controllers-2.48.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-visualization-msgs-4.9.0-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311hbc2a38a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-64/ros2-distro-mutex-0.7.0-humble_13.conda
@@ -1282,8 +1396,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.10.0-h159367c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.25.2-py311hed34c8f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py311h1e13796_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.14-he3e324a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
@@ -1294,6 +1408,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.2.0-hb60516a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2025.9.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
@@ -1308,7 +1423,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h49ec1c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.0.6-h924138e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
@@ -1327,6 +1442,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
@@ -1334,11 +1450,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
@@ -1351,15 +1473,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.5-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.44-hdf4bb16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
@@ -1427,9 +1554,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.10.3-np20py311h639b07a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.193-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-11.2.0-h97e1849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -1442,20 +1571,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.60.1-py311h164a683_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.3-h90308e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.0-h9414720_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.0-hc87f4d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.17.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.9-h5313800_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-12.2.1-h044d27a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.1.0-he4899c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_h587839b_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -1470,6 +1609,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.19-h05dc504_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.8-h27a9ab5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
@@ -1499,9 +1639,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-he30d5cf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-he30d5cf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-he30d5cf_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.76-h5706e9e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.71-h51d75a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-36_hd72aa62_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he95a3c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.0-default_he95a3c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.1-h18504b1_1.conda
@@ -1511,7 +1652,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.1-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
@@ -1522,16 +1665,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.1.0-hd0aa34e_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.0-h7cdfd2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.55-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
@@ -1543,11 +1689,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwy-1.3.0-h81d0cf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.8-h53e0a65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-cmake2-2.17.2-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-math6-6.15.1-py311h9dbc854_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h0b3ff8d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-36_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-36_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-h2edbd07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.1-h86ecc28_2.conda
@@ -1577,6 +1726,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.6-hb4b1422_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.29.3-h9267e96_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h9b423fc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h68efd32_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
@@ -1587,19 +1737,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.1.0-hd0aa34e_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.9-hd926fa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.4-h27834fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.20.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-h7a57436_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.9-hf39d17c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.4-h1187dce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.12-hfefdfc9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.6.2-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.9-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libusb-1.0.29-h06eaf92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.2-h3e4203c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvulkan-loader-1.4.313.0-h8b8848b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
@@ -1613,6 +1762,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h80f16a2_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py311h2dad8b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.10.6-py311hfecb2dc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.6-py311hb9c6b48_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -1631,6 +1781,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.37-h3ad9384_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.117-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.10.0-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.5-h1fc2f77_0.conda
@@ -1638,6 +1790,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.4-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-hfae3067_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
@@ -1646,12 +1799,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.3.0-py311h3bd873a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.7.0-py311h799fced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.1.0-py311h19352d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h77cf2aa_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py311h01b6c42_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -1666,19 +1823,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.13-h1683364_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-orocos-kdl-1.5.1-py311h2cb90db_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pywavelets-1.9.0-py311h1ed8e69_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py311h164a683_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hbe73643_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.9.2-h6c90349_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rav1e-0.7.1-ha3529ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ackermann-msgs-2.0.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ackermann-steering-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-action-msgs-1.2.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-actionlib-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-admittance-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-cmake-1.3.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-cmake-auto-1.3.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-cmake-copyright-0.12.12-np126py311hbdd918e_13.conda
@@ -1722,24 +1884,53 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-pep257-0.12.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-uncrustify-0.12.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ament-xmllint-0.12.12-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-angles-1.15.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-backward-ros-1.0.8-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-bicycle-steering-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-builtin-interfaces-1.2.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-class-loader-2.2.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-common-interfaces-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-composition-interfaces-1.2.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-console-bridge-vendor-1.4.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-control-msgs-4.8.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-control-toolbox-3.6.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-interface-2.51.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-manager-2.51.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-manager-msgs-2.51.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-cyclonedds-0.10.5-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-diagnostic-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-diff-drive-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-domain-coordinator-0.10.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-effort-controllers-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-fastcdr-1.0.24-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-fastrtps-2.6.10-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-filters-2.2.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-force-torque-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-forward-command-controller-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-0.5.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-geometry-msgs-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gmock-vendor-1.10.9006-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gpio-controllers-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gripper-controllers-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gtest-vendor-1.10.9006-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-hardware-interface-2.51.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-iceoryx-binding-c-2.0.5-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-iceoryx-hoofs-2.0.5-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-iceoryx-posh-2.0.5-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311hfe9da55_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-image-transport-3.1.12-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-imu-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-interactive-markers-2.3.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-joint-state-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-joint-trajectory-controller-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-kdl-parser-2.6.4-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-kinematics-interface-0.4.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-laser-geometry-2.4.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-1.0.9-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-ros-0.19.10-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-testing-1.0.9-np126py311hbdd918e_13.conda
@@ -1747,13 +1938,25 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-testing-ros-0.19.10-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-xml-1.0.9-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-launch-yaml-1.0.9-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-libcurl-vendor-3.1.3-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-libstatistics-collector-1.3.4-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-libyaml-vendor-1.2.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-lifecycle-msgs-1.2.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-map-msgs-2.1.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-mecanum-drive-controller-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-message-filters-4.3.7-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-nav-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-osrf-pycommon-2.1.6-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-parameter-traits-0.5.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pid-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pluginlib-5.1.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pose-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-position-controllers-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pybind11-vendor-2.4.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-python-cmake-module-0.10.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-range-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rcl-5.3.9-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rcl-action-5.3.9-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rcl-interfaces-1.2.1-np126py311hbdd918e_13.conda
@@ -1768,6 +1971,8 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rclpy-3.3.16-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rcpputils-2.4.5-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rcutils-5.1.6-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-realtime-tools-2.14.0-np126py311h7501b8c_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-resource-retriever-3.1.3-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-6.1.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-0.11.3-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-common-0.11.3-np126py311hbdd918e_13.conda
@@ -1778,9 +1983,12 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-2.8.4-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-robot-state-publisher-3.0.3-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros-core-0.10.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros-environment-3.2.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros-workspace-1.0.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2-controllers-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2action-0.18.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2cli-0.18.12-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311hbdd918e_13.conda
@@ -1817,8 +2025,16 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rpyutils-0.2.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rsl-1.2.0-np126py311hfe9da55_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-common-11.2.18-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-default-plugins-11.2.18-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311ha9b9805_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-rendering-11.2.18-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz2-11.2.18-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-py-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-shape-msgs-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-spdlog-vendor-1.3.1-np126py311h5f8052a_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-sros2-0.10.6-np126py311hbdd918e_13.conda
@@ -1826,12 +2042,31 @@ environments:
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-statistics-msgs-1.2.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-std-msgs-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-std-srvs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-steering-controllers-library-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-stereo-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tcb-span-1.0.2-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-kdl-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-msgs-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-py-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-ros-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-ros-py-0.25.14-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tinyxml-vendor-0.8.3-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tinyxml2-vendor-0.7.6-np126py311hbdd918e_14.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tl-expected-1.0.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tracetools-4.1.1-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-trajectory-msgs-4.9.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tricycle-controller-2.48.0-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tricycle-steering-controller-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-uncrustify-vendor-2.0.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-unique-identifier-msgs-2.2.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdf-2.6.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hbdd918e_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdfdom-4.0.1-py311h7a77afc_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdfdom-headers-1.0.6-py311h7a77afc_13.conda
+      - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-velocity-controllers-2.48.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-visualization-msgs-4.9.0-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311hbdd918e_13.conda
       - conda: https://prefix.dev/robostack-humble/linux-aarch64/ros2-distro-mutex-0.7.0-humble_13.conda
@@ -1841,8 +2076,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.10.0-h112f5b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-image-0.25.2-py311hffd966a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.16.2-py311h33b5a33_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.54-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.14-h7e2c5d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
@@ -1853,6 +2088,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.2.0-h8f856e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2025.9.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-11.0.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
@@ -1867,7 +2103,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-16.0.0-py311h19352d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hdac3a21_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.0.6-hdd96247_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.24.0-h698ed42_0.conda
@@ -1885,6 +2121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.6-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
@@ -1892,10 +2129,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.1-h86ecc28_2.conda
@@ -1908,6 +2151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.2.5-h92288e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.25.0-py311h51cfe5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
   jazzy:
@@ -1921,11 +2165,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-hdf8817f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
@@ -1993,9 +2241,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.10.3-np20py312hf621b31_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -2013,6 +2263,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.1-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
@@ -2020,14 +2271,29 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.9-h86084c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake3-3.5.5-h05f81b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-7.5.2-h5bbc156_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-python-7.5.2-py312h89d136e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools-2.0.3-h3f54f1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils2-2.2.1-hb586d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -2042,6 +2308,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.19-h0804adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -2075,6 +2342,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-36_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_h99862b1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.1-ha55d5d9_1.conda
@@ -2084,7 +2352,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
@@ -2095,22 +2365,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools-2.0.3-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools2-2.0.3-h3f54f1a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.1-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
@@ -2121,6 +2395,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-36_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-36_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
@@ -2152,9 +2427,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.6-h3675c94_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h2fe6a88_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py312h1f51ce1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
@@ -2191,6 +2467,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.6-py312h7900ff3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py312he3d6523_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -2208,6 +2485,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.10.0-h84d6215_0.conda
@@ -2217,6 +2496,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-hecca717_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -2232,6 +2512,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h0c4a6be_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -2246,19 +2529,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.1-py312h1289d80_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.9.0-py312h4f23490_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.3-np126py312h3bd2861_10.conda
@@ -2302,24 +2590,59 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.3-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.5.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.7.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.37.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.37.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.37.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.5.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.5.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.37.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.4-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.37.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.5.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.9-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.6-np126py312h3bd2861_10.conda
@@ -2327,13 +2650,30 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.9-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.7-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.5.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.7-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.7-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np126py312h3bd2861_10.conda
@@ -2348,6 +2688,8 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.5-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.2-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.4-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.9.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.1-np126py312h3bd2861_10.conda
@@ -2358,9 +2700,12 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-control-test-assets-4.37.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.0-np126py312h3bd2861_10.conda
@@ -2403,8 +2748,18 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np126py312hd4d1b83_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.15-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312h39124df_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.15-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.15-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np126py312hbd70b12_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np126py312he340118_10.conda
@@ -2413,13 +2768,31 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.0.2-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.14-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.1-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.0.2-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.32.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h3bd2861_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.32.0-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np126py312h3bd2861_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.11.0-jazzy_10.conda
@@ -2429,6 +2802,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.10.0-h159367c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.25.2-py312hf79963d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py312h7a1785b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat14-14.8.0-h5bb51b8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat14-python-14.8.0-py312h22a3d64_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
@@ -2474,6 +2849,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
@@ -2481,11 +2857,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
@@ -2498,15 +2880,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.5-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.44-hdf4bb16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
@@ -2574,9 +2961,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.10.3-np20py312hfdb7a0d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.193-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -2594,20 +2983,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.60.1-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.3-h90308e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.0-h9414720_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.0-hc87f4d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.17.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.9-h5313800_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-13.1.2-hdb06ba2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-cmake3-3.5.5-h740f95d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math7-7.5.2-h1ad700d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math7-python-7.5.2-py312h9452373_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools-2.0.3-h8a9b3d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils2-2.2.1-h8c9a663_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.1.0-he4899c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_h587839b_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -2622,6 +3027,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.19-h05dc504_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.8-h27a9ab5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
@@ -2654,6 +3060,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.76-h5706e9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-36_hd72aa62_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he95a3c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.0-default_he95a3c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.1-h18504b1_1.conda
@@ -2663,7 +3070,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.1-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
@@ -2674,22 +3083,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.1.0-hd0aa34e_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.0-h7cdfd2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.55-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools-2.0.3-h7ac5ae9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools2-2.0.3-h8a9b3d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils2-2.2.1-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwy-1.3.0-h81d0cf9_1.conda
@@ -2700,6 +3113,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-36_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-36_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-h2edbd07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.1-h86ecc28_2.conda
@@ -2729,9 +3143,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.6-hb4b1422_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.29.3-h9267e96_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h9b423fc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h68efd32_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py312h39f64fe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.50.4-h022381a_0.conda
@@ -2767,6 +3182,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h80f16a2_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py312hd077ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.10.6-py312h8025657_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.6-py312h9d0c5ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -2784,6 +3200,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.37-h3ad9384_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.117-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.10.0-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.5-h1fc2f77_0.conda
@@ -2791,6 +3209,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.4-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-hfae3067_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
@@ -2806,6 +3225,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h77cf2aa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312hc03dbd4_600.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -2820,19 +3242,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.11-h1683364_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-orocos-kdl-1.5.1-py312h1ab2c47_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pywavelets-1.9.0-py312h5fde510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hbe73643_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.9.2-h6c90349_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rav1e-0.7.1-ha3529ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-msgs-2.0.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-action-msgs-2.0.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-actionlib-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-admittance-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-2.5.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-auto-2.5.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-copyright-0.17.3-np126py312h01c0cb9_10.conda
@@ -2876,24 +3303,59 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-pep257-0.17.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-uncrustify-0.17.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-xmllint-0.17.3-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-angles-1.16.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-backward-ros-1.0.8-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-bicycle-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-builtin-interfaces-2.0.3-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-chained-filter-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-class-loader-2.7.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-common-interfaces-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-composition-interfaces-2.0.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-console-bridge-vendor-1.7.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-msgs-5.5.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-toolbox-4.7.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-interface-4.37.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-4.37.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-msgs-4.37.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-cyclonedds-0.10.5-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diagnostic-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diagnostic-updater-4.2.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diff-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-domain-coordinator-0.12.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-effort-controllers-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastcdr-2.2.5-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastrtps-2.14.5-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastrtps-cmake-module-3.6.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-filters-2.2.2-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-foonathan-memory-vendor-1.3.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-force-torque-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-forward-command-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-0.5.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-py-0.5.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-geometry-msgs-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gmock-vendor-1.14.9000-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gpio-controllers-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gps-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gripper-controllers-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gtest-vendor-1.14.9000-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-tools-vendor-0.0.7-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-hardware-interface-4.37.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-binding-c-2.0.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-hoofs-2.0.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-posh-2.0.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-image-transport-5.1.7-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-imu-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-interactive-markers-2.5.4-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-limits-4.37.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-state-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-trajectory-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kdl-parser-2.11.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kinematics-interface-1.5.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-laser-geometry-2.7.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-3.4.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-ros-0.26.9-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-testing-3.4.6-np126py312h01c0cb9_10.conda
@@ -2901,13 +3363,30 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-testing-ros-0.26.9-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-xml-3.4.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-yaml-3.4.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libstatistics-collector-1.7.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libyaml-vendor-1.6.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-lifecycle-msgs-2.0.3-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-map-msgs-2.4.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-mecanum-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-message-filters-4.11.7-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-nav-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-omni-wheel-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-osrf-pycommon-2.1.7-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-2.7.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-msgs-2.7.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parallel-gripper-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parameter-traits-0.5.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pid-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pluginlib-5.4.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pose-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-position-controllers-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-python-cmake-module-0.11.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-range-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-9.2.7-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-action-9.2.7-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-interfaces-2.0.3-np126py312h01c0cb9_10.conda
@@ -2922,6 +3401,8 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclpy-7.1.5-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcpputils-2.11.2-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcutils-6.7.4-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-realtime-tools-3.9.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-resource-retriever-3.4.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-7.3.2-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-connextdds-0.22.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-connextdds-common-0.22.1-np126py312h01c0cb9_10.conda
@@ -2932,9 +3413,12 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-implementation-2.15.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-implementation-cmake-7.3.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-core-0.11.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-environment-4.2.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-workspace-1.0.3-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2-control-test-assets-4.37.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2-controllers-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2action-0.32.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2cli-0.32.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2cli-common-extensions-0.3.0-np126py312h01c0cb9_10.conda
@@ -2977,8 +3461,18 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rpyutils-0.4.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rsl-1.2.0-np126py312hcea3410_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rti-connext-dds-cmake-module-0.22.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-common-14.1.15-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312hc3c81ed_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-rendering-14.1.15-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz2-14.1.15-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-urdf-1.0.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-vendor-0.0.10-np126py312hac67124_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sensor-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-service-msgs-2.0.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-shape-msgs-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-spdlog-vendor-1.6.1-np126py312hbd405f3_10.conda
@@ -2987,13 +3481,31 @@ environments:
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-statistics-msgs-2.0.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-std-msgs-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-std-srvs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-steering-controllers-library-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-stereo-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tcb-span-1.0.2-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-eigen-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-kdl-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-msgs-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-py-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-0.36.14-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tinyxml2-vendor-0.9.1-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tl-expected-1.0.2-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tracetools-8.2.4-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-trajectory-msgs-5.3.6-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-controller-4.32.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-type-description-interfaces-2.0.3-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-uncrustify-vendor-3.0.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-unique-identifier-msgs-2.5.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-2.10.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h01c0cb9_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-4.0.1-py312h9804fc4_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-headers-1.1.2-py312h9804fc4_10.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-velocity-controllers-4.32.0-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-visualization-msgs-5.3.6-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-yaml-cpp-vendor-9.0.1-np126py312h01c0cb9_10.conda
       - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros2-distro-mutex-0.11.0-jazzy_10.conda
@@ -3003,6 +3515,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.10.0-h112f5b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-image-0.25.2-py312hdc0efb6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.16.2-py312h410a068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat14-14.8.0-hb4dca6f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat14-python-14.8.0-py312he22bb7a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
@@ -3047,6 +3561,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.6-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
@@ -3054,10 +3569,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.1-h86ecc28_2.conda
@@ -3070,6 +3591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.2.5-h92288e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.25.0-py312hd41f8a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
   kilted:
@@ -3083,11 +3605,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.44-hdf8817f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
@@ -3155,9 +3681,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.10.3-np20py312hf621b31_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.0-gpl_hc3e963e_905.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -3175,6 +3703,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.1-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h165c975_23.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
@@ -3182,15 +3711,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-15.4.0-h7d2aa7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.9-h86084c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake4-4.2.0-h83e9d05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-8.2.0-h91c16d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-python-8.2.0-py312hc0cb2ee_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools-2.0.3-h3f54f1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h22fa418_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h6e4c0c1_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -3207,6 +3751,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.19-h0804adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -3237,9 +3782,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-36_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_h99862b1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.1-ha55d5d9_1.conda
@@ -3249,7 +3795,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
@@ -3260,23 +3808,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools-2.0.3-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.1-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.1.1-h38f3fdc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -3286,6 +3839,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-36_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-36_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
@@ -3317,9 +3871,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.6-h3675c94_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h9ef548d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h2fe6a88_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
@@ -3327,10 +3883,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.20.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
@@ -3342,7 +3898,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.313.0-h5279c79_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
@@ -3358,6 +3913,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.6-py312h7900ff3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.6-py312he3d6523_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -3375,6 +3931,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.3-py312h33ff503_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.10.0-h84d6215_0.conda
@@ -3384,6 +3942,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-hecca717_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -3399,6 +3958,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_604.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -3413,19 +3975,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.1-py312h1289d80_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.9.0-py312h4f23490_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ackermann-msgs-2.0.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ackermann-steering-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-admittance-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h31f38b3_14.conda
@@ -3470,22 +4037,56 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-bicycle-steering-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-chained-filter-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.6.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diff-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-effort-controllers-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-force-torque-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-forward-command-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gpio-controllers-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gps-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.6.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-imu-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kinematics-interface-2.2.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.3-np2py312h31f38b3_14.conda
@@ -3493,12 +4094,30 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mecanum-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-motion-primitives-controllers-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-omni-wheel-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parallel-gripper-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pid-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pose-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-position-controllers-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-range-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h31f38b3_14.conda
@@ -3513,6 +4132,8 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.8-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.6.0-np2py312hdba20d8_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.0-np2py312h31f38b3_14.conda
@@ -3527,9 +4148,12 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.3-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-zenoh-cpp-0.6.4-np2py312hf7ffe29_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2-control-test-assets-5.6.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2-controllers-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.1-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.0-np2py312h31f38b3_14.conda
@@ -3572,8 +4196,19 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.5-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.2.0-np2py312h2cad078_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hb5dd976_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.6-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.6-np2py312ha3ea0c0_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312hb464df2_14.conda
@@ -3582,13 +4217,31 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-steering-controllers-library-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.0.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.0.2-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tricycle-controller-5.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tricycle-steering-controller-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h31f38b3_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-velocity-controllers-5.7.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h31f38b3_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zenoh-cpp-vendor-0.6.4-np2py312hf7ffe29_14.conda
@@ -3599,8 +4252,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.10.0-h159367c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.25.2-py312hf79963d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.2-py312h7a1785b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-python-15.3.0-py312he766b8f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.22-h68140b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.3-h3e344bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.2-pyhd8ed1ab_0.conda
@@ -3646,6 +4301,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
@@ -3653,11 +4309,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
@@ -3671,15 +4333,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.2.5-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.44-hdf4bb16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
@@ -3747,9 +4414,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.10.3-np20py312hfdb7a0d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.193-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.0-gpl_h8d881e6_905.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -3767,21 +4436,37 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.60.1-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h0241a67_23.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.3-h90308e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.0-h9414720_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.0-hc87f4d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glslang-15.4.0-h9cbfd48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.17.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.9-h5313800_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-13.1.2-hdb06ba2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-cmake4-4.2.0-h4d22069_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-8.2.0-hb1c1663_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-python-8.2.0-py312ha2f5aa3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools-2.0.3-h8a9b3d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils3-3.1.1-h69e8eaf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.1.0-he4899c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_h587839b_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -3796,6 +4481,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.19-h05dc504_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.8-h27a9ab5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
@@ -3825,9 +4511,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-he30d5cf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-he30d5cf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-he30d5cf_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.76-h5706e9e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.75-h51d75a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-36_hd72aa62_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he95a3c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.0-default_he95a3c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-21.1.0-default_h94a09a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.1-h18504b1_1.conda
@@ -3837,7 +4524,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.1-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
@@ -3848,23 +4537,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.1.0-hd0aa34e_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.1.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.0-h7cdfd2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.55-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.2.0-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools-2.0.3-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils2-2.2.1-h7ac5ae9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils3-3.1.1-h02c2806_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.12.1-default_h6f258fa_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwy-1.3.0-h81d0cf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -3874,6 +4568,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-36_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-36_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-h2edbd07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm21-21.1.0-h2b567e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.1-h86ecc28_2.conda
@@ -3883,7 +4578,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312hfe27425_605.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h64abb66_604.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.2.0-hcd21e76_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.2.0-hcd21e76_1.conda
@@ -3903,9 +4598,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.6-hb4b1422_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h8bb3b26_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h9b423fc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h68efd32_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.50.4-h022381a_0.conda
@@ -3913,10 +4610,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.1.0-hd0aa34e_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.9-hd926fa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.7-h2bb824b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.20.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-h7a57436_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.9-hf39d17c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.7-h7b9e449_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburcu-0.14.0-h0a1ffab_0.conda
@@ -3926,7 +4623,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvulkan-loader-1.4.313.0-h8b8848b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
@@ -3942,6 +4638,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h80f16a2_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py312hd077ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.10.6-py312h8025657_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.6-py312h9d0c5ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -3959,14 +4656,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.37-h3ad9384_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.117-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.3.3-py312h6615c27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.10.0-h17cf362_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.0-hc11aaa7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.5-hf28b12f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.24.1-h55827e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.4-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-hfae3067_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
@@ -3981,7 +4680,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h77cf2aa_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_605.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_604.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
@@ -3996,19 +4698,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.11-h1683364_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-orocos-kdl-1.5.1-py312h1ab2c47_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pywavelets-1.9.0-py312h5fde510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hbe73643_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.9.2-h6c90349_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rav1e-0.7.1-ha3529ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ackermann-msgs-2.0.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ackermann-steering-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-action-msgs-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-actionlib-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-admittance-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-2.7.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-auto-2.7.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2c707e6_14.conda
@@ -4053,22 +4760,56 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-pep257-0.19.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-xmllint-0.19.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-bicycle-steering-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-builtin-interfaces-2.3.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-chained-filter-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-class-loader-2.8.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-common-interfaces-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-composition-interfaces-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.6.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.6.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.6.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-cyclonedds-0.10.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diff-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-effort-controllers-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastcdr-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastdds-3.2.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-force-torque-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-forward-command-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry-msgs-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gmock-vendor-1.15.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gpio-controllers-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gps-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gtest-vendor-1.15.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.5-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.6.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-imu-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.6.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kinematics-interface-2.2.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-3.8.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-ros-0.28.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-3.8.3-np2py312h2c707e6_14.conda
@@ -4076,12 +4817,30 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ros-0.28.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-xml-3.8.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-yaml-3.8.3-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mecanum-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-motion-primitives-controllers-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-nav-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-omni-wheel-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parallel-gripper-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pid-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pluginlib-5.6.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.3-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pose-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-position-controllers-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-range-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-10.1.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-action-10.1.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-interfaces-2.3.0-np2py312h2c707e6_14.conda
@@ -4096,6 +4855,8 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclpy-9.1.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcpputils-2.13.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcutils-6.9.8-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.6.0-np2py312h96cef23_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-7.8.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-1.1.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-common-1.1.0-np2py312h2c707e6_14.conda
@@ -4110,9 +4871,12 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-0.14.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-implementation-0.14.3-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-zenoh-cpp-0.6.4-np2py312hcc87671_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-core-0.12.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-environment-4.3.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-workspace-1.0.3-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2-control-test-assets-5.6.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2-controllers-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2action-0.38.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-0.38.1-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-common-extensions-0.4.0-np2py312h2c707e6_14.conda
@@ -4155,8 +4919,19 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-c-4.9.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.5-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rpyutils-0.6.3-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.2.0-np2py312hcb96c97_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rti-connext-dds-cmake-module-1.1.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hdb042cc_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.6-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.6-np2py312hca9473c_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-service-msgs-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-shape-msgs-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-spdlog-vendor-1.7.0-np2py312h208f11a_14.conda
@@ -4165,13 +4940,31 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-statistics-msgs-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-msgs-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-srvs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-steering-controllers-library-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-stereo-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.0.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tinyxml2-vendor-0.10.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.0.2-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tricycle-controller-5.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tricycle-steering-controller-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h2c707e6_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_14.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-velocity-controllers-5.7.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-visualization-msgs-5.5.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h2c707e6_14.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zenoh-cpp-vendor-0.6.4-np2py312hcc87671_14.conda
@@ -4182,8 +4975,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.10.0-h112f5b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scikit-image-0.25.2-py312hdc0efb6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.16.2-py312h410a068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-python-15.3.0-py312hd1fdc56_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.22-h506f210_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/shaderc-2025.3-h8c88b8f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.2-pyhd8ed1ab_0.conda
@@ -4228,6 +5023,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.6-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
@@ -4235,10 +5031,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.2-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.1-h2dbfc1b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.1-h86ecc28_2.conda
@@ -4252,6 +5054,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.2.5-h92288e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.25.0-py312hd41f8a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
       - pypi: https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
 packages:
@@ -4300,6 +5103,18 @@ packages:
   purls: []
   size: 7773
   timestamp: 1717599240447
+- conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+  sha256: a362b4f5c96a0bf4def96be1a77317e2730af38915eb9bec85e2a92836501ed7
+  md5: b3f0179590f3c0637b7eb5309898f79e
+  depends:
+  - __unix
+  - hicolor-icon-theme
+  - librsvg
+  license: LGPL-3.0-or-later OR CC-BY-SA-3.0
+  license_family: LGPL
+  purls: []
+  size: 631452
+  timestamp: 1758743294412
 - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
   sha256: b9214bc17e89bf2b691fad50d952b7f029f6148f4ac4fe7c60c08f093efdf745
   md5: 76df83c2a9035c54df5d04ff81bcc02d
@@ -4445,6 +5260,92 @@ packages:
   purls: []
   size: 3572443
   timestamp: 1753274717951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+  sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
+  md5: 6b889f174df1e0f816276ae69281af4d
+  depends:
+  - at-spi2-core >=2.40.0,<2.41.0a0
+  - atk-1.0 >=2.36.0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.1,<3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 339899
+  timestamp: 1619122953439
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+  sha256: c2c2c998d49c061e390537f929e77ce6b023ef22b51a0f55692d6df7327f3358
+  md5: 4ea9d4634f3b054549be5e414291801e
+  depends:
+  - at-spi2-core >=2.40.0,<2.41.0a0
+  - atk-1.0 >=2.36.0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.1,<3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 322172
+  timestamp: 1619123713021
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+  sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
+  md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.3,<3.0a0
+  - xorg-libx11
+  - xorg-libxi
+  - xorg-libxtst
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 658390
+  timestamp: 1625848454791
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+  sha256: cd48de9674a20133e70a643476accc1a63360c921ab49477638364877937a40d
+  md5: a12602a94ee402b57063ef74e82016c0
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.3,<3.0a0
+  - xorg-libx11
+  - xorg-libxi
+  - xorg-libxtst
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 622407
+  timestamp: 1625848355776
+- conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+  sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
+  md5: f730d54ba9cd543666d7220c9f7ed563
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 355900
+  timestamp: 1713896169874
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
+  sha256: 69f70048a1a915be7b8ad5d2cbb7bf020baa989b5506e45a676ef4ef5106c4f0
+  md5: 9308557e2328f944bd5809c5630761af
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 358327
+  timestamp: 1713898303194
 - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
   sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
   md5: 791365c5f65975051e4e017b5da3abf5
@@ -6669,6 +7570,51 @@ packages:
   - pkg:pypi/empy?source=hash-mapping
   size: 40210
   timestamp: 1586444722817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+  sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
+  md5: 057083b06ccf1c2778344b6dabace38b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libegl-devel
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libgl-devel
+  - libglx >=1.7.0,<2.0a0
+  - libglx-devel
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 411735
+  timestamp: 1758743520805
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
+  sha256: aa562cdd72d2d15b0f2ee4565c8e34f18b52f7135a3f3b1ce727c202425c3bec
+  md5: 1c50e7c46ccefffe918ac974fa1a6752
+  depends:
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libegl-devel
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libgl-devel
+  - libglx >=1.7.0,<2.0a0
+  - libglx-devel
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 422103
+  timestamp: 1758743388115
 - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
   sha256: 2d721421a60676216e10837a240c75e2190e093920a4016a469fa9a62c95ab5f
   md5: 8681d7f876da5e66a1c7fce424509383
@@ -7039,6 +7985,16 @@ packages:
   purls: []
   size: 12010889
   timestamp: 1757195113491
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+  sha256: 19025a4078ff3940d97eb0da29983d5e0deac9c3e09b0eabf897daeaf9d1114e
+  md5: 66b8b26023b8efdf8fcb23bac4b6325d
+  depends:
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=hash-mapping
+  size: 17976
+  timestamp: 1759948208140
 - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
   sha256: a32e511ea71a9667666935fd9f497f00bcc6ed0099ef04b9416ac24606854d58
   md5: 04a55140685296b25b79ad942264c0ef
@@ -7378,6 +8334,88 @@ packages:
   purls: []
   size: 144992
   timestamp: 1719014317113
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h165c975_23.conda
+  sha256: 66441643fb22912b304944945180429bb734f569a3b6228fe5b9a70bebf88a92
+  md5: 7335e72da49f11061b550bec41d6e6bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - imath >=3.2.1,<3.2.2.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libraw >=0.21.4,<0.22.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.5,<3.4.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  purls: []
+  size: 470221
+  timestamp: 1757407791120
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
+  sha256: 03ccff5d255eab7a1736de9eeb539fbb1333036fa5e37ea7c8ec428270067c99
+  md5: bbdf3d43d752b793ac81f27b28c49e2d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libraw >=0.21.3,<0.22.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.1,<3.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  purls: []
+  size: 467860
+  timestamp: 1729024045245
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h0241a67_23.conda
+  sha256: cc3e284b1ac114a762f187bd24ff92f7be4682819aa5338b64ef93f28224a85f
+  md5: 52d156dc3594298da971f91b9c6ffe6e
+  depends:
+  - imath >=3.2.1,<3.2.2.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libraw >=0.21.4,<0.22.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.5,<3.4.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  purls: []
+  size: 485711
+  timestamp: 1757407736034
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
+  sha256: 0a0ed82992c87aa67604569d35b6180863ca21081e94739194e6adde3f92f84d
+  md5: f6891bd5c49b824889b065446edefe37
+  depends:
+  - imath >=3.1.12,<3.1.13.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libraw >=0.21.3,<0.22.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.1,<3.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  purls: []
+  size: 453451
+  timestamp: 1729024016441
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
   sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
   md5: 4afc585cd97ba8a23809406cd8a9eda8
@@ -7533,6 +8571,81 @@ packages:
   purls: []
   size: 82124
   timestamp: 1712692444545
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+  sha256: 86f5484e38f4604f7694b14f64238e932e8fd8d7364e86557f4911eded2843ae
+  md5: fb05eb5c47590b247658243d27fc32f1
+  depends:
+  - libgcc-ng >=9.3.0
+  - libglu
+  - libstdcxx-ng >=9.3.0
+  - xorg-libx11
+  - xorg-libxext
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 662569
+  timestamp: 1607113198887
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+  sha256: f872cc93507b833ec5f2f08e479cc0074e5d73defe4f91d54f667a324d0b4f61
+  md5: 2a46529de1ff766f31333d3cdff2b734
+  depends:
+  - libgcc-ng >=9.3.0
+  - libglu
+  - libstdcxx-ng >=9.3.0
+  - xorg-libx11
+  - xorg-libxext
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 649830
+  timestamp: 1607113149975
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.0-he175458_0.conda
+  sha256: 3846e03ce529d9d8655651ad765b92cbb7baef4f2345e4df28b2af6133343a58
+  md5: 1891353ef1a104cff6d51de55a60c9c0
+  depends:
+  - glib-tools 2.86.0 hf516916_0
+  - libffi >=3.4.6,<3.5.0a0
+  - libglib 2.86.0 h1fed272_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 611178
+  timestamp: 1757403380893
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.0-h9414720_0.conda
+  sha256: 06b49163e0cb9446c7c40299db824e50f4ca0c562ef0cd8a8871713cb60a33cc
+  md5: 18a0f501a62ffa12b5dd3d4028cb48dd
+  depends:
+  - glib-tools 2.86.0 hc87f4d4_0
+  - libffi >=3.4.6,<3.5.0a0
+  - libglib 2.86.0 h7cdfd2c_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 623316
+  timestamp: 1757403337755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.0-hf516916_0.conda
+  sha256: b77316bd5c8680bde4e5a7ab7013c8f0f10c1702cc6c3b0fd0fac3923a31fec3
+  md5: 1a8e49615381c381659de1bc6a3bf9ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libglib 2.86.0 h1fed272_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 117284
+  timestamp: 1757403341964
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.0-hc87f4d4_0.conda
+  sha256: e5970e3dccdb0ae95b8dfff3f6b6c5f542b45eb51959658db37ef5cb8ed6c8c2
+  md5: 2e792d667df13158c9a35c366c46057c
+  depends:
+  - libgcc >=14
+  - libglib 2.86.0 h7cdfd2c_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 127330
+  timestamp: 1757403314321
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-15.4.0-h7d2aa7d_0.conda
   sha256: f5c862af017fc7133ced3470a45234a2a62eb21277de9c077304fd375a1daf05
   md5: 7b8580757837b637316ed415a5463ad1
@@ -7677,6 +8790,200 @@ packages:
   purls: []
   size: 102400
   timestamp: 1755102000043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
+  sha256: e6866409ba03df392ac5ec6f0d6ff9751a685ed917bfbcd8a73f550c5fe83c2b
+  md5: df7835d2c73cd1889d377cfd6694ada4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - adwaita-icon-theme
+  - cairo >=1.18.2,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.82.2,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  purls: []
+  size: 2413095
+  timestamp: 1738602910851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
+  sha256: efbd7d483f3d79b7882515ccf229eceb7f4ff636ea2019044e98243722f428be
+  md5: 0adddc9b820f596638d8b0ff9e3b4823
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - adwaita-icon-theme
+  - cairo >=1.18.4,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libgcc >=14
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.84.3,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  purls: []
+  size: 2427887
+  timestamp: 1754732581595
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-12.2.1-h044d27a_1.conda
+  sha256: 233f5cda023ac275644e3e3b3663adeca99d7d71cf2379b483d00c3c37163d33
+  md5: c9c0b953e77213e1fd0cdb4a2590ba02
+  depends:
+  - adwaita-icon-theme
+  - cairo >=1.18.2,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.82.2,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  purls: []
+  size: 2530145
+  timestamp: 1738603119015
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-13.1.2-hdb06ba2_0.conda
+  sha256: 15f0f8bc5b5fc1c51be13f0dd4e2dcfb4cd6555e75b18656d51def0d8b7e4db2
+  md5: 52fc4ad5de8b211077edfa9e657f6cab
+  depends:
+  - adwaita-icon-theme
+  - cairo >=1.18.4,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libgcc >=14
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.84.3,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  purls: []
+  size: 2557826
+  timestamp: 1754732391605
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+  sha256: a497d2ba34fdfa4bead423cba5261b7e619df3ac491fb0b6231d91da45bd05fc
+  md5: d8d8894f8ced2c9be76dc9ad1ae531ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - gstreamer 1.24.11 hc37bda9_0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2859572
+  timestamp: 1745093626455
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+  sha256: a13e1059f23497243100b5786e5a7ffac2182885dd56bd7813f518faff959b26
+  md5: 2328f6ad67fc8d33402091e3d770ca73
+  depends:
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - gstreamer 1.24.11 h17c303d_0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2806661
+  timestamp: 1745097877029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
+  sha256: 6e93b99d77ac7f7b3eb29c1911a0a463072a40748b96dbe37c18b2c0a90b34de
+  md5: 056d86cacf2b48c79c6a562a2486eb8c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.84.1,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2021832
+  timestamp: 1745093493354
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
+  sha256: 49a399a7c6e2f3d4ad6338fed8d5f3548baa6edeeaec716cca3505f84f3473fb
+  md5: 8cc29506178d015d91d8b28725f0bd0c
+  depends:
+  - glib >=2.84.1,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2032739
+  timestamp: 1745095972722
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
   sha256: 1f738280f245863c5ac78bcc04bb57266357acda45661c4aa25823030c6fb5db
   md5: 55e29b72a71339bc651f9975492db71f
@@ -7704,6 +9011,345 @@ packages:
   purls: []
   size: 409213
   timestamp: 1748320114722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+  sha256: fc8abccb4b0d454891847bdd8163332ff8607aa33ea9cf1e43b3828fc88c42ce
+  md5: a891e341072432fafb853b3762957cbf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - glib-tools
+  - harfbuzz >=10.4.0
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libxkbcommon >=1.8.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 5563940
+  timestamp: 1741694746664
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_4.conda
+  sha256: f93db23673420fdce94f941c72a2ab6b9dc772685e6ad7ba1f90d613a07da61c
+  md5: 628d8a36bf3acdbfe3d13a7bf44d9ec2
+  depends:
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - glib-tools
+  - harfbuzz >=10.4.0
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libxkbcommon >=1.8.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 5642921
+  timestamp: 1741700832622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+  sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
+  md5: 4d8df0b0db060d33c9a702ada998a8fe
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 318312
+  timestamp: 1686545244763
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+  sha256: 1e9cc30d1c746d5a3399a279f5f642a953f37d9f9c82fd4d55b301e9c2a23f7c
+  md5: 2aeaeddbd89e84b60165463225814cfc
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 332673
+  timestamp: 1686545222091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake3-3.5.5-h05f81b2_0.conda
+  sha256: b654d0102a8b8242836a5863c0157945b5c549d505383f4f8b724926a55f68aa
+  md5: fda2ad837ffe2ed7f73ddfab260d82e3
+  depends:
+  - libgz-cmake3 ==3.5.5 h54a6638_0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7430
+  timestamp: 1759138411890
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-cmake3-3.5.5-h740f95d_0.conda
+  sha256: 156c068a26873adeed74deef7cc2788a0d952409c9d70dd62f1b21f94a90b758
+  md5: fe4f85a94f05fc0ba646a19e642c16c3
+  depends:
+  - libgz-cmake3 ==3.5.5 h7ac5ae9_0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7440
+  timestamp: 1759138433911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake4-4.2.0-h83e9d05_1.conda
+  sha256: 05d289bdcbe5ea05964b34e8e19ac1b7ad950fa66bb4add04d4015e257c74088
+  md5: 591dd28313202ca8a42a36a953c0752b
+  depends:
+  - libgz-cmake4 ==4.2.0 h54a6638_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7428
+  timestamp: 1759138566319
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-cmake4-4.2.0-h4d22069_1.conda
+  sha256: 56f200805dcd36f15cb05a131840e431daa2a5d9396828da2a2121f7a36d1ee7
+  md5: 034cfec6b8e5e3c879ae65faf0ff9dd8
+  depends:
+  - libgz-cmake4 ==4.2.0 h7ac5ae9_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7431
+  timestamp: 1759138590699
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-7.5.2-h5bbc156_2.conda
+  sha256: 3c0eeb73fb3a5d01d6e2f10778a0948286b19cf9500ae24a67547262c521ff35
+  md5: 058fd7a11695871d6c26080a1b2e96a1
+  depends:
+  - libgz-math7 ==7.5.2 h54a6638_2
+  - gz-math7-python >=7.5.2,<7.5.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8251
+  timestamp: 1759147748392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math7-7.5.2-h1ad700d_2.conda
+  sha256: d57fee63316552456c6e7dcb8f4f12bda203f01171f5caeb8c8f1c5823e0faec
+  md5: 5a688a452b1ed9514847f73aa22ca66d
+  depends:
+  - libgz-math7 ==7.5.2 h7ac5ae9_2
+  - gz-math7-python >=7.5.2,<7.5.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8250
+  timestamp: 1759147772705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math7-python-7.5.2-py312h89d136e_2.conda
+  sha256: a20c5d236a70831cfa21fda695c4482fcbbe64ea4c2db32d59c66ee7df05fe05
+  md5: f49be6a36d1cd45f9fcc96d2446c41c4
+  depends:
+  - libgz-math7 ==7.5.2 h54a6638_2
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-math7 >=7.5.2,<8.0a0
+  - pybind11-abi ==11
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1029585
+  timestamp: 1759147748392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math7-python-7.5.2-py312h9452373_2.conda
+  sha256: 77495e6d48939268df6814ed624ecc7b0ce114e89ffe26fc673941dd5cacf518
+  md5: 3d51d5c0f3d774eee6b96025a5fedeb6
+  depends:
+  - libgz-math7 ==7.5.2 h7ac5ae9_2
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python 3.12.* *_cpython
+  - libgz-math7 >=7.5.2,<8.0a0
+  - python_abi 3.12.* *_cp312
+  - pybind11-abi ==11
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 881527
+  timestamp: 1759147772705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-8.2.0-h91c16d2_2.conda
+  sha256: f7b8b7992433e8841f871e0877497d01cde635818f993a70aa9ae6eaefb255c4
+  md5: 2d150314957d6006b81c7e3b8683eb2e
+  depends:
+  - libgz-math8 ==8.2.0 h54a6638_2
+  - gz-math8-python >=8.2.0,<8.2.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8198
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-8.2.0-hb1c1663_2.conda
+  sha256: 6e6a69ddd17acee80dc6fee6668d38bc3f59e54ccb8897d337860c5dda086a59
+  md5: c8c37eacb7c1e93a5b4ab47841159547
+  depends:
+  - libgz-math8 ==8.2.0 h7ac5ae9_2
+  - gz-math8-python >=8.2.0,<8.2.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8198
+  timestamp: 1759147825383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-python-8.2.0-py312hc0cb2ee_2.conda
+  sha256: caa552f19bfea9400322276375a8570b26dedbd61360a4ecf898212194cded7b
+  md5: 75c9b44db1148bf7d96b79ba89e94915
+  depends:
+  - libgz-math8 ==8.2.0 h54a6638_2
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - pybind11-abi ==11
+  - libgz-math8 >=8.2.0,<9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1046498
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-python-8.2.0-py312ha2f5aa3_2.conda
+  sha256: 6717654b30deadb8bbcb2d294be2eee6db87eb16a1af8cb71d4f35fc0e629a4b
+  md5: bd0464532d09a69bdc9c5f67cf63a0da
+  depends:
+  - libgz-math8 ==8.2.0 h7ac5ae9_2
+  - python
+  - python 3.12.* *_cpython
+  - libstdcxx >=14
+  - libgcc >=14
+  - pybind11-abi ==11
+  - python_abi 3.12.* *_cp312
+  - libgz-math8 >=8.2.0,<9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 892861
+  timestamp: 1759147825383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools-2.0.3-h3f54f1a_1.conda
+  sha256: 392eee31355835b7659dbc44813c79ab8e42bb4b1b7500a423d155a04e034bee
+  md5: 8c366a7251e68161425d4602e5e928e4
+  depends:
+  - libgz-tools ==2.0.3 h54a6638_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7803
+  timestamp: 1759148392717
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools-2.0.3-h8a9b3d2_1.conda
+  sha256: b11d62b42f0201ed471f5321add67a252e9e855aeb4093f00910cf145df5d6e5
+  md5: fa47af686315f36b3fc6814b4d49355b
+  depends:
+  - libgz-tools ==2.0.3 h7ac5ae9_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7807
+  timestamp: 1759148397768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
+  sha256: 1d578b70672a212ee4aeae44f2377070bb1aacfcf81862e7d306e6c9e2a02345
+  md5: 397d00a36abb84cca1f532fdec91c905
+  depends:
+  - gz-tools ==2.0.3 h3f54f1a_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7839
+  timestamp: 1759148392717
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
+  sha256: b6d2d8703e2b767cfa55a9c8459ec5ad6f6bcf8e71808d4100a4ec692338c3ac
+  md5: 6d3b2b60fcceb741666a26cf5da0dc12
+  depends:
+  - gz-tools ==2.0.3 h8a9b3d2_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7834
+  timestamp: 1759148397768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils2-2.2.1-hb586d9b_0.conda
+  sha256: ef804e2d96918cb95a5c697c8a183d1566458efd6f0e2961356353d281840d44
+  md5: cacfdeb5f47396142bacdb2e87ae6b2a
+  depends:
+  - libgz-utils2 ==2.2.1 h54a6638_0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8053
+  timestamp: 1759142442807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils2-2.2.1-h8c9a663_0.conda
+  sha256: 863d216cb0cca49581b2c9873c7e953548bc14f49a36051211c52b9d64133e5a
+  md5: e4597f618a3d575d49efae0d2724a680
+  depends:
+  - libgz-utils2 ==2.2.1 h7ac5ae9_0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8044
+  timestamp: 1759142461849
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h22fa418_2.conda
+  sha256: 33089a4281393c6ab1199bac919a2ae9abd4ad7184ad07eca92d8a6109d0a430
+  md5: 0efde9d42e9ae05ee1f5430d4a8eb359
+  depends:
+  - libgz-utils3 ==3.1.1 h38f3fdc_2
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8167
+  timestamp: 1759142868065
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils3-3.1.1-h69e8eaf_2.conda
+  sha256: eaab19e67bfaae1045ef380d7e788cd52347b9fbeae5e1ba50178d20d00ab701
+  md5: 509b14c6588593131cf4086de0df295c
+  depends:
+  - libgz-utils3 ==3.1.1 h02c2806_2
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8164
+  timestamp: 1759142884485
 - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -7792,6 +9438,22 @@ packages:
   purls: []
   size: 3915364
   timestamp: 1753363295810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+  sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
+  md5: bbf6f174dcd3254e19a2f5d2295ce808
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 13841
+  timestamp: 1605162808667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
+  sha256: 479a0f95cf3e7d7db795fb7a14337cab73c2c926a5599c8512a3e8f8466f9e54
+  md5: 331add9f855e921695d7b569aa23d5ec
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 13896
+  timestamp: 1605162856037
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -8358,6 +10020,18 @@ packages:
   purls: []
   size: 727096
   timestamp: 1754514489871
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
+  sha256: f1ac18b11637ddadc05642e8185a851c7fab5998c6f5470d716812fae943b2af
+  md5: 446bd6c8cb26050d528881df495ce646
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=hash-mapping
+  size: 112714
+  timestamp: 1741263433881
 - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
   sha256: 2057ca87b313bde5b74b93b0e696f8faab69acd4cb0edebb78469f3f388040c0
   md5: 5aeabe88534ea4169d4c49998f293d6c
@@ -9521,6 +11195,30 @@ packages:
   purls: []
   size: 298363
   timestamp: 1756599431316
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.71-h39aace5_0.conda
+  sha256: 2bbefac94f4ab8ff7c64dc843238b6c8edcc9ff1f2b5a0a48407a904dc7ccfb2
+  md5: dd19e4e3043f6948bd7454b946ee0983
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 102268
+  timestamp: 1729940917945
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
+  sha256: 9c84448305e7c9cc44ccec7757cf5afcb5a021f4579aa750a1fa6ea398783950
+  md5: c44c16d6976d2aebbd65894d7741e67e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 120375
+  timestamp: 1741176638215
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
   sha256: a946b61be1af15ff08c7722e9bac0fab446d8b9896c9f0f35657dfcf887fda8a
   md5: 0f7f0c878c8dceb3b9ec67f5c06d6057
@@ -9533,6 +11231,28 @@ packages:
   purls: []
   size: 121852
   timestamp: 1744577167992
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.71-h51d75a7_0.conda
+  sha256: 2b66e66e6a0768e833e7edc764649679881ec0a6b37d9bf254b1ceb3b8b434ef
+  md5: 29f6092b6e938516ca0b042837e64fa5
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 106877
+  timestamp: 1729940936697
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.75-h51d75a7_0.conda
+  sha256: d77e8bd8d5714a80c1fa88037e71d5c29f21bae1e9281528006c9c5a6175ac1a
+  md5: c5456e13665779bf7a62dc7724ca2938
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 108212
+  timestamp: 1741177682469
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.76-h5706e9e_0.conda
   sha256: 909a467436e714f1fb4daca150654dc71f6e06b371f467088d98608850f4822e
   md5: dc0fbf47fc1f3217e87e77c0b0d28a77
@@ -9631,6 +11351,31 @@ packages:
   purls: []
   size: 20335085
   timestamp: 1759436412922
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.8-default_h99862b1_4.conda
+  sha256: be2cd2768c932ade04bc4868b0f564ce6681bc861f28027419dc6651525afeb1
+  md5: 2a7f3bca5b60a34be5a35cbc70711bce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 21250739
+  timestamp: 1759440009094
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.8-default_he95a3c9_4.conda
+  sha256: a714cf0bf3cebb3f7943729465decede621e4018f55bf97f7e21235ffe5ef36c
+  md5: 136f09b9fb42e3bc2d384622c8d241ce
+  depends:
+  - libgcc >=14
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 20804100
+  timestamp: 1759437174609
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.0-default_h99862b1_1.conda
   sha256: efe9f1363a49668d10aacdb8be650433fab659f05ed6cc2b9da00e3eb7eaf602
   md5: d599b346638b9216c1e8f9146713df05
@@ -9949,6 +11694,29 @@ packages:
   purls: []
   size: 53551
   timestamp: 1731330990477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: f6e7095260305dc05238062142fb8db4b940346329b5b54894a90610afa6749f
+  md5: b513eb83b3137eca1192c34bf4f013a7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_2
+  - libgl-devel 1.7.0 ha4b6fd6_2
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 30380
+  timestamp: 1731331017249
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
+  sha256: 9c8e9d2289316741d037f0c5003de42488780d181453543f75497dd5a4891c7c
+  md5: cd8877e3833ba1bfac2fbaa5ae72c226
+  depends:
+  - libegl 1.7.0 hd24410f_2
+  - libgl-devel 1.7.0 hd24410f_2
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 30397
+  timestamp: 1731331017398
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
@@ -9969,6 +11737,28 @@ packages:
   purls: []
   size: 115123
   timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
+  md5: 96ae6083cd1ac9f6bc81631ac835b317
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 438992
+  timestamp: 1685726046519
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
   sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
   md5: 4211416ecba1866fab0c6470986c22d6
@@ -10201,6 +11991,47 @@ packages:
   purls: []
   size: 652592
   timestamp: 1747060671875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+  sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
+  md5: 68fc66282364981589ef36868b1a7c78
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.45,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  purls: []
+  size: 177082
+  timestamp: 1737548051015
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
+  sha256: 7e199bb390f985b34aee38cdb1f0d166abc09ed44bd703a1b91a3c6cd9912d45
+  md5: d256b0311b7a207a2c6b68d2b399f707
+  depends:
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.45,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  purls: []
+  size: 191033
+  timestamp: 1737548098172
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
   sha256: 50a9e9815cf3f5bce1b8c5161c0899cc5b6c6052d6d73a4c27f749119e607100
   md5: 2f4de899028319b27eb7a4023be5dfd2
@@ -10337,6 +12168,27 @@ packages:
   purls: []
   size: 145442
   timestamp: 1731331005019
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: e281356c0975751f478c53e14f3efea6cd1e23c3069406d10708d6c409525260
+  md5: 53e7cbb2beb03d69a478631e23e340e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_2
+  - libglx-devel 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 113911
+  timestamp: 1731331012126
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
+  sha256: ec5c3125b38295bad8acc80f793b8ee217ccb194338d73858be278db50ea82f1
+  md5: 5d8323dff6a93596fb6f985cf6e8521a
+  depends:
+  - libgl 1.7.0 hd24410f_2
+  - libglx-devel 1.7.0 hd24410f_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 113925
+  timestamp: 1731331014056
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
   sha256: 33336bd55981be938f4823db74291e1323454491623de0be61ecbe6cf3a4619c
   md5: b8e4c93f4ab70c3b6f6499299627dbdc
@@ -10428,6 +12280,29 @@ packages:
   purls: []
   size: 77736
   timestamp: 1731330998960
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: 0a930e0148ab6e61089bbcdba25a2e17ee383e7de82e7af10cc5c12c82c580f3
+  md5: 27ac5ae872a21375d980bd4a6f99edf3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 26388
+  timestamp: 1731331003255
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
+  sha256: 4bc28ecc38f30ca1ac66a8fb6c5703f4d888381ec46d3938b7c3383210061ec5
+  md5: 1f9ddbb175a63401662d1c6222cef6ff
+  depends:
+  - libglx 1.7.0 hd24410f_2
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 26362
+  timestamp: 1731331008489
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
   sha256: 125051d51a8c04694d0830f6343af78b556dd88cc249dfec5a97703ebfb1832d
   md5: dcd5ff1940cd38f6df777cac86819d60
@@ -10548,6 +12423,36 @@ packages:
   purls: []
   size: 297443
   timestamp: 1759147772705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
+  sha256: 604ee7ebac74a45c95ca38152b98984a6ea195ce88e47332bdf397f1ecf3b4b2
+  md5: 57644d9cd6fe5cda498611d058ce9197
+  depends:
+  - eigen
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 298011
+  timestamp: 1759147796036
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.2.0-h7ac5ae9_2.conda
+  sha256: 493858b10aae627eedb6a3e8fba881f5fc6acc787ffbb74fa6c85658dc7e2178
+  md5: da869f0b8c19bd4c70c269ca10336c5e
+  depends:
+  - eigen
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 299154
+  timestamp: 1759147825383
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools-2.0.3-h54a6638_1.conda
   sha256: 11b948f8379ddf26e045ddbcca6f884a537ec2afc13986e9cbd19518855b2c6d
   md5: 94785d73f138a7e56359e0535179953a
@@ -10576,6 +12481,26 @@ packages:
   purls: []
   size: 50928
   timestamp: 1759148397768
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-tools2-2.0.3-h3f54f1a_1.conda
+  sha256: 1f7afd70cbe30ecee83ebc331b671f2687a0860d473e52159c31f0d144f1f96d
+  md5: f4166655927e17784cc09ff4e6ebffc1
+  depends:
+  - libgz-tools ==2.0.3 h54a6638_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7831
+  timestamp: 1759148392717
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-tools2-2.0.3-h8a9b3d2_1.conda
+  sha256: 9a5cc38cee9837e05baad357025a663593767bbc88eb7e2ced2d9bc6bcf5f87e
+  md5: 1a8eeda377bd62df4d8cdc9a1e588d06
+  depends:
+  - libgz-tools ==2.0.3 h7ac5ae9_1
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 7836
+  timestamp: 1759148397768
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils2-2.2.1-h54a6638_0.conda
   sha256: cd088106d56bce44016488b7a2eee3da2cefdf172d5799d3bf149d2f95002b58
   md5: 8fc9b2355d26b0d7896e9047036dc418
@@ -10603,6 +12528,36 @@ packages:
   purls: []
   size: 63203
   timestamp: 1759142461849
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-utils3-3.1.1-h38f3fdc_2.conda
+  sha256: 89905428e197c5796e12fb6324843e4da616d17dfe161695ba4e440c16a0e231
+  md5: b1f372fd32c93c1c169c69b2d3ec2ebb
+  depends:
+  - cli11
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - spdlog >=1.15.3,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 78059
+  timestamp: 1759142868065
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-utils3-3.1.1-h02c2806_2.conda
+  sha256: ddf80d4134a0604b4b2ef8cb0774b97f81d75c0073b44b5bd4b90886d1bdcb54
+  md5: 9711ced02615b5e385d5d8172870ed61
+  depends:
+  - cli11
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - spdlog >=1.15.3,<1.16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 79427
+  timestamp: 1759142884485
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
   sha256: eecaf76fdfc085d8fed4583b533c10cb7f4a6304be56031c43a107e01a56b7e2
   md5: d821210ab60be56dd27b5525ed18366d
@@ -10722,6 +12677,61 @@ packages:
   purls: []
   size: 147224
   timestamp: 1741527785226
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-cmake2-2.17.2-hac33072_0.conda
+  sha256: 4bace3310a094d54dbccd211c0c6b28152d4f8fe9d70c7eae33279eb1584242d
+  md5: ca93261530c18fcd1dc8ce9eb202f7e8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 266880
+  timestamp: 1715202041745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-cmake2-2.17.2-h0a1ffab_0.conda
+  sha256: cd8714d9bd2bcce9846653369261ef260535df2b501c46a0b3c8fc6abd8c5b01
+  md5: 85e2f1a8cfb7f9aa1973a9a45b5add63
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 268913
+  timestamp: 1715202151197
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-math6-6.15.1-py311h4d89148_4.conda
+  sha256: 7b776ffc30f3eebe0d233cfc321276f69b894ea3a7ecab69ab5cf96af7fc6027
+  md5: b5d3bb8777fc908083d2e59108a24047
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=14
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - libstdcxx >=14
+  - pybind11-abi 11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1191158
+  timestamp: 1756310724088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-math6-6.15.1-py311h9dbc854_4.conda
+  sha256: ad87864bc37c5e91dfc74f311cc1d40d0d2ea0812c9a5c442f1718d28203ed96
+  md5: 246758f2ea6fc2739a2498ef322b5c53
+  depends:
+  - eigen
+  - libgcc >=14
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - libstdcxx >=14
+  - pybind11-abi 11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1050198
+  timestamp: 1756317642516
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
   sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
   md5: 9fa334557db9f63da6c9285fd2a48638
@@ -10972,6 +12982,35 @@ packages:
   purls: []
   size: 39961732
   timestamp: 1757348788272
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
+  sha256: a6fddc510de09075f2b77735c64c7b9334cf5a26900da351779b275d9f9e55e1
+  md5: 59a7b967b6ef5d63029b1712f8dcf661
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 43987020
+  timestamp: 1752141980723
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-h2b567e5_0.conda
+  sha256: ff6d7cb1422ae11d796339b9daa17bfdb1983fcabc8f225f31647cd2579ed821
+  md5: b2ae284ba64d978316177c9ab68e3da5
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 42763622
+  timestamp: 1752138032512
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
   sha256: d190f1bf322149321890908a534441ca2213a9a96c59819da6cabf2c5b474115
   md5: 9ad637a7ac380c442be142dfb0b1b955
@@ -11548,6 +13587,60 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 20733237
   timestamp: 1751758100288
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h64abb66_604.conda
+  sha256: 162de95a847ceef9e4b035dc98a53363fe79cd8892226f4b11dcacf5b66c2419
+  md5: a50dedf66869719ed04984b34ae19491
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=8.0.0,<9.0a0
+  - harfbuzz >=11.4.3
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - imath >=3.2.1,<3.2.2.0a0
+  - jasper >=4.2.8,<5.0a0
+  - libasprintf >=0.25.1,<1.0a0
+  - libavif16 >=1.3.0,<2.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=14
+  - libgettextpo >=0.25.1,<1.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.3,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjxl >=0.11,<0.12.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-arm-cpu-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-batch-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-auto-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-hetero-plugin >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-ir-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-onnx-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-paddle-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-pytorch-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-frontend >=2025.2.0,<2025.2.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.2.0,<2025.2.1.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.3.5,<3.4.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - qt6-main >=6.9.1,<6.10.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 21303947
+  timestamp: 1756079061641
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h86caf62_600.conda
   sha256: 3e40282885a6b93e146e1f575b5dc813ec5b018f18b0c460cca01b3051e6e9d0
   md5: 97211b10693091fb0eb523388c105db3
@@ -11602,60 +13695,6 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 20726674
   timestamp: 1751758642250
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312hfe27425_605.conda
-  sha256: c124449492980a60184ec1c744cd68783fc3a60753edec52c2d34b4128293ae8
-  md5: 56d82c5710163fc5026674fec78fdc4c
-  depends:
-  - _openmp_mutex >=4.5
-  - ffmpeg >=8.0.0,<9.0a0
-  - harfbuzz >=12.0.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - imath >=3.2.1,<3.2.2.0a0
-  - jasper >=4.2.8,<5.0a0
-  - libasprintf >=0.25.1,<1.0a0
-  - libavif16 >=1.3.0,<2.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.1,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libgettextpo >=0.25.1,<1.0a0
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.0,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - libjxl >=0.11,<0.12.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-arm-cpu-plugin >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-auto-batch-plugin >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-auto-plugin >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-hetero-plugin >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-ir-frontend >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-onnx-frontend >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-paddle-frontend >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-pytorch-frontend >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-tensorflow-frontend >=2025.2.0,<2025.2.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.2.0,<2025.2.1.0a0
-  - libpng >=1.6.50,<1.7.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.23,<3
-  - openexr >=3.4.0,<3.5.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - qt6-main >=6.9.2,<6.10.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 21225525
-  timestamp: 1759259190118
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py313hb0835c5_605.conda
   sha256: 336906fbb0efcda4fbcc6fea31663478a5f2aaae09d6c80014660d0d064928ba
   md5: 4e5b11a1b549a52e291f1a4b8e4038c8
@@ -12583,6 +14622,38 @@ packages:
   purls: []
   size: 21641
   timestamp: 1744008367211
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
+  sha256: 96bbd009b3d7f82e9af37e980af9285431ecd5c6f098a0f1afe0021d8d02b88a
+  md5: e4fdd13a67d5b30459463e925b9e7e1f
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - _openmp_mutex >=4.5
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - jasper >=4.2.5,<5.0a0
+  - lcms2 >=2.17,<3.0a0
+  license: LGPL-2.1-only
+  purls: []
+  size: 704665
+  timestamp: 1744641234631
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
+  sha256: 98360c0fce61f693afad344b55835ca9a8c8344434511676623c5c642ad67d96
+  md5: 1723d3fd7b6ed1fdefd4f20e0d3c3079
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - _openmp_mutex >=4.5
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - jasper >=4.2.5,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lcms2 >=2.17,<3.0a0
+  license: LGPL-2.1-only
+  purls: []
+  size: 742040
+  timestamp: 1744641244231
 - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
   sha256: 475013475a3209c24a82f9e80c545d56ccca2fa04df85952852f3d73caa38ff9
   md5: b9846db0abffb09847e2cb0fec4b4db6
@@ -12714,6 +14785,25 @@ packages:
   purls: []
   size: 366628
   timestamp: 1758613468126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py312h1f51ce1_2.conda
+  sha256: 41a56a57a0bb78429a5ad571226dbe4cffed586446d11ad30cc4173f89c1cee8
+  md5: 6dc0e6dc04a710e77bfe2865dad3f3b8
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  - libgz-math7 >=7.5.2,<8.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libgz-cmake3 >=3.5.5,<4.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1236819
+  timestamp: 1759339825312
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
   sha256: e62b01452964fc3c88777088afdfb1ae2b66b00299b1da9380b1c8781de6eca5
   md5: deb02f1dc8045de577cc3c845ea7849a
@@ -12732,6 +14822,24 @@ packages:
   purls: []
   size: 1236957
   timestamp: 1759339825313
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py312h39f64fe_2.conda
+  sha256: 0ac75f115584bb5b7783c1c94b46966251095f03467c5687b38aaaf60d8db7dc
+  md5: b74a8a2efd31f3426aaff959759f6320
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-cmake3 >=3.5.5,<4.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  - libgz-math7 >=7.5.2,<8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1173519
+  timestamp: 1759339827373
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
   sha256: 4b1b64e969bf210026eb7662ea48f6da0fa632d1f0f642910679cecf066152ea
   md5: e32d8fd9e6040c7dc5b4b08bb1380a0e
@@ -12750,6 +14858,42 @@ packages:
   purls: []
   size: 1173696
   timestamp: 1759339860946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
+  sha256: 548e4abe1589149118ac29705792f4f2ba029bcf49b1ba77c575b45df4aad714
+  md5: 86617f3d3ac5bba1914a9a403ea36890
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-math8 >=8.2.0,<9.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils3 >=3.1.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1404495
+  timestamp: 1759340798807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
+  sha256: 4cd050db50c408ad5fabd32f29ecd62734e965f58ec60541249a36520861975a
+  md5: 076aff262f27ea8ed74d23527afa7bbb
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1338463
+  timestamp: 1759340813824
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   md5: ef1910918dd895516a769ed36b5b3a4e
@@ -12932,6 +15076,36 @@ packages:
   purls: []
   size: 29229
   timestamp: 1757043052495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.4-h3dc2cb9_0.conda
+  sha256: 5a073ee10beb11a8616277b37f09971d14fe6b1311c1ab69620c030537f0eefd
+  md5: cb9e2966356c3cd8b91fc3998cc4eaa0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.71,<2.72.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.0,<2.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 488348
+  timestamp: 1741612443852
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
+  sha256: e26b22c0ae40fb6ad4356104d5fa4ec33fe8dd8a10e6aef36a9ab0c6a6f47275
+  md5: 1e12c8aa74fa4c3166a9bdc135bc4abf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.1,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 487969
+  timestamp: 1750949895969
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
   sha256: 6b063df2d13dc9cedeae7b1591b1917ced7f4e1b04f7246e66cc7fb0088dea07
   md5: b6d222422c17dc11123e63fae4ad4178
@@ -12947,6 +15121,34 @@ packages:
   purls: []
   size: 492733
   timestamp: 1757520335407
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.4-h27834fc_0.conda
+  sha256: f80282962e974af3629b9623ee908590210837eb93a0b63bb2058c10bfa51821
+  md5: 1e88213b16672350abe3810b002a1b0d
+  depends:
+  - libcap >=2.71,<2.72.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.0,<2.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 509966
+  timestamp: 1741612450564
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.7-h2bb824b_0.conda
+  sha256: 35ecfc98c22d4f035b051fe72398206607d48944e7bd4f60431e63eb95538e0d
+  md5: 63b49a2d12a1739f72be430c2ed58727
+  depends:
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.1,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 510879
+  timestamp: 1750949944203
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.9-hd926fa8_0.conda
   sha256: 98ac09c139bbffbe4f6448924a8f3f1fca16f4ac8816b39d629a22f7fd66ad5f
   md5: 6751bb1ae9b58008862a0c3a1340e17e
@@ -13017,6 +15219,28 @@ packages:
   purls: []
   size: 487507
   timestamp: 1758278441825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.4-h9a4d06a_0.conda
+  sha256: 65ebc2185cdc008f8da92864e8063e60293c59134b11b13e4bc44fd6f6e04eec
+  md5: 8b87f46f586167c54b2d4c0fd4a72001
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.71,<2.72.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 143836
+  timestamp: 1741612453664
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
+  sha256: 3fca2655f4cf2ce6b618a2b52e3dce92f27f429732b88080567d5bbeea404c82
+  md5: 5a23e52bd654a5297bd3e247eebab5a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 143533
+  timestamp: 1750949902296
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
   sha256: 1c8f0b02c400617a9f2ea8429c604b28e25a10f51b3c8d73ce127b4e7b462297
   md5: 973f365f19c1d702bda523658a77de26
@@ -13028,6 +15252,26 @@ packages:
   purls: []
   size: 144265
   timestamp: 1757520342166
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.4-h1187dce_0.conda
+  sha256: 1389af70858732b9bf6384c2af9b1da4b261bc8d889bb6a25d853a75cbb04073
+  md5: 0a0bd551a68587c7dd852324da97b853
+  depends:
+  - libcap >=2.71,<2.72.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 153980
+  timestamp: 1741612457053
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.7-h7b9e449_0.conda
+  sha256: 8c9847a934e251479f343f0be3b771836cdccfcf132145bd2da34946acd01988
+  md5: d19d804623b40d7ab5f807c240b4caaf
+  depends:
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 154447
+  timestamp: 1750949949664
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.9-hf39d17c_0.conda
   sha256: e1f1824646a997bb3c82162291092631c2bccb15e9f07b386bb89434293f531a
   md5: de668d7632a3107a1652ca9f4b9d1118
@@ -13056,6 +15300,17 @@ packages:
   purls: []
   size: 1409624
   timestamp: 1626959749923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+  sha256: f2ac872920833960e514ce9efd8f7c08ce66dd870738d73839d1bce1ac497de6
+  md5: a730b2badd586580c5752cc73842e068
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 75491
+  timestamp: 1638450786937
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
   sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
   md5: e179a69edd30d75c0144d7a380b88f28
@@ -13068,6 +15323,17 @@ packages:
   purls: []
   size: 75995
   timestamp: 1757032240102
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.6.2-h01db608_0.tar.bz2
+  sha256: 7862d36ffc9f6b2ed3381ce77c78b9e5691d7353a19dd2050630868e192adf6f
+  md5: 93b7bbf9099cfe09e67c0abe34bb7885
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 90479
+  timestamp: 1638452154070
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
   sha256: 86c013d522975b76e16a74341bfcb22f6ec2e9b8b87ec3e15380f46c435eaa7b
   md5: 5d8191a950e492a06dc29b491dd5f7c5
@@ -13111,6 +15377,18 @@ packages:
   purls: []
   size: 127967
   timestamp: 1756125594973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.9-h84d6215_0.conda
+  sha256: bfa34a5a929d792dfcfbbe2d9ee21bd870d73d646512e21c871dab0b80194468
+  md5: ecd409e7bfcf4ee73f74d7a2cc91a4c3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 121336
+  timestamp: 1738604403935
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.12-hfefdfc9_0.conda
   sha256: 43daf21754c0d8618c2fcc1ac1cad8740f9a107358cc31d8619554463f366609
   md5: 63a654dceff75b84fe8ff32ddb66b7fe
@@ -13122,6 +15400,17 @@ packages:
   purls: []
   size: 129619
   timestamp: 1756126369793
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.9-h17cf362_0.conda
+  sha256: 2922ab8ac4cdd966c1b13dad6ccc4c07c7db2054400843ee443ffd5e7b3f292e
+  md5: 8eef9430276ab3dbe6ad5b8f23ff5e26
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 123614
+  timestamp: 1738605619021
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
   sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
   md5: d17e3fb595a9f24fa9e149239a33475d
@@ -13861,6 +16150,68 @@ packages:
   - pkg:pypi/markdown-it-py?source=hash-mapping
   size: 64736
   timestamp: 1754951288511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py311h3778330_0.conda
+  sha256: 66c072c37aefa046f3fd4ca69978429421ef9e8a8572e19de534272a6482e997
+  md5: 0954f1a6a26df4a510b54f73b2a0345c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 26016
+  timestamp: 1759055312513
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
+  sha256: f77f9f1a4da45cbc8792d16b41b6f169f649651a68afdc10b2da9da12b9aa42b
+  md5: f775a43412f7f3d7ed218113ad233869
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 25321
+  timestamp: 1759055268795
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py311h2dad8b0_0.conda
+  sha256: ce376b158fbfe9778d5309caade1b6c3b0578549d4f75e2bc52091ecc2d6c3a5
+  md5: ff6e48e0ba263a5f446237001fd59c4a
+  depends:
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 26446
+  timestamp: 1759056188151
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py312hd077ced_0.conda
+  sha256: f35cf61ae7fbb3ed0529f000b4bc9999ac0bed8803654ed2db889a394d9853c2
+  md5: d4e5ac7000bdc398b3cfba57f01e7e63
+  depends:
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 25943
+  timestamp: 1759056553164
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.6-py311h38be061_1.conda
   sha256: c40fdf402bb4433d242204d89575ccd02a725544c15703c969eb33881f7e26d5
   md5: 0783509652a221fb6e7910ab65799b89
@@ -14569,6 +16920,58 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 34574
   timestamp: 1734112236147
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.37-h29cc59b_0.conda
+  sha256: 472306630dcd49a221863b91bd89f5b8b81daf1b99adf1968c9f12021176d873
+  md5: d73ccc379297a67ed921bd55b38a6c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 230951
+  timestamp: 1752841107697
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.37-h3ad9384_0.conda
+  sha256: 29431722d6715cfa9589583eca96d740d2fa3ca50d32593d9eafcd3eea3c9bb6
+  md5: 81e99082a0d055a3888369dafdfa427c
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 236193
+  timestamp: 1752842469552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.117-h445c969_0.conda
+  sha256: 85f2d6d93199454818866b355834a8c5dc64a87e14da3b242208c9dc2156852a
+  md5: 970af0bfac9644ddbf7e91c1336b231b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.37,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 2045760
+  timestamp: 1759509411326
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.117-h544fa81_0.conda
+  sha256: af706f4b0e730070661e129090d4325caa47a36a51d8b45ccf87c7d104c8cac9
+  md5: d64a3b42b230f874211256bf8cdc59c7
+  depends:
+  - libgcc >=14
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.37,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 2049285
+  timestamp: 1759512197014
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
   sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
   md5: a502d7aad449a1206efb366d6a12c52d
@@ -14837,6 +17240,20 @@ packages:
   purls: []
   size: 1285497
   timestamp: 1753614928285
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.5-hf28b12f_1.conda
+  sha256: 63f6304520532713ecaa81f72d9a8d7c1fb0d0e8cff171752cd4012ff3129213
+  md5: 9b719447bcb994fbeb73e935b683a514
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - imath >=3.2.1,<3.2.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1285361
+  timestamp: 1755533933096
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.0-hc11aaa7_1.conda
   sha256: 3320677573e379e7cba8cb21f64f23c2932d6430bdf9e7800b4157a3da612a88
   md5: a97539d84b68d2a87f96f4eee098360c
@@ -14983,6 +17400,31 @@ packages:
   purls: []
   size: 3644584
   timestamp: 1759326000128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-hecca717_9.conda
+  sha256: a42acc90755298659cf1f106de785ed3e2b53eaa618d6482e274a640285c2b48
+  md5: c2e17c0499b87656b84b6befdfa87860
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 388932
+  timestamp: 1756373582551
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-hfae3067_9.conda
+  sha256: c809dcdb3ef0ce86487dc2513d6b417a432fd2d9395e0dda70b39ce6235da40d
+  md5: 14ca160b633a74d997e367d7b52a705e
+  depends:
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 377180
+  timestamp: 1756373598418
 - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
   sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
   md5: 56ee94e34b71742bbdfa832c974e47a8
@@ -15625,6 +18067,43 @@ packages:
   purls: []
   size: 761857
   timestamp: 1757472971364
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
+  sha256: d2377bb571932f2373f593b7b2fc3b9728dc6ae5b993b1b65d7f2c8bb39a0b49
+  md5: 66b1fa9608d8836e25f9919159adc9c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=257.4
+  - libxcb >=1.17.0,<2.0a0
+  constrains:
+  - pulseaudio 17.0 *_1
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 764231
+  timestamp: 1742507189208
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
+  sha256: 0294728d0a2fc0bdfbcfda98b7ada2d8bb420f76c944fa041ece4140858c2ee5
+  md5: a617203ec445f510a3a8651810c735e0
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=257.4
+  - libxcb >=1.17.0,<2.0a0
+  constrains:
+  - pulseaudio 17.0 *_1
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 763814
+  timestamp: 1742507234837
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h77cf2aa_2.conda
   sha256: 588c9ba305e8ece39357b36174a371671916e878b98fdd7521296008a895adb1
   md5: 50f9b250973773b3a9888b57893cbdcd
@@ -15713,11 +18192,11 @@ packages:
   purls: []
   size: 1153848
   timestamp: 1751758156649
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_605.conda
-  sha256: 59562af68fa3d26054c40c5bb6049e74fe93444cd49117f84f8626afd61295d3
-  md5: 7590664ea4027a3d1bc8bea2927a54b4
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_604.conda
+  sha256: 4018f4a7df5fccf262903b68c2b7b58829322e9dcf1012e991670cb87f0523cc
+  md5: a0aaba03990333ff68574ac3a938f88f
   depends:
-  - libopencv 4.12.0 qt6_py312hfe27425_605
+  - libopencv 4.12.0 qt6_py312h64abb66_604
   - libprotobuf >=6.31.1,<6.31.2.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
@@ -15725,8 +18204,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1154302
-  timestamp: 1759259263494
+  size: 1154433
+  timestamp: 1756079105897
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312hc03dbd4_600.conda
   sha256: 08cdb38fd56c25f660604a9501c5cd9f750b35de7e5087f6ac6b0dcdc1b58d6b
   md5: 0f2fd9ce4518657308fd48aff36a8d2f
@@ -15755,6 +18234,44 @@ packages:
   purls: []
   size: 1154603
   timestamp: 1759258389656
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+  sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
+  md5: 70ece62498c769280f791e836ac53fff
+  depends:
+  - python >=3.8
+  - pybind11-global ==3.0.1 *_0
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pybind11?source=hash-mapping
+  size: 232875
+  timestamp: 1755953378112
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+  sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
+  md5: f0599959a2447c1e544e216bddf393fa
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14671
+  timestamp: 1752769938071
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
+  sha256: f11a5903879fe3a24e0d28329cb2b1945127e85a4cdb444b45545cf079f99e2d
+  md5: fe10b422ce8b5af5dab3740e4084c3f9
+  depends:
+  - python >=3.8
+  - __unix
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pybind11-global?source=hash-mapping
+  size: 228871
+  timestamp: 1755953338243
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
   sha256: 1950f71ff44e64163e176b1ca34812afc1a104075c3190de50597e1623eb7d53
   md5: 85815c6a22905c080111ec8d56741454
@@ -16221,6 +18738,74 @@ packages:
   - pkg:pypi/python-dateutil?source=hash-mapping
   size: 233310
   timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.1-py311h1ddb823_9.conda
+  sha256: 2bb2961ca9b6869cfa7fd3ea8045c3b2f5b6530e85f663aa80f9ab6bef7abb61
+  md5: 941d28f9759a3720981ed818ddd76c90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  - orocos-kdl
+  - pybind11
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 337310
+  timestamp: 1756373657165
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-orocos-kdl-1.5.1-py312h1289d80_9.conda
+  sha256: 01e6c2061798065c8317c76729d7b23b98f40e52fcce783c7e870f2efdd05ab7
+  md5: 9dce9e4528bb3277d5a728579d28b5ae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  - orocos-kdl
+  - pybind11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 337695
+  timestamp: 1756373809688
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-orocos-kdl-1.5.1-py311h2cb90db_9.conda
+  sha256: ffda90df69ca6056050dd1da58f923a071fcfef30ac02e5106d16acc968f69e4
+  md5: 4dd7804d8d3f51851ebf0d069698bf89
+  depends:
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  - orocos-kdl
+  - pybind11
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 285267
+  timestamp: 1756373680218
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-orocos-kdl-1.5.1-py312h1ab2c47_9.conda
+  sha256: 9aa5500bef6d896973abbc020a4a9292096258408a60be99b98e6093e35d886a
+  md5: edfe58f05e6e0303f6fb9fb1eb1a0e56
+  depends:
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  - orocos-kdl
+  - pybind11
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 285742
+  timestamp: 1756373762135
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
   build_number: 8
   sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
@@ -16484,6 +19069,123 @@ packages:
   purls: []
   size: 456306
   timestamp: 1720813980184
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
+  sha256: f1fee8d35bfeb4806bdf2cb13dc06e91f19cb40104e628dd721989885d1747ad
+  md5: 9279a2436ad1ba296f49f0ad44826b78
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.16.2,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gst-plugins-base >=1.24.11,<1.25.0a0
+  - gstreamer >=1.24.11,<1.25.0a0
+  - harfbuzz >=11.4.3
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  - libclang13 >=20.1.8
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.3,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libpq >=17.6,<18.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.11.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.37,<5.0a0
+  - nss >=3.115,<4.0a0
+  - openssl >=3.5.2,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 52149940
+  timestamp: 1756072007197
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hbe73643_5.conda
+  sha256: 88fa7acea70be2846842a3d8fc48a81b3d4ce2d90d7f2b1112227416a0135924
+  md5: 04bd1a8591a1e75d294ef39ee9b8d146
+  depends:
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.16.2,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gst-plugins-base >=1.24.11,<1.25.0a0
+  - gstreamer >=1.24.11,<1.25.0a0
+  - harfbuzz >=11.4.3
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.8,<20.2.0a0
+  - libclang13 >=20.1.8
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.3,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.8,<20.2.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libpq >=17.6,<18.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.11.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.37,<5.0a0
+  - nss >=3.115,<4.0a0
+  - openssl >=3.5.2,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 51916609
+  timestamp: 1756053434448
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
   sha256: ac540c33b8e908f49e4eae93032708f7f6eeb5016d28190f6ed7543532208be2
   md5: f7bfe5b8e7641ce7d11ea10cfd9f33cc
@@ -16834,6 +19536,93 @@ packages:
   - pkg:pypi/rich?source=hash-mapping
   size: 201098
   timestamp: 1753436991345
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ackermann-msgs-2.0.2-np126py311hbc2a38a_13.conda
+  sha256: 3193e40a109ec36c82b4f66ae1e8f0c520272dad36d751c3e868a4b11db0b53b
+  md5: e0474511d2964f59aa2e72bb3dba01db
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 82111
+  timestamp: 1753312099342
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ackermann-msgs-2.0.2-np126py311hbdd918e_13.conda
+  sha256: 7a4d0faca1fbdabaf4531ef3487ba78813cb55c0a1eb544c782c09f340d6f8f2
+  md5: 3e1b9ee1c8e41e3d02f6cb2322c389eb
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 85391
+  timestamp: 1753312542656
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ackermann-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 45ebcfd55029a358d1677ea6605e880a8fb26ec77cbf09254349394af5202857
+  md5: b0723da3bebb936c998bfc3033b5edb9
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 90740
+  timestamp: 1753314990884
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ackermann-steering-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 0af5ee9449b5c6b708aa3587d04ff79cfc8e92febc78e37f3341d20c2bb92a3d
+  md5: d1e1e6b73d8dfb49229b6f9a9be121a1
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 93579
+  timestamp: 1753314995661
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-action-msgs-1.2.1-np126py311hbc2a38a_13.conda
   sha256: 21c3b06788cd8d7d6a8a4d66dc58131e486aae86f250d309ea69336fb4b1c450
   md5: f1fad637e992126ca6d4d6b4a2802f89
@@ -16911,6 +19700,76 @@ packages:
   license: BSD-3-Clause
   size: 104185
   timestamp: 1753312576698
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-admittance-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 5cf22d8b624c15012e7fdaea59ab1bd9510911f0d44123c500a32a01d63e511b
+  md5: 9654a89ae6af1f7b7bac6f97ad2f3bfd
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-kinematics-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-eigen
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-kdl
+  - ros-humble-tf2-ros
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 363275
+  timestamp: 1753314659680
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-admittance-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 215612175ae980bc011b841cedd024e8e13ebbddf6b4e7fc56a0f1d44568783d
+  md5: f15570fc76714fed2f7fa63989a5d13a
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-kinematics-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-eigen
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-kdl
+  - ros-humble-tf2-ros
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 350948
+  timestamp: 1753314683624
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ament-cmake-1.3.12-np126py311hbc2a38a_13.conda
   sha256: 4d6e11bc6d3f105a41def2d370bdc3f83721a8242cda74015d8dfdd4b687adbc
   md5: 1649629c82db4f2fba285a7d833bcffc
@@ -18480,6 +21339,126 @@ packages:
   license: BSD-3-Clause
   size: 27692
   timestamp: 1753308463210
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-angles-1.15.0-np126py311hbc2a38a_13.conda
+  sha256: fa0a16116645cba83107d6d6cfeb51d090f2cc9fe22f8af6580b40763055e3c9
+  md5: 98f8955a45cc96839d5ebe61cc6f3d6e
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 32616
+  timestamp: 1753308433001
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-angles-1.15.0-np126py311hbdd918e_13.conda
+  sha256: 0dac2a1546c69234b6dd7f57ec0d188e60635c20735f8d857c930920c15461bd
+  md5: ebe98292fbd35a7b79bf7c17a04c39d8
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 32370
+  timestamp: 1753308560061
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-backward-ros-1.0.8-np126py311hbc2a38a_13.conda
+  sha256: 84518c2d82ce489336081c2a0e9d65941f956459058c326206b361b31684d501
+  md5: 65e49ac25c331fe8d00e345ca5f3b442
+  depends:
+  - elfutils
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - elfutils >=0.193,<0.194.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 338333
+  timestamp: 1753308051141
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-backward-ros-1.0.8-np126py311hbdd918e_13.conda
+  sha256: 73feea8cb3a9c085fc06a550c3c157ac1518ec11f43810056883c86b65dd80ca
+  md5: e193723971d2735ce9e5af3664c65b51
+  depends:
+  - elfutils
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - elfutils >=0.193,<0.194.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 328541
+  timestamp: 1753308184754
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-bicycle-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: a4af082cd4815555c9a6c8a7ad0eaeed328b164cc3c02eaa5c97903980d3e4a8
+  md5: 4a1d81512c3e379d4b4fe799c9bd445d
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 88314
+  timestamp: 1753314977019
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-bicycle-steering-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 04ede0a3f43bcd2fb91861188966f348f1d147c12871b60990c57062803a01d9
+  md5: cad1546ed91405778ef322b0ffb4b560
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 91799
+  timestamp: 1753314980011
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-builtin-interfaces-1.2.1-np126py311hbc2a38a_13.conda
   sha256: f5ebc8075baaa6bf5e03425026d34d1b1be3d44a0731401bd51afa639ca66740
   md5: de5e2635e51811b0665d011c976ea7a2
@@ -18683,6 +21662,242 @@ packages:
   license: BSD-3-Clause
   size: 26273
   timestamp: 1753309636279
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-control-msgs-4.8.0-np126py311hbc2a38a_13.conda
+  sha256: fcb43e311d473fb58b673757aab3106a95b64ce6aab19e66ecaa64add9d47b40
+  md5: 454384cfb428d64006670f19edd09f7b
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 680081
+  timestamp: 1753312376430
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-control-msgs-4.8.0-np126py311hbdd918e_13.conda
+  sha256: 902fddddc1ea2a1fe8457995db3b304891284d9a95bdbd6d506477c7f433c18b
+  md5: e9a373d51574b481bccbaf3693a8e783
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 684195
+  timestamp: 1753312772941
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-control-toolbox-3.6.1-np126py311hbc2a38a_13.conda
+  sha256: 63e7ea9b68fb7c8d02773a3cc93dbbd20aded6ba21c530c7b405a73c97af339e
+  md5: 67a24e538e01f9a2ac34a6889a442ea3
+  depends:
+  - eigen
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-filters
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcutils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 198436
+  timestamp: 1753314055813
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-control-toolbox-3.6.1-np126py311hbdd918e_13.conda
+  sha256: 7ed8c4ab8835316ce14b5167f6723d92e27a4a95c2c95ae147ee46527e385cfb
+  md5: 5444e92eaf6f9d0d17d3f1e102d6aed9
+  depends:
+  - eigen
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-filters
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcutils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 197221
+  timestamp: 1753314148427
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-interface-2.51.0-np126py311hbc2a38a_13.conda
+  sha256: f02a49ab3ec3ad4050601548562a90f7a72f9dc0a3b63f62a73daee35cd00248
+  md5: 7b4ecbba468ff2e894b15e3947802fa1
+  depends:
+  - python
+  - ros-humble-hardware-interface
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 61182
+  timestamp: 1753313853755
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-interface-2.51.0-np126py311hbdd918e_13.conda
+  sha256: b4d8297f3b7e3f09c75a464b440909027e7da821b593a1b95c69b0cd1dad9079
+  md5: 2cc08250ce5c6a911b675fa4f210992b
+  depends:
+  - python
+  - ros-humble-hardware-interface
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 61833
+  timestamp: 1753313963942
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-manager-2.51.0-np126py311hbc2a38a_13.conda
+  sha256: 58b7103cf3b1a544b5954d2245363a1174be80dfa9e6596fde6fe5539a5708cf
+  md5: c0aa5606e4491cf20fef5df8c4dfa085
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-controller-manager-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-ros2-control-test-assets
+  - ros-humble-ros2param
+  - ros-humble-ros2run
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 484588
+  timestamp: 1753314348269
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-manager-2.51.0-np126py311hbdd918e_13.conda
+  sha256: ec465e493dbdbcfffaa27050d0e6c7006edd85ab8af83255edfb84be3afdc669
+  md5: 2ac75a9357e5dee973caaab4a3507ecf
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-controller-manager-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-ros2-control-test-assets
+  - ros-humble-ros2param
+  - ros-humble-ros2run
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 470786
+  timestamp: 1753314411665
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-controller-manager-msgs-2.51.0-np126py311hbc2a38a_13.conda
+  sha256: 8eae689896b918d288c70f5c59cebfeee657a9349abc2e2c5cd90495fb0998ac
+  md5: 823f6d995db4b60e6649f5c37f842a10
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-lifecycle-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 308704
+  timestamp: 1753311936677
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-controller-manager-msgs-2.51.0-np126py311hbdd918e_13.conda
+  sha256: 24dd22e7a78a7cb7e8df26846d63318dab651fbaef7da92610ecf7da4aad57c7
+  md5: 1bd92cdc57fd0ee1e7e7e17b3c80b35d
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-lifecycle-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 314429
+  timestamp: 1753312410586
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-cyclonedds-0.10.5-np126py311hbc2a38a_13.conda
   sha256: 13ab35228674132d0ecb601c25dc7e12731f4c851d2364267e7e45c89c8e8e94
   md5: c86ab3549fb7c876cfba9ca5380f9fe5
@@ -18764,6 +21979,63 @@ packages:
   license: BSD-3-Clause
   size: 150197
   timestamp: 1753312612991
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-diff-drive-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 29a140646186156802f24d97f445a72e05aa5c713be8de682e086ba0d2d15e11
+  md5: 86db207146ce7c195c983ebd4b8a080d
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 303718
+  timestamp: 1753314609400
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-diff-drive-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 5f89c0c05c94ddae6157e1c21fa3d897ea4bac29e41f3ce2dd9b349c866b85d2
+  md5: 2505d0294fd8d8793c3fd0ee7bf03c8a
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 287503
+  timestamp: 1753314627974
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-domain-coordinator-0.10.0-np126py311hbc2a38a_13.conda
   sha256: 19055d6b7c212e1a85fbc55ea65a3c195b6f4901103aedf99fd6a1acf1151358
   md5: 8932d8b6155c236c96643efaaa84a64b
@@ -18797,6 +22069,78 @@ packages:
   license: BSD-3-Clause
   size: 20397
   timestamp: 1753308438235
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-effort-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 615f565f4453fb282980b6b12f34f6a4f5f647a4d2d2995a07b24872a5f550af
+  md5: da25e2c3ef14c1192c803461d8ef6399
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 64602
+  timestamp: 1753314965308
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-effort-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: b9185a8d16e9fea2b930d3c016a58d46f1a799e353a5fc556e393e1a15540c11
+  md5: 6530c8970e41966fd4de4a8de8560421
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 65764
+  timestamp: 1753314966799
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hbc2a38a_13.conda
+  sha256: ef7e772043a33a602061362bff749dc630516816f7f11075dfb8410f3c1887ab
+  md5: c3d764141fe3ca6b22b9d68c4a814d0d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 23396
+  timestamp: 1753309032963
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-eigen3-cmake-module-0.1.1-np126py311hbdd918e_13.conda
+  sha256: 13fa7471a8c8f56af861c85cdd1a913b19ccfbd3043d8e7a43a86204b7996def
+  md5: d47f0030b4cdcfe4dd8ed634cac2ecaf
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 23220
+  timestamp: 1753309029255
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-fastcdr-1.0.24-np126py311hbc2a38a_13.conda
   sha256: 2884bac4fe1ad38443470ad62119371f9d2c10a8937471de1d0303dedf90f4d5
   md5: e838ab8ea5d838183fc6e1313debc4e8
@@ -18906,6 +22250,46 @@ packages:
   license: BSD-3-Clause
   size: 26580
   timestamp: 1753309383682
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-filters-2.2.1-np126py311hbc2a38a_13.conda
+  sha256: 9e1ab7186032de5886a3aeee790c32aa1947719deea057492a4bd8c55e742101
+  md5: ae75878d2dbf5ff472ab1a9c5017936d
+  depends:
+  - libboost-devel
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 123255
+  timestamp: 1753313158712
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-filters-2.2.1-np126py311hbdd918e_13.conda
+  sha256: 5e30638a7ac0c6ff75d63b085520355ea99c9b0e6d3e7631fe6e72c8e9650fb4
+  md5: ff4a06c31afc76f388fae92b8db7e4fd
+  depends:
+  - libboost-devel
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 125295
+  timestamp: 1753313389445
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311hbc2a38a_13.conda
   sha256: a92ff1fc0e77fd1774a0eebb8a4b8a2ef4bc470a1cb930a80206d3f355f15bf6
   md5: 9971d1b14a4728a3e29aee5ce713732c
@@ -18944,6 +22328,198 @@ packages:
   license: BSD-3-Clause
   size: 19277
   timestamp: 1753309082086
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-force-torque-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: c8e5d75f8b90f27a4dadc424f1808272c5f4f9c86776717fd15b7d06ab59f714
+  md5: 7241b1f5d26887cdb95c94cdacec50e2
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 142475
+  timestamp: 1753314698050
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-force-torque-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 7c72506fa267003e281162ce059c6838f489d2d8536ed280e6f353dd5fdd4657
+  md5: 4411027c22bdb24bd36038401629973b
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 141262
+  timestamp: 1753314716336
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-forward-command-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 0ef72096eea16a8908f80da70e6a6d28c3797fd8f076c7c4713fae4610ab0567
+  md5: 65840c6a0db09c1dffe5a4a58610dc0b
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 211539
+  timestamp: 1753314631927
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-forward-command-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 8a595c89ddc1599b8e39edd9e9e55ed68dbdc8d97e45ea09761bee62e626ff03
+  md5: ee1292d53f25a381224946d8bc8de37a
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 209097
+  timestamp: 1753314657561
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-generate-parameter-library-0.5.0-np126py311hbc2a38a_13.conda
+  sha256: a0231c6444885a0002af6b63ac5ee3da42d51018e768a446e0fb9f4d269f2c0d
+  md5: 7b3a403418fb067cf4d1e00f5c70fe2d
+  depends:
+  - fmt
+  - python
+  - ros-humble-generate-parameter-library-py
+  - ros-humble-parameter-traits
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 47519
+  timestamp: 1753313907569
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-0.5.0-np126py311hbdd918e_13.conda
+  sha256: 90d2a607e275199afb5128481198c32c77e26c19e8afb65c50ed13c5587a7833
+  md5: 9c49ff06c57d2c8657a8b5a176cdc1f8
+  depends:
+  - fmt
+  - python
+  - ros-humble-generate-parameter-library-py
+  - ros-humble-parameter-traits
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 47193
+  timestamp: 1753314010124
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hbc2a38a_13.conda
+  sha256: 2ccec5ef960376aea21ddd01d59bd142560e90a264a6ec931287f72b4ab9f23a
+  md5: 3df71b853171601e2fa316443aa5a26d
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - typeguard
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 72265
+  timestamp: 1753308346375
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-generate-parameter-library-py-0.5.0-np126py311hbdd918e_13.conda
+  sha256: 91c8eca96d8aca26359f9401dca1ff7b6dde5a5fe3e5bd380a06aaafeaee90b8
+  md5: a443d21fd6afd2955bc0f6df856d8592
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - typeguard
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 72101
+  timestamp: 1753308458551
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-geometry-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: 66aac3623a511209119c1632331f3055cd2b9c8dd612490d5151221a8e715105
   md5: 1dffeaa1fd651a86000aabac131b8b25
@@ -19015,6 +22591,104 @@ packages:
   license: BSD-3-Clause
   size: 113399
   timestamp: 1753308151142
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gpio-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: d8320c2cec42c697dbd3dcb25b8f6d4d9ad5c1b8e5c34d383d633f1697f0bbb4
+  md5: 7d6cc459a23fbbbecdeab90a877ce2a4
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 227685
+  timestamp: 1753314675199
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gpio-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 1a4ffde691e47bfffb1a43362d3a6afeebc86266ccc4dff8a94eb0f520da0fd9
+  md5: a67bad11c3b7b802996cb2b27304789c
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 224173
+  timestamp: 1753314691745
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gripper-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 2923a213e6b2d26a4eb34309586d54de15acfee6ae7e48adcc0a7dbc591f2289
+  md5: ebe58cc9a7235051a09e517a0e3a0f50
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 140060
+  timestamp: 1753314658743
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-gripper-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 10166a9392a3068d5ad1947cbbc2af87ece79de451575632b0e8f72c1afa6907
+  md5: 5e3ffd3aa36dc29ebdfc08fd144c7283
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 138444
+  timestamp: 1753314673188
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-gtest-vendor-1.10.9006-np126py311hbc2a38a_13.conda
   sha256: 6a069fe63a49fa5056ace74da96ba86779d60d0dd1879b1f17d1843010082792
   md5: aace104a62696fc0084b6dd0df74c91a
@@ -19047,6 +22721,52 @@ packages:
   license: BSD-3-Clause
   size: 199747
   timestamp: 1753308066715
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-hardware-interface-2.51.0-np126py311hbc2a38a_13.conda
+  sha256: 71f754202d948b697c6bfe6661c4b5dc7bb6e4077da7cdaac53532d3720f9434
+  md5: 59930c1666803df50b82daae421a81ae
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-lifecycle-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 299052
+  timestamp: 1753313533752
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-hardware-interface-2.51.0-np126py311hbdd918e_13.conda
+  sha256: ac59c10b832abb77ab8c92eeae87ffd2dc69c6e61ad2d63421969a30bf08ad27
+  md5: ca76a0fec387c874aaf51ace8773ad58
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-lifecycle-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 289819
+  timestamp: 1753313691253
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311hbc2a38a_13.conda
   sha256: f9b1d35c984cb911a4c5a4e01342d10eaa67a92ea8f1d0b17dd29be12791af69
   md5: 650ff6e0bf8e4a498da06f330431d500
@@ -19149,6 +22869,456 @@ packages:
   license: BSD-3-Clause
   size: 571724
   timestamp: 1753308154921
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h58b36e0_13.conda
+  sha256: dd18611970cfdc80dfcf7886e6103b122e9631aee9065efeec21a673966146b3
+  md5: 1c35afea3f23a4cb0216e79bb21c9af7
+  depends:
+  - libignition-cmake2
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - graphviz >=12.2.1,<13.0a0
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 28599
+  timestamp: 1753309488213
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311hfe9da55_13.conda
+  sha256: b44493029f7c4c696b4fdda0a7811fc6e9d648f8562a30dd880f4e863442ec0d
+  md5: 8d92b04d8f701ed140c97a66be9fa6e7
+  depends:
+  - libignition-cmake2
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - graphviz >=12.2.1,<13.0a0
+  license: BSD-3-Clause
+  size: 29459
+  timestamp: 1753309354092
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hbc2a38a_13.conda
+  sha256: 5b5c6d6b8e4e4caa7ff9ba9491c5360c4d829f50ca3c8379d3435b23e9d0c4e1
+  md5: 2860d950971841fa14ddddfa26fc8351
+  depends:
+  - libignition-math6
+  - python
+  - ros-humble-ignition-cmake2-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libignition-math6 >=6.15.1,<7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 26056
+  timestamp: 1753309530282
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ignition-math6-vendor-0.0.2-np126py311hbdd918e_13.conda
+  sha256: d3b0eccfc1d90aff4096c69376c9b688ea00230d895aef88fdb98b768d12be00
+  md5: d1c7572bf135af823b6a43e19fbcf3f1
+  depends:
+  - libignition-math6
+  - python
+  - ros-humble-ignition-cmake2-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libignition-math6 >=6.15.1,<7.0a0
+  license: BSD-3-Clause
+  size: 25797
+  timestamp: 1753309384180
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-image-transport-3.1.12-np126py311hbc2a38a_13.conda
+  sha256: fd92c854a89fe86ea684a59c3f65d7bfce15d334113a66479b9bf60cf64fa39d
+  md5: a5898df73af1b67924740bac78eb2aed
+  depends:
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 543688
+  timestamp: 1753313922042
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-image-transport-3.1.12-np126py311hbdd918e_13.conda
+  sha256: 1bf44c6d67e776d802ab529b4a727c616a7d67b6b7581fbf99113b86f34ed0c8
+  md5: d4ac956b639c6750c0b96147de3d5378
+  depends:
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 548825
+  timestamp: 1753314043667
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-imu-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 0c32d2d9f8d220201b9b581ae59bf7bd722ce081033ad764baa98aa0d756aab1
+  md5: 3136374c22513114a5f34a7debc83f81
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 145193
+  timestamp: 1753314642183
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-imu-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+  sha256: ac676b038aca291d7ef9e445c5839671cdf67b822a3562f0cbd661fdc8ed9487
+  md5: 5cf10857ca9627fa47157fa808d51318
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 143716
+  timestamp: 1753314655132
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-interactive-markers-2.3.2-np126py311hbc2a38a_13.conda
+  sha256: 07446256a6841db76989d16db3050599a0b07feb8565ac6f07e0507b1b2a54a4
+  md5: cbf91c10c269975a1f6db0b7eb48366d
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 318221
+  timestamp: 1753314484876
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-interactive-markers-2.3.2-np126py311hbdd918e_13.conda
+  sha256: 19a918612cd556c96897ce220aa58a1af186dbdd99591328dea49b5bfc58925c
+  md5: 71d4e421fddf4885dd534ecd53ec2da4
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 312197
+  timestamp: 1753314498917
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-joint-state-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 3e0b3df07298a1ded3d599e45fec63a87419bb8b520dea76f442ce664b213f12
+  md5: 1833915803acad9f1ef4584417aab036
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-builtin-interfaces
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcutils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 160984
+  timestamp: 1753314608984
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-joint-state-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 98a2f424be8746d6c22c00c44f1089a0cfb660b7480cd17fa25fb997f3621e76
+  md5: ab3a6d984d3e69e922dbbcb5811c0b0e
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-builtin-interfaces
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcutils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 159551
+  timestamp: 1753314618519
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-joint-trajectory-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 0e3140ec88d32967cf0c0ce756fe0690eb57224807f49a84a3e0b176dfb9fd57
+  md5: 5acec29ec163ec789b527d316c037415
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tl-expected
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 360323
+  timestamp: 1753314696293
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-joint-trajectory-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: baa845feea03c4f10c99e85a8e4d6933867fd065d8499867997270621e5b0fac
+  md5: ea9ad68cefdc8836cd9444bd83cf7d8b
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tl-expected
+  - ros-humble-trajectory-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 350828
+  timestamp: 1753314728513
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-kdl-parser-2.6.4-np126py311hbc2a38a_13.conda
+  sha256: 9b329a3b569c69def0bf93dbf5a6f23d5b1c97ad0862e4cde544fd39c52167ae
+  md5: bf13572b451a5464ab4bfbb6e6caafb4
+  depends:
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-urdf
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 46615
+  timestamp: 1753310374807
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-kdl-parser-2.6.4-np126py311hbdd918e_13.conda
+  sha256: ff3ae15122d34c97690258e8538af80639e0a25098fc8632539fe4f25b7e8fb7
+  md5: 3bdcecfd30b2ece085a4db7ecb09ce02
+  depends:
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-urdf
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 47500
+  timestamp: 1753312077498
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-kinematics-interface-0.4.0-np126py311hbc2a38a_13.conda
+  sha256: 9aa10e36ff805eeb53494902cd0565aedaf382df0af364be169f81588c054180
+  md5: 05dc617966db3ebc07e0eebe127a064d
+  depends:
+  - eigen
+  - python
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 42401
+  timestamp: 1753313478803
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-kinematics-interface-0.4.0-np126py311hbdd918e_13.conda
+  sha256: bb9b022538515f633b62274decbbd07e8e3b40a637744f8aed4eb4a796c9f3e8
+  md5: 9e34a2d5574d34510511ffb0b68add87
+  depends:
+  - eigen
+  - python
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 43346
+  timestamp: 1753313637036
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-laser-geometry-2.4.0-np126py311hbc2a38a_13.conda
+  sha256: ad7415b738ba321b88768c1373c95214630dd7ccdf238b511d017c2012348b70
+  md5: 108ad131bae9ac89057e6de1c539b927
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-sensor-msgs-py
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 58708
+  timestamp: 1753313149134
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-laser-geometry-2.4.0-np126py311hbdd918e_13.conda
+  sha256: ccd2eb19ac81dde878074a4fc192d35968e46f88dc0b85841d406ce5be4db2aa
+  md5: 689f7835b8105a0f0303bce571222fa2
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-sensor-msgs-py
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 58087
+  timestamp: 1753313380050
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-launch-1.0.9-np126py311hbc2a38a_13.conda
   sha256: bebbea8a453199515b17ec9cf99c643be5ae60a21a6835486e577d4c522a00bb
   md5: 366369f5066692d9e9c881e1a320abe5
@@ -19428,6 +23598,44 @@ packages:
   license: BSD-3-Clause
   size: 26192
   timestamp: 1753308889716
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-libcurl-vendor-3.1.3-np126py311hbc2a38a_13.conda
+  sha256: b616c098ba88cf8fa043168f29f23d3d5e22f09f57b821e95e30ac2524561f43
+  md5: d16728dc5e661cde5e54be3c83fe0c71
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libcurl >=8.14.1,<9.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 23217
+  timestamp: 1753308423238
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-libcurl-vendor-3.1.3-np126py311hbdd918e_13.conda
+  sha256: f8c4de09b7d81d425738179a8b02ecf23bf99dcd9141d8492e8c3d23b9616ecc
+  md5: 87725f15d06a06ca6c6167cd8fbfadcf
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libcurl >=8.14.1,<9.0a0
+  license: BSD-3-Clause
+  size: 23056
+  timestamp: 1753308554309
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-libstatistics-collector-1.3.4-np126py311hbc2a38a_13.conda
   sha256: 3215e434d022b67292fb023d421fa2983e7363adce1dc49f1db2f7329bf79a7d
   md5: 77fb7bf4d9e1c617d09babdf43c3f1f3
@@ -19545,6 +23753,145 @@ packages:
   license: BSD-3-Clause
   size: 178810
   timestamp: 1753312305724
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-map-msgs-2.1.0-np126py311hbc2a38a_13.conda
+  sha256: 6249c2e5d6f8f20cd446f8a69ecee2a616bcba9de74d1983eb9626f86ece3912
+  md5: b03b9cf65dbfda1c84aba683a0dc617b
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 207171
+  timestamp: 1753312350047
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-map-msgs-2.1.0-np126py311hbdd918e_13.conda
+  sha256: fbdb2f768ad51107f0b5873c67b93f3a9052c11353539cc3a1bc10fad513d679
+  md5: 4bd555d345cd80a13d8ea54aaa896b6e
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 211682
+  timestamp: 1753312745807
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-mecanum-drive-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 4b2cb43bee440f3f56115ad6d2b68ea41663ac245ab29832093de158d0d6358c
+  md5: 6f47b9c0af5a1bb3619e7a55a556f3ca
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 284532
+  timestamp: 1753314709226
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-mecanum-drive-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 66ef807960e631944a632715a7f07445aa3a7621a51d4b1c71b7d365a23a9af5
+  md5: 2951259388518f00fefba60077a32afb
+  depends:
+  - python
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 276049
+  timestamp: 1753314740873
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-message-filters-4.3.7-np126py311hbc2a38a_13.conda
+  sha256: 58a35e18fb14dee701b9ee7878037b4523e4626c7acc678c3da5235b6a01a7d4
+  md5: 2329877d72e14b35231719a41de043ff
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 74893
+  timestamp: 1753313494264
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-message-filters-4.3.7-np126py311hbdd918e_13.conda
+  sha256: f090095cb6fc5fc3c7546d97961b5a895b235ca0fae34ecab2fa449c008ab162
+  md5: e771c1060dc5200cbdb27be1976ef325
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 74887
+  timestamp: 1753313653415
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-nav-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: 2038c336d5162ec244ba9b74d5aba7aca97789629a632b552903a937465a430e
   md5: 2c710e43b1d0551bb33929ee18654345
@@ -19585,6 +23932,47 @@ packages:
   license: BSD-3-Clause
   size: 209912
   timestamp: 1753312680461
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hbc2a38a_13.conda
+  sha256: de46a2167d484f48c194054a1c03c933c0828070c7c4608102aaf7c5b13934c5
+  md5: 62f2e860f99ce1163d32027820e0c49a
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 26819
+  timestamp: 1753309542357
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311hbdd918e_13.conda
+  sha256: e3268363c6022194dcaf3167cff82536d8eae8cb2c348acc62672770971997bc
+  md5: 544df8e306cb89d2b9302cd27cf0a72a
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 26694
+  timestamp: 1753309398501
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-osrf-pycommon-2.1.6-np126py311hbc2a38a_13.conda
   sha256: f98fb2e3c542b9600512acf317cbb418adc5d7f03730f0e28ca8ac7f05d13ea5
   md5: 63b2ce925db370d03a65c96a1dcd0bf6
@@ -19620,6 +24008,107 @@ packages:
   license: BSD-3-Clause
   size: 65577
   timestamp: 1753308066519
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-parameter-traits-0.5.0-np126py311hbc2a38a_13.conda
+  sha256: 4d1c0eb96bd87ee32842e9d564459d8626531847b713626528c1615496412f34
+  md5: f03394999710af5b882779423c98b937
+  depends:
+  - fmt
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 47244
+  timestamp: 1753313509881
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-parameter-traits-0.5.0-np126py311hbdd918e_13.conda
+  sha256: a38c7a45d6b14467809a7e26f3b36f0f2b715541ab37153c19bca7ef6cfd1cc6
+  md5: b103d33934127f09422fcc13ae84d477
+  depends:
+  - fmt
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rsl
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 46984
+  timestamp: 1753313668116
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pid-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: c90979b6eab1699f3d33df3e8433c7445caf91e25e0638e8a6d9051e0ad768d2
+  md5: 1cbbfee81a4b1f72b029a1e90179198d
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-parameter-traits
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 257022
+  timestamp: 1753314685115
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pid-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: ea6c77ff7ee6d142360fe6fafd88e62e9ff29dde38adb87d73b49642ee6433ef
+  md5: 28800f51efaa3c15726c0de37d05a908
+  depends:
+  - python
+  - ros-humble-angles
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-control-toolbox
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-parameter-traits
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 249851
+  timestamp: 1753314715659
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pluginlib-5.1.0-np126py311hbc2a38a_13.conda
   sha256: 8775874f04996c5f33b54dd39e809d5fee684af3bd9daff75856160cf0ad62ad
   md5: b3467319d31a545af309eaf4ad691df5
@@ -19662,6 +24151,131 @@ packages:
   license: BSD-3-Clause
   size: 40838
   timestamp: 1753311878856
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pose-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 953f8499500e5cdc9d8a5f859db86a716b331924885d304dd268ec71eab17022
+  md5: ee2a834f3f6ae8926f5f35576bb7d6c2
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 153407
+  timestamp: 1753314668563
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pose-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 83caf29ff4da06d5566a0813bbd2faa3db865a010d00da81b91230b877516a28
+  md5: 5746456ccb8c0d7f742676895cfc0224
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 151775
+  timestamp: 1753314698384
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-position-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 2bcf927b8fbc1f339608ad84fcaea8486856135637a3c4ba52433c322cf9b0ee
+  md5: 073353011b740b949558501f9533a789
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 64066
+  timestamp: 1753314953159
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-position-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: ab6a862e327a31301dbfdf88a8a0264b5688b4cb29e88de4b22454117cc28cac
+  md5: 57767930bfca91c3e70f373bc67586cf
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 65098
+  timestamp: 1753314953335
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-pybind11-vendor-2.4.2-np126py311hbc2a38a_13.conda
+  sha256: 479252348c97d1d2325248795669e8fdf80669b646a038b47a4697dd0bf561a0
+  md5: 605444c887765cda6db2342f29aa737b
+  depends:
+  - pybind11
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 22348
+  timestamp: 1753308425968
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-pybind11-vendor-2.4.2-np126py311hbdd918e_13.conda
+  sha256: b3da2486a1451ac8fe4a0b937c1c077f0e4ed2ac136374439a21573b4a8f3266
+  md5: 04a4bee52e52ce90f63611620c58baae
+  depends:
+  - pybind11
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22165
+  timestamp: 1753308541837
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-python-cmake-module-0.10.0-np126py311hbc2a38a_13.conda
   sha256: 82183ca2a9bf24dab1889f2ca136bffc2463435c46c26548925ff1a1b3861d4a
   md5: 4061bfeff2c08662e0f26000a9c56f65
@@ -19695,6 +24309,96 @@ packages:
   license: BSD-3-Clause
   size: 27593
   timestamp: 1753309386762
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hbc2a38a_13.conda
+  sha256: dde27e015035a42b685e9eb3db4488e34af58fc807eb9b84260e5574cbda5bbc
+  md5: 00230d6542037c10aeb9edd09f9ee39b
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-pybind11-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 26837
+  timestamp: 1753309841031
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-python-orocos-kdl-vendor-0.2.5-np126py311hbdd918e_13.conda
+  sha256: 8ee2d80aafc2b1b9aae943da5276a504536d086e020729562e44137cf7cbdbd3
+  md5: d4085a1905de0fa4be8e6bb5413fff7f
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-pybind11-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 26710
+  timestamp: 1753309610769
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-range-sensor-broadcaster-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 0a49e67f93ee4b891bd7d24f5b95a7072eedeb0e3d8b8f4aff836546d69bde51
+  md5: 4dad5c05fb5af455854b7059b8efec20
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 136022
+  timestamp: 1753314652064
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-range-sensor-broadcaster-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 5501fbcba27aa4b83bc62cb8d27baba29280c6a1b1079e4986e90c714d2aae85
+  md5: a8e2cd86a4fdae87e4beb846e3ba53fd
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 135201
+  timestamp: 1753314676712
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rcl-5.3.9-np126py311hbc2a38a_13.conda
   sha256: ec48fadd9812801265fab47865db3f9f63ed1669614be50cddd8ff4a1dd4830b
   md5: a71af214c801802909a4af2c48b2c8f1
@@ -20309,6 +25013,91 @@ packages:
   license: BSD-3-Clause
   size: 120302
   timestamp: 1753309706612
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-realtime-tools-2.14.0-np126py311h122846f_13.conda
+  sha256: f779a72b5fa42f8e837b1ce9d889494e6b9105f869c428529b01dd8d82001f32
+  md5: dc6243ac1e39e6a2823bf780ac4da858
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - libcap >=2.71,<2.72.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  license: BSD-3-Clause
+  size: 68815
+  timestamp: 1753313560095
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-realtime-tools-2.14.0-np126py311h7501b8c_13.conda
+  sha256: dbb1d48de48d11a71da999b2c9ce7bceb615d4ac62548ffed5fce58fe11f0358
+  md5: 320ef1f2c76a162d6640b436affe1a40
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - libcap >=2.71,<2.72.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - libboost >=1.86.0,<1.87.0a0
+  license: BSD-3-Clause
+  size: 74044
+  timestamp: 1753313713749
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-resource-retriever-3.1.3-np126py311hbc2a38a_13.conda
+  sha256: 1fe8a82e34404d287e8f7dd4485970201f5ed0823c368a035b90df3815799b63
+  md5: 704afea002142605922162c06a9d0c3d
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-libcurl-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 44364
+  timestamp: 1753309853232
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-resource-retriever-3.1.3-np126py311hbdd918e_13.conda
+  sha256: 3f8eb8a260260f546a03363bd76dbed41bc8279dd6d2fde3c7affa89a20e8adc
+  md5: 51254d1135ac4e998c4527ad394f629c
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-libcurl-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45254
+  timestamp: 1753309625369
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rmw-6.1.2-np126py311hbc2a38a_13.conda
   sha256: 4a520f33478d4a02dd5e5806a6d43d217db391bde5bdeab9083a7e1a3d22980c
   md5: 3af9d608b90b0c525075a8d47e02ae85
@@ -20797,6 +25586,61 @@ packages:
   license: BSD-3-Clause
   size: 28530
   timestamp: 1753309574840
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-robot-state-publisher-3.0.3-np126py311hbc2a38a_13.conda
+  sha256: 40c6a8d8ef522336ce37d48fe7aa24eadc84145f7980d2c3f93815de67497a8f
+  md5: 7b5d5e6ffbd7e8251db93b3ef0f5cf55
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-kdl-parser
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 257351
+  timestamp: 1753314067571
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-robot-state-publisher-3.0.3-np126py311hbdd918e_13.conda
+  sha256: 2f376cd3224a764e19f9f97b76a0d6d49192f1c17b0ca4090496600f1638a344
+  md5: 7066452b03f1f812667ee4fc00a2f37f
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-kdl-parser
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 252953
+  timestamp: 1753314163503
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311hbc2a38a_13.conda
   sha256: c0ac7cfb4a52d4ad7e54b422f2b786ba0519be84c243c64d7218c9e47d053abc
   md5: fad2b4bd8caa297bdf97da45ec77a34a
@@ -20955,6 +25799,112 @@ packages:
   license: BSD-3-Clause
   size: 35788
   timestamp: 1753307996232
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hbc2a38a_13.conda
+  sha256: b39007d1076b2ea4cca318b8a1f59e63ee8b8cb8c1439199fcb5478edf50458e
+  md5: 338580fb946f4a6a72ac2ae5b9ad1436
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 26502
+  timestamp: 1753308436666
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2-control-test-assets-2.51.0-np126py311hbdd918e_13.conda
+  sha256: de6be4dd22eddca09e4cfbd31fe6f15309f21e95036df454793b430c2606f1cd
+  md5: b22914dd41d804be54570202147dfaff
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 26287
+  timestamp: 1753308553190
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: df8a3aa30d813ecfe8ae9f7a145e77fc42dbc053202211f65bbbc9ad0ee1ab90
+  md5: 3767a536dff3233b9f62cb11a27e101a
+  depends:
+  - python
+  - ros-humble-ackermann-steering-controller
+  - ros-humble-admittance-controller
+  - ros-humble-bicycle-steering-controller
+  - ros-humble-diff-drive-controller
+  - ros-humble-effort-controllers
+  - ros-humble-force-torque-sensor-broadcaster
+  - ros-humble-forward-command-controller
+  - ros-humble-gpio-controllers
+  - ros-humble-gripper-controllers
+  - ros-humble-imu-sensor-broadcaster
+  - ros-humble-joint-state-broadcaster
+  - ros-humble-joint-trajectory-controller
+  - ros-humble-mecanum-drive-controller
+  - ros-humble-pid-controller
+  - ros-humble-pose-broadcaster
+  - ros-humble-position-controllers
+  - ros-humble-range-sensor-broadcaster
+  - ros-humble-ros-workspace
+  - ros-humble-steering-controllers-library
+  - ros-humble-tricycle-controller
+  - ros-humble-tricycle-steering-controller
+  - ros-humble-velocity-controllers
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22792
+  timestamp: 1753315828114
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-ros2-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 59f75230a5606a587d150c7af7083da78aaeec2427fef5c14880481908511037
+  md5: ce140c073f6291b9f1218b3c4900a2c1
+  depends:
+  - python
+  - ros-humble-ackermann-steering-controller
+  - ros-humble-admittance-controller
+  - ros-humble-bicycle-steering-controller
+  - ros-humble-diff-drive-controller
+  - ros-humble-effort-controllers
+  - ros-humble-force-torque-sensor-broadcaster
+  - ros-humble-forward-command-controller
+  - ros-humble-gpio-controllers
+  - ros-humble-gripper-controllers
+  - ros-humble-imu-sensor-broadcaster
+  - ros-humble-joint-state-broadcaster
+  - ros-humble-joint-trajectory-controller
+  - ros-humble-mecanum-drive-controller
+  - ros-humble-pid-controller
+  - ros-humble-pose-broadcaster
+  - ros-humble-position-controllers
+  - ros-humble-range-sensor-broadcaster
+  - ros-humble-ros-workspace
+  - ros-humble-steering-controllers-library
+  - ros-humble-tricycle-controller
+  - ros-humble-tricycle-steering-controller
+  - ros-humble-velocity-controllers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22614
+  timestamp: 1753315589734
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-ros2action-0.18.12-np126py311hbc2a38a_13.conda
   sha256: 48cb1cec6128f237a95d1b892f61c248c9dbe63015ff3d58e7935e76be166e4b
   md5: b8be8730ff46f3b1e915fb3f0037946f
@@ -22527,6 +27477,52 @@ packages:
   license: BSD-3-Clause
   size: 25694
   timestamp: 1753308576715
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rsl-1.2.0-np126py311h58b36e0_13.conda
+  sha256: 1fa868f36f205d7109eaa6013ce61da86aa1a888304208654e9dc7e5144ea186
+  md5: 33d44028a94324cdd81967d288ef8d36
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - graphviz >=12.2.1,<13.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 56238
+  timestamp: 1753313148376
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rsl-1.2.0-np126py311hfe9da55_13.conda
+  sha256: 698bbc2778d726fe3f8305d6c9622ca99b06e93e1913ecc62456186d0be3703d
+  md5: ed421d622b57e4fe25c2e3dce7e9f5d0
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-tcb-span
+  - ros-humble-tl-expected
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - graphviz >=12.2.1,<13.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 57414
+  timestamp: 1753313381367
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311hbc2a38a_13.conda
   sha256: 710b793c1a78baab8626c07ed04aba0c20200cc229dbeb2d29414364c91ab331
   md5: 044ff177cdfdc53a802018d42355fb44
@@ -22561,6 +27557,399 @@ packages:
   license: BSD-3-Clause
   size: 30741
   timestamp: 1753309569389
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hbc2a38a_13.conda
+  sha256: 497c6ca0e05824dc535b7098517b2c8c0417c43cb2af3a68f59a11d2f94d5faa
+  md5: 84e0848a7bffc769ecc08d0238c627ba
+  depends:
+  - assimp
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 24156
+  timestamp: 1753309483401
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-assimp-vendor-11.2.18-np126py311hbdd918e_13.conda
+  sha256: 8423436f5e5d0a6e90d9e519603c12fbfd60ba857a321f7f7d47b515faea1f4a
+  md5: 788efd6ea662d0353992b246e1c969b9
+  depends:
+  - assimp
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 24070
+  timestamp: 1753309348817
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-common-11.2.18-np126py311hbc2a38a_13.conda
+  sha256: 46c3eaeb5cb9034418e8177188e5249eca6cb17e5d40f228162606fcd036b3a1
+  md5: 2169ef3b7aa736cb26e197f6205332d6
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 839286
+  timestamp: 1753314316450
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-common-11.2.18-np126py311hbdd918e_13.conda
+  sha256: 80ebbd97dc0d5e4d1b25a1c5dbd0dd510c5a9b092d95860027d6f8edf818d58b
+  md5: fe7a38ba7583a610ea3143f24882be82
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 832802
+  timestamp: 1753314374909
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-default-plugins-11.2.18-np126py311hbc2a38a_13.conda
+  sha256: 1d527cc98d85e6480ae09a040bc3488343af7203473bc12f8905413065a30161
+  md5: 59c48098f4c12158abe33ad7f15124ac
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-ignition-math6-vendor
+  - ros-humble-image-transport
+  - ros-humble-interactive-markers
+  - ros-humble-laser-geometry
+  - ros-humble-map-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: BSD-3-Clause
+  size: 2238373
+  timestamp: 1753315139439
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-default-plugins-11.2.18-np126py311hbdd918e_13.conda
+  sha256: d6db00239f5b9669b8beb91a1d94f68ecb0da30eafa0157b15919d0e8db71839
+  md5: 2ea71bbbaccde19b509a60f6543a846c
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-ignition-math6-vendor
+  - ros-humble-image-transport
+  - ros-humble-interactive-markers
+  - ros-humble-laser-geometry
+  - ros-humble-map-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 2264456
+  timestamp: 1753315075550
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311h0de9e34_13.conda
+  sha256: d18cabb92f780b91e13d5a4abe8a63a001dcd1fe68f46fdf5a728b2507ac031e
+  md5: 084fb7fc5fa70628fba4fda1b58af4bd
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - freeimage >=3.18.0,<3.19.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - pugixml >=1.15,<1.16.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libglu >=9.0.3,<9.1.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 5420331
+  timestamp: 1753309107123
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-ogre-vendor-11.2.18-np126py311ha9b9805_13.conda
+  sha256: deebdd720d24d2e6328092ad09147274e9c9c359ef3d225054c4560dcdd02b88
+  md5: 330861fb57c8d0b5c517d5cff76012a2
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - pugixml >=1.15,<1.16.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - freeimage >=3.18.0,<3.19.0a0
+  - libglu >=9.0.3,<9.1.0a0
+  license: BSD-3-Clause
+  size: 5297221
+  timestamp: 1753309093026
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz-rendering-11.2.18-np126py311hbc2a38a_13.conda
+  sha256: 0169c842ba6aadb23f13c47d3b7de7edf9cdcf201e8120cea9a35c09b336ad66
+  md5: 08f7d032fc46b5a7444220851d0e1fe7
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-assimp-vendor
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 899566
+  timestamp: 1753309946425
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz-rendering-11.2.18-np126py311hbdd918e_13.conda
+  sha256: d4c7915fc0f9fe2f6efe85faf25bdd7cb159c75a5e2d9bc07eb370813acc8c42
+  md5: fd6342cb75e9b3cdb87d20b667bb5521
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-assimp-vendor
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 890716
+  timestamp: 1753309732832
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-rviz2-11.2.18-np126py311hbc2a38a_13.conda
+  sha256: 9dcf98b1b9dc1dbbcafb90318118241ab59633527b95c6ca212e4977126a8940
+  md5: 4c126328aa8d7fe1202648e8dca9bd63
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 61825
+  timestamp: 1753315820870
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-rviz2-11.2.18-np126py311hbdd918e_13.conda
+  sha256: a1c3c538aeda8e47e56c283820af132421b62afc586d7dc8fee8f3478f31ebf8
+  md5: 9d1c52aac186053fa3c222b5ba93f0ed
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.7.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: BSD-3-Clause
+  size: 62930
+  timestamp: 1753315600675
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-sensor-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: d09931cc0cdaaf016b706d5545174fce4e677f9bc05d1308ce5330cb3cb84f3c
   md5: 4795c3510ef11156a36a5b6bcea5c847
@@ -22601,6 +27990,41 @@ packages:
   license: BSD-3-Clause
   size: 451376
   timestamp: 1753312655453
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-sensor-msgs-py-4.9.0-np126py311hbc2a38a_13.conda
+  sha256: f673c00a47cca02bdc9264897895e2593fddb1d582fcbee0d340173c29f5f2e4
+  md5: 62830a314cd50dbd017d6ebd1638ca22
+  depends:
+  - numpy
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 30447
+  timestamp: 1753312423962
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-py-4.9.0-np126py311hbdd918e_13.conda
+  sha256: 76199c803d51c89e7255e26c5a30fefeaac93bce19ad8764b35efbb14d1f1d07
+  md5: 5f713261bd3c9c6b62d77fd6db9c1726
+  depends:
+  - numpy
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 30288
+  timestamp: 1753312814058
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-shape-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: 5566eb46ba47bdea256d0cf2b5167b49889494e628537a9d1da02978355208b2
   md5: 03d5ada9dea91fb87c3e78419f06d626
@@ -22857,6 +28281,71 @@ packages:
   license: BSD-3-Clause
   size: 109136
   timestamp: 1753312321430
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-steering-controllers-library-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 6bd4481237c63bc7ba9d3d1cd12290417e38696980a0b832107bbbf497d579f9
+  md5: 78377f9327b947e57459425ffab2fd4b
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 287608
+  timestamp: 1753314660005
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-steering-controllers-library-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 78f27da59cce5834cbb8eccc78806c70999163b23c55a24d73bbe63eef33c116
+  md5: 89b14253253450a82c5a79120c0792ba
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-generate-parameter-library
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 277573
+  timestamp: 1753314691217
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-stereo-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: 2cd72c49117f216d26a42054d1e552ff1563bb108afb997fad1ce9bec80103c2
   md5: 197edd14144c44d5f91d1831c63da28e
@@ -22895,6 +28384,426 @@ packages:
   license: BSD-3-Clause
   size: 79887
   timestamp: 1753312805430
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tcb-span-1.0.2-np126py311hbc2a38a_13.conda
+  sha256: 45a71166d283da11817a15c8379c2adac9766ecb6f8b77d49b067cb0da24e502
+  md5: b1ad585e0e9ce350207b9b5ad81188ef
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27469
+  timestamp: 1753308410892
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tcb-span-1.0.2-np126py311hbdd918e_13.conda
+  sha256: 9182401229df01529326486a6e80d77df32f95e140972dae1857eb89090e4194
+  md5: 135c518fae1b4b0b788a2a4dc80f8915
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27337
+  timestamp: 1753308531492
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: 20074fb310cced124e01a92567b9b2097c66a9807c4bf6de0b4889e3e20cfaab
+  md5: b9b653f18a3046a382aa434b2730e911
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-console-bridge-vendor
+  - ros-humble-geometry-msgs
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 131232
+  timestamp: 1753312285376
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-0.25.14-np126py311hbdd918e_13.conda
+  sha256: 56616c25a4c55e5d69bd358a2d55b2e9e52d59c0981427616f5046d882077b44
+  md5: de5ebd5b9a722639f54fbcff8eddd9c0
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-console-bridge-vendor
+  - ros-humble-geometry-msgs
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 126529
+  timestamp: 1753312694805
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-eigen-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: c555ecec413506c6b53f91afbfaa1e2657d6f65c001bd537187ad909dda62502
+  md5: cb79194a2c419ac4734c56f3d7781d54
+  depends:
+  - eigen
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 42888
+  timestamp: 1753314111418
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-0.25.14-np126py311hbdd918e_13.conda
+  sha256: ec8e7dcfe4eaa44680190234398055a45ae18086ece275b7aac4d606b33ff59c
+  md5: be69c84bb8f010836bcc0798e1e8fa7e
+  depends:
+  - eigen
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 42726
+  timestamp: 1753314209479
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: 295dc6a7b18e693f4184caaa8c2ca400253c3d5c0473643e1ed8235783608f16
+  md5: 6edb42eb8871d465f7b3252aa6cdd66c
+  depends:
+  - numpy
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 56102
+  timestamp: 1753314104169
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-geometry-msgs-0.25.14-np126py311hbdd918e_13.conda
+  sha256: f48eb91988ab7b769eceb138eff0409022f9fc63ba7547d989458ffc204dd8d3
+  md5: f6d9df0b37a4cedd8e709f650e971c07
+  depends:
+  - numpy
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 55939
+  timestamp: 1753314202230
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-kdl-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: a6b327b09c2f16a4a01cccc7c85593c28b38f2115257ba6013b401e6f07304ef
+  md5: 078bd777f1f577d8259e226cd01ccc44
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-python-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 42340
+  timestamp: 1753314094365
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-kdl-0.25.14-np126py311hbdd918e_13.conda
+  sha256: 30732fa6921a2102644efa020bf3f2502bdf905662fae5a0f0c623ddb35edca9
+  md5: abb17544632339fb375074ac1adb8830
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-python-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 42149
+  timestamp: 1753314193442
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-msgs-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: 24d65455d31effcb963347a1f7b278cb4613e136b746cf95e7f673a993855856
+  md5: 5da6a174f12405a44f84f4d5adf9e409
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 170525
+  timestamp: 1753312188939
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-msgs-0.25.14-np126py311hbdd918e_13.conda
+  sha256: ad697e53e68c9deff85d76057d69fcba25843da249c57a77f0fadb1584537670
+  md5: b6b8e63dd5dabc1a3efeda831f2bfb5f
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 174257
+  timestamp: 1753312614608
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-py-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: ca162128f43c9540ac6a5f92400a0f1720423240019dfcf305ceff1b64a01dc0
+  md5: 6ec160638206734caa1b853a60cc81f2
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rpyutils
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 55858
+  timestamp: 1753313131962
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-py-0.25.14-np126py311hbdd918e_13.conda
+  sha256: 9641ee88f4d5674d6a0016ece88bab124e6b9cdd5491199e890f4b81cad33637
+  md5: 2de0b90a6fa6b6a0fc1483d5bace6aa9
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rpyutils
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 54089
+  timestamp: 1753313362834
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-ros-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: 626283458e370de1412a3d79071b4af0c6a59d0b66117582e5dacd3173602997
+  md5: b18122c6356bea1251d8d8441db588c0
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 449759
+  timestamp: 1753313870085
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-ros-0.25.14-np126py311hbdd918e_13.conda
+  sha256: 72c3663286c9bb103dc33b4f2b70f2a10232eb2088cd0ad5b4b9fbfc9237ba7b
+  md5: 84a25377d9f37787bd2bb1e51a0893c4
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 451913
+  timestamp: 1753313978533
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tf2-ros-py-0.25.14-np126py311hbc2a38a_13.conda
+  sha256: c32d00748d90ebeab97ec13df6be290acaf670ad7470f9330439167a458401b6
+  md5: 21a0efcb62a128cf0d13ee1f066100ad
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45070
+  timestamp: 1753313502785
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tf2-ros-py-0.25.14-np126py311hbdd918e_13.conda
+  sha256: 45bf92e21b560be95aeca43da67ddc7c19974b1a79381793b19bdd2e40927ddb
+  md5: 998f1a30f85c1462c7255bb545a0767f
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 44826
+  timestamp: 1753313662116
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tinyxml-vendor-0.8.3-np126py311hbc2a38a_13.conda
+  sha256: 5a27846578d5c9139931a2f5afb34b4a25a8f84478b05b0c5c64dfef17ef531a
+  md5: bc37e340a36e7ead6f4df9586c652cb5
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - tinyxml
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - tinyxml
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 23608
+  timestamp: 1753308431112
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tinyxml-vendor-0.8.3-np126py311hbdd918e_13.conda
+  sha256: 1dd2bfcef76bc4820c84152ea4070128bfce2fc18d29a7314482c9da850159c3
+  md5: 14d62c47717a01b2bfd0712ab942a33b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - tinyxml
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - tinyxml
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 23440
+  timestamp: 1753308548715
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311hbc2a38a_14.conda
   sha256: d806603bd80250d30cb69158dca4d273920ee172f3bf3d5119728889e9697789
   md5: 9ef35ad9a922d89a4de91ee02d56afc2
@@ -22932,6 +28841,38 @@ packages:
   license: BSD-3-Clause
   size: 24229
   timestamp: 1757431788630
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tl-expected-1.0.2-np126py311hbc2a38a_13.conda
+  sha256: 6125b1ab7d343fb2a3ea4dbb213eca4f5555154ee0a4b316d809feb83aa0478c
+  md5: 70db5fac7a0aa5304196d5947b1a57d9
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 33065
+  timestamp: 1753308441031
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tl-expected-1.0.2-np126py311hbdd918e_13.conda
+  sha256: 21314b7ad339548520e46690a6ff5f117946245470179fe171dbd4f6ab568af4
+  md5: 006e26b0f577c4ad603057138fb6f998
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 32904
+  timestamp: 1753308565269
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tracetools-4.1.1-np126py311hbc2a38a_13.conda
   sha256: 93982131be249a36fddde88395345ccdc6d3aed356e13ffcb1a54bb43c1b8b4c
   md5: de14d6283f08354ac73d99104822d0c3
@@ -23006,6 +28947,119 @@ packages:
   license: BSD-3-Clause
   size: 137969
   timestamp: 1753312649758
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tricycle-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 3b11449b248bd26919ba894a8c10f923c9d9b803d3d920aa57636ea86104385e
+  md5: 082f0da758c93bd4a025dc8f2d8d6ed8
+  depends:
+  - python
+  - ros-humble-ackermann-msgs
+  - ros-humble-backward-ros
+  - ros-humble-builtin-interfaces
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 271509
+  timestamp: 1753314609989
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tricycle-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: c5dd85f213af3beeedbd64e0801d41ca63bcdcd762e932208fc82feceeb47ce1
+  md5: 5c8a80ea8f03088069b1993b0c11cc28
+  depends:
+  - python
+  - ros-humble-ackermann-msgs
+  - ros-humble-backward-ros
+  - ros-humble-builtin-interfaces
+  - ros-humble-controller-interface
+  - ros-humble-geometry-msgs
+  - ros-humble-hardware-interface
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rcpputils
+  - ros-humble-realtime-tools
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 263020
+  timestamp: 1753314625003
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-tricycle-steering-controller-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: ae1d5d967af1effe8f13cee2744883d80b3f1c6452ada2a5f69f1996bc475eef
+  md5: e6ba17525853612e56f4e12c93226ad3
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 89366
+  timestamp: 1753314924677
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-tricycle-steering-controller-2.48.0-np126py311hbdd918e_13.conda
+  sha256: cb879f7241b35db65d7d82ae79d14730dfb00debf066574065c5044ac5ec104d
+  md5: b43c91dc260fccf3ee44344d052701ca
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-control-msgs
+  - ros-humble-controller-interface
+  - ros-humble-hardware-interface
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-srvs
+  - ros-humble-steering-controllers-library
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 92312
+  timestamp: 1753314914743
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-uncrustify-vendor-2.0.2-np126py311hbc2a38a_13.conda
   sha256: dc2f0bdc5febb036bf4398cbf94b16b865539a71fcb95579d6c19ce672855a7c
   md5: d774a323a1fcdfa8bc0186754f044549
@@ -23075,6 +29129,187 @@ packages:
   license: BSD-3-Clause
   size: 73096
   timestamp: 1753312264532
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdf-2.6.1-np126py311hbc2a38a_13.conda
+  sha256: 843d3686f323377ab6a99efe42358e77b6baff053961b6d0c4807cf67e91348d
+  md5: aae8a8a9edca5824b06341ae6736fb8c
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf-parser-plugin
+  - ros-humble-urdfdom
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 149991
+  timestamp: 1753310221994
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdf-2.6.1-np126py311hbdd918e_13.conda
+  sha256: 22e725adbe9b9c6bcd747a6b7f22ae23199aef7714c01022327b3217ff0dd2af
+  md5: c08b9bdb81f328765614b5eb93237133
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf-parser-plugin
+  - ros-humble-urdfdom
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 151762
+  timestamp: 1753311929386
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hbc2a38a_13.conda
+  sha256: 48453a2f3c81ae8bd4c881081f4de316e87392261e3107e3edf15bc79dd16369
+  md5: 2a0d225ca1a590669972f4cbf60da698
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 31353
+  timestamp: 1753309867407
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdf-parser-plugin-2.6.1-np126py311hbdd918e_13.conda
+  sha256: abf570a472d60864612e1469e20335c52ccf5deb9cff3869893008e9aa3f8545
+  md5: 7b2fe6a6776e67ecf371efa059bd0e3c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 31206
+  timestamp: 1753309641303
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdfdom-4.0.1-py311h82375c7_13.conda
+  sha256: 5695170cbc1e70227b7d36a59896bc00f9f9979752773d5925bfbc44cf0d2bb2
+  md5: b96b7e6f93c49e51409c3de0c7f6985e
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml-vendor
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - tinyxml
+  - urdfdom >=4.0.1,<4.1.0a0
+  - tinyxml
+  - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 8146
+  timestamp: 1753309944502
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdfdom-4.0.1-py311h7a77afc_13.conda
+  sha256: 89925ec1874a0b3a1cdcf1532d56633250ac24a619746426f42dfeaab3862d2c
+  md5: 0c4306262876e7a2f4df88b8c7bf18b9
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml-vendor
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.7.* humble_*
+  - tinyxml
+  - urdfdom >=4.0.1,<4.1.0a0
+  - tinyxml
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 7876
+  timestamp: 1753309730734
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-urdfdom-headers-1.0.6-py311h82375c7_13.conda
+  sha256: 94e92717f27b9e3a98daf87d9f327b3b751a6773bfadf73a638798912c7aec6f
+  md5: e7323a7daee75ed5a03a1de849b48434
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - urdfdom_headers >=1.0.6,<1.1.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 7423
+  timestamp: 1753307891723
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-urdfdom-headers-1.0.6-py311h7a77afc_13.conda
+  sha256: e2471a14e211e51e2333dfa7e2725a792f701a47fe83ec50a0083acb68492909
+  md5: 391c102cbd76a8d8911e2a9a19cef69d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - urdfdom_headers >=1.0.6,<1.1.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 7127
+  timestamp: 1753308069242
+- conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-velocity-controllers-2.48.0-np126py311hbc2a38a_13.conda
+  sha256: 2a7369a14833bef15df1f67b0aecc951dd15b62b32c181c92d65afc709bcf9c2
+  md5: 92ece79d4584ed756c8af9288ed1ec30
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  license: BSD-3-Clause
+  size: 64667
+  timestamp: 1753315724783
+- conda: https://prefix.dev/robostack-humble/linux-aarch64/ros-humble-velocity-controllers-2.48.0-np126py311hbdd918e_13.conda
+  sha256: 827c4b631d1057714e797939719b113e45e41a79fc73891dac25967cad4d882f
+  md5: 96fb7edc7b991b347b936d5afec68067
+  depends:
+  - python
+  - ros-humble-backward-ros
+  - ros-humble-forward-command-controller
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.7.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.7.0,<0.8.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 65772
+  timestamp: 1753315486860
 - conda: https://prefix.dev/robostack-humble/linux-64/ros-humble-visualization-msgs-4.9.0-np126py311hbc2a38a_13.conda
   sha256: 73d6a82969fb72ce10f3e31d3c2213f34e4732b79598bd9c6f852530b9ed902c
   md5: 5030da524b6907e925c0a085109786f6
@@ -23155,6 +29390,93 @@ packages:
   license: BSD-3-Clause
   size: 22778
   timestamp: 1753308529103
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np126py312h3bd2861_10.conda
+  sha256: a6e4d021829ea5d6f78acd35eb7c17fed26e82a5a1fd550aec82cd33df01feb2
+  md5: 44309499f7ae548e57ddb252aeb1acaa
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 89563
+  timestamp: 1759136811377
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-msgs-2.0.2-np126py312h01c0cb9_10.conda
+  sha256: 185b111436a72936ceef00bc4c036c254d61b9a23d1689d3bed6fb31d842a22c
+  md5: ef490f4438fc9fd8fd4c90db163e81af
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 93746
+  timestamp: 1759136958439
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 75520faf0e0777c01447254b2bdf889bc0a7f5d7d671ef123c04ceb287b802de
+  md5: 2c2af27302a68c06549ce2ed32785df9
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 104533
+  timestamp: 1759141599261
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 374b31eed27388bb36b8f42e052563e553943c3b4fa518c015702c6ccab587c5
+  md5: 8f804f8e40b773256ffc2f8645775cb1
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 101493
+  timestamp: 1759140858695
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np126py312h3bd2861_10.conda
   sha256: 1b8a875e47775e899830d48cfccb1d258d3bfd702f69914ccc49567fc467e8b5
   md5: ff46c9e8166e2255a2c9830e9bc6c4a7
@@ -23232,6 +29554,76 @@ packages:
   license: BSD-3-Clause
   size: 114671
   timestamp: 1759137022299
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 82bbcd87135f25569195cef72774b351c6552c305fdf8ab6bfd2abbd05bf806f
+  md5: b1ed16618352d87f5cef99222aab797a
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-kinematics-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-eigen
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-kdl
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-trajectory-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 416137
+  timestamp: 1759141158493
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-admittance-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: cfa366bf917241ea93113ac805977db208de15bcf1f667f2482a1bb7867962e6
+  md5: 36260dba3e181ff47c0bdb18b27e1293
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-kinematics-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-eigen
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-kdl
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-trajectory-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 403060
+  timestamp: 1759140412859
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np126py312h3bd2861_10.conda
   sha256: da8dd702f6b270346c303f855cbcddc73e3cb2cc2a5e0b3d7c1dc22dce44702a
   md5: d515c31f480d0de07aa5d21786600ac6
@@ -24814,6 +31206,127 @@ packages:
   license: BSD-3-Clause
   size: 27919
   timestamp: 1759134607102
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np126py312h3bd2861_10.conda
+  sha256: 9cdb0608062c540952abd7e2fcdca543a9d11436d72351bdabdaaa1da9f0c5df
+  md5: 2160deca977b5174682ef4c0557ceb96
+  depends:
+  - python
+  - ros-jazzy-ament-cmake
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 33829
+  timestamp: 1759134515576
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-angles-1.16.1-np126py312h01c0cb9_10.conda
+  sha256: 2c4538f7aedea9889c5b86ad1f35f3a51cc547a422f7a5928d0622456fe73955
+  md5: 5293ff7e905f6fbff2d89a40acfa94ff
+  depends:
+  - python
+  - ros-jazzy-ament-cmake
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 33821
+  timestamp: 1759134703067
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np126py312h3bd2861_10.conda
+  sha256: bf79b923d75cbe2e33bdc728592d23323a5d8f959b374e0f3c1a278f346d134e
+  md5: 8a6ae578f17e75968ab410b0407dffd0
+  depends:
+  - elfutils
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - elfutils >=0.193,<0.194.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 333536
+  timestamp: 1759134113567
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-backward-ros-1.0.8-np126py312h01c0cb9_10.conda
+  sha256: ff0beacf5d813e137f21fa3c8f24c190cf667bec20bf14a142e9c87d9847db36
+  md5: a2bf4006a44ee790316853a036530a76
+  depends:
+  - elfutils
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - elfutils >=0.193,<0.194.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 323326
+  timestamp: 1759134314945
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: a38c492295bb4f12b9d6f39d516b2eaac51a3f6e8f4779b29419f383780081b6
+  md5: 36cdbaca2502f1804e0b7160e2d540c1
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 102376
+  timestamp: 1759141582818
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-bicycle-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 04f5a0646e6c1d452d4f5ef9e72e0503c53e0713662f675667c29de19602012b
+  md5: 3b55a26320dfc0b491b08bf99f1bee58
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 100436
+  timestamp: 1759140825073
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np126py312h3bd2861_10.conda
   sha256: 61591684d33300b93566ad1cca53a3650ec16733ae4a68cd032e4f20812d03ce
   md5: 01a602042c395cf018dabdadd12482ac
@@ -24849,6 +31362,51 @@ packages:
   license: BSD-3-Clause
   size: 84159
   timestamp: 1759136455628
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 1dded0fcdaa8b4faeda598692fee7b550ca7d3203770519886da4bf4e62a4819
+  md5: c861c179113d5e56aca9bfb0f71596ef
+  depends:
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-filters
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 212428
+  timestamp: 1759141120286
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-chained-filter-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 6f21c974c7b7ba10f1f95b590dc3751884d4092ba6dfd7ac98040f07dc80e6be
+  md5: 992b193f231c7791e5f11f3c265db386
+  depends:
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-filters
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 209508
+  timestamp: 1759140364553
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np126py312h3bd2861_10.conda
   sha256: be0277d168c4d3b5496569c5efdc5b79caafad2ce5997e57f1b033f7ec413257
   md5: e3c6ff36d580c6426ebc93f10e76493e
@@ -25017,6 +31575,266 @@ packages:
   license: BSD-3-Clause
   size: 27490
   timestamp: 1759135505352
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.5.0-np126py312h3bd2861_10.conda
+  sha256: 3f6932e0f58a612b03e61a437d1e50a8eadc72753b27f5437aee4313cdbbcd32
+  md5: c786738c314ce9ef53263b641d482691
+  depends:
+  - python
+  - ros-jazzy-action-msgs
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-trajectory-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 1192027
+  timestamp: 1759137246598
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-msgs-5.5.0-np126py312h01c0cb9_10.conda
+  sha256: 5393d8e5ec718366997b8fced31f021a4ff11b0e910df526cfa146f3d359701e
+  md5: 4f00186a960917fe24a7ddd6a4187946
+  depends:
+  - python
+  - ros-jazzy-action-msgs
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-trajectory-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 1201269
+  timestamp: 1759137313765
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.7.1-np126py312h3bd2861_10.conda
+  sha256: 533c8a228b7436c824f680521c8e86a04a88f9a8b6784ec1fa47b5f8a4a3a7e5
+  md5: 6e114918ae1a85fcffd029bc20c0a371
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-filters
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rcutils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-ros
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 288568
+  timestamp: 1759139565969
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-toolbox-4.7.1-np126py312h01c0cb9_10.conda
+  sha256: 5ad9ec4707723c9419f76bd3cfcd3c8c9efd225f3b975ad0f2e93a03e292ae84
+  md5: 03c985b5ceb6373146161a264efba9d7
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-filters
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rcutils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-ros
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 284478
+  timestamp: 1759139161165
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.37.0-np126py312h3bd2861_10.conda
+  sha256: 32b9ff9dd38924e987f1ec34ec35b512f954d26baaa3547d96a9a37a1a9cdbe4
+  md5: 42c981b5aaac40f1d73ddac5a1d9becf
+  depends:
+  - python
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 120122
+  timestamp: 1759139823518
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-interface-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: 81211460366838d7e8195aa627fe6288e09aa4cd2127d0d9d926844c955d4e94
+  md5: 3e0e46450783e72926353297895ec236
+  depends:
+  - python
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 119202
+  timestamp: 1759139396818
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.37.0-np126py312h3bd2861_10.conda
+  sha256: b3594c1acabf24b13135faaed07df31baad29846c0c88cbd72d5cf23bce0ed08
+  md5: 5fb4a8f47e9fa21104d3c7b71773c899
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-controller-manager-msgs
+  - ros-jazzy-diagnostic-updater
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-launch
+  - ros-jazzy-launch-ros
+  - ros-jazzy-libstatistics-collector
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-ros2-control-test-assets
+  - ros-jazzy-ros2param
+  - ros-jazzy-ros2run
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 658896
+  timestamp: 1759140634338
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: 0702ecddfd13412f6ff5377cd5f9904a6e97ae9484421fa404c49cebcbcab6d4
+  md5: 62afc8f8108a90eb029bb98877a720b4
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-controller-manager-msgs
+  - ros-jazzy-diagnostic-updater
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-launch
+  - ros-jazzy-launch-ros
+  - ros-jazzy-libstatistics-collector
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-ros2-control-test-assets
+  - ros-jazzy-ros2param
+  - ros-jazzy-ros2run
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 622594
+  timestamp: 1759139958262
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.37.0-np126py312h3bd2861_10.conda
+  sha256: c655fbeb89dc2719c085eeb3353c627b06742a6e665c7fc296dc56c61a169fa1
+  md5: f701cb9f20cfffef750a57ac3b248ec9
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-lifecycle-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 546357
+  timestamp: 1759136842329
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-msgs-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: f7aab0bdb4fdd820305d43f793982a5b2b54d75528cb9551297f406c62322d78
+  md5: 356675520b59f64beb86a21d6423d546
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-lifecycle-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 554015
+  timestamp: 1759136990894
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np126py312h3bd2861_10.conda
   sha256: 215189a1a3943b68bffe815fbd28c871f578c40015df68f70bb59fc3d6ee38ea
   md5: dd85d860da3116391d794ece4dc97c79
@@ -25098,6 +31916,105 @@ packages:
   license: BSD-3-Clause
   size: 213093
   timestamp: 1759137167286
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np126py312h3bd2861_10.conda
+  sha256: a46565349f85a1a09385044613311b91606358dc47cd48ce3e1083a32be5fefe
+  md5: 9a89432fccbde73faaccc913c5defe77
+  depends:
+  - python
+  - ros-jazzy-diagnostic-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 187693
+  timestamp: 1759138952647
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diagnostic-updater-4.2.6-np126py312h01c0cb9_10.conda
+  sha256: 67907bf484033b9a2acfa61867e8c962b155a3a7098e4bcfc3b8ffb50adc8bda
+  md5: 344bf4d2f0014fb66627799cdd524a3b
+  depends:
+  - python
+  - ros-jazzy-diagnostic-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 190047
+  timestamp: 1759138630136
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 27d48c14e6c24b460cf5dbdb0639945b8d386f2f34d50bad83e9187cf5b41120
+  md5: 3f92b8ff3db101db3aba370baa97cabe
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 324327
+  timestamp: 1759141218740
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diff-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: ac29f05f3072e4af903fe3e272662fbcdf67d43a2fd19603ce51f0c74584ea76
+  md5: fbae102a34781a00e5e8ba7a78ca2e21
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 308506
+  timestamp: 1759140472302
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np126py312h3bd2861_10.conda
   sha256: a5ff0e936b903f3e86fb2524c6a7f594ab24dac3fad910a53e97b36ae5413637
   md5: 7c0173e23b895b5be8e3fd15a4a77f59
@@ -25129,6 +32046,79 @@ packages:
   license: BSD-3-Clause
   size: 20946
   timestamp: 1759134594842
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: e2579204b611aaa30cead7622876606ea07ec46f903e06bb08bafd329f44b294
+  md5: ca2bd96e454a07340470a2b8ac48c47d
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 76392
+  timestamp: 1759141552920
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-effort-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 61cf30f2d0ce69575861053ca98137f7411b043af96f55e5ea8c0cf8c793887b
+  md5: a337b7bda7fbec222c07582075dc80b7
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 77418
+  timestamp: 1759140743202
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h3bd2861_10.conda
+  sha256: a738c67eb7b3af2dba229eaa0c38198617f1236387b347d3cc5027c65afaca79
+  md5: 4400d09ab5f92b6e3ca1332931bf9399
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23328
+  timestamp: 1759134760262
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-eigen3-cmake-module-0.3.0-np126py312h01c0cb9_10.conda
+  sha256: f509ce64ad2678fc837979a637bd5738e4bc95cb1be7e0ea8b68a1f7d7c79b19
+  md5: 413a27ce2cc89edb47bcba1268929da8
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23397
+  timestamp: 1759134931486
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np126py312h3bd2861_10.conda
   sha256: 7b4737c7fe822a8449685ba5f57edf6adf9d32e611c8cb4ed0242db0578c6627
   md5: 658d8fd55a9fdcb15ff5e57708aa0874
@@ -25236,6 +32226,47 @@ packages:
   license: BSD-3-Clause
   size: 27287
   timestamp: 1759135204807
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np126py312h3bd2861_10.conda
+  sha256: 9fe35f2a0d09a89a6373b458d44cb3a271a87934385e3275e91a1671a498e917
+  md5: 93f9007b09d434043b7319e5facf5a9d
+  depends:
+  - libboost-devel
+  - python
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 132298
+  timestamp: 1759138291621
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-filters-2.2.2-np126py312h01c0cb9_10.conda
+  sha256: 87eff9cbc3f9334f092f4198d684102c0bfb730ef6db57cf2e39e0a330639d9c
+  md5: 4c625cf979eed6eee2788de8f0d30460
+  depends:
+  - libboost-devel
+  - python
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 132920
+  timestamp: 1759138096264
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np126py312h3bd2861_10.conda
   sha256: cb8c94ec85adb43f1ad85fabff560bb4d08b41634eaee6f6f5144ed548e1f482
   md5: cef3439419d6b3f1224b340baf4ddc75
@@ -25275,6 +32306,198 @@ packages:
   license: BSD-3-Clause
   size: 19447
   timestamp: 1759134993926
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 5a032f5465ff8e4b35e850e2ec76810ef2053fdabc775e431d286fc307fcc766
+  md5: 24016b199e98eea4b11baa05e2383fbc
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 168716
+  timestamp: 1759141199918
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-force-torque-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: b0fd1c6ee00f2df3b25107c24b52e63beadcf0ef828c665e5f95a35dd98d0e31
+  md5: 682c2593e31f1aead23903a4f5235316
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 165863
+  timestamp: 1759140451186
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: f6110e20b9ab08b6617514df076069f00aa31590403cb6f0cc1f0f585a0a02ec
+  md5: df8df511de5e9c1e0fd47b1722c21829
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 223918
+  timestamp: 1759141120912
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-forward-command-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 5495629487a37f327dee17e9fc3adc49f002733a9da46d9af30c9eb13678c3c0
+  md5: be94839bfe74d6a1d7b085cb87367f1f
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 220008
+  timestamp: 1759140355200
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.5.0-np126py312h3bd2861_10.conda
+  sha256: ae92f844e3f4421ecc5f32068f1005f887839acd4c36244536a5637d8a14f082
+  md5: 8c1572b8c9c4cce9bb85f635364ec287
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-generate-parameter-library-py
+  - ros-jazzy-parameter-traits
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 50391
+  timestamp: 1759138934072
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-0.5.0-np126py312h01c0cb9_10.conda
+  sha256: 5080315f116b3c4cffc04fe9f61402b3d3a98c0ac5d3142064a1284fe643bfa7
+  md5: 1021481bc81bcb8853017c91aa6fb87c
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-generate-parameter-library-py
+  - ros-jazzy-parameter-traits
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 50233
+  timestamp: 1759138611338
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.5.0-np126py312h3bd2861_10.conda
+  sha256: 9ea879c21e545528934f78209bb4a0014b5d01a57ad4f6fcad77d6062aa63dad
+  md5: 6c819af33399ca4a0fc953b309e358ca
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - typeguard
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 70849
+  timestamp: 1759134419555
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-py-0.5.0-np126py312h01c0cb9_10.conda
+  sha256: 541a78622ece4ce60394c39ba5e7a38369ee8b705c9da971a6ba6ad81b5a12b2
+  md5: e935a120eaae36aec61b9a25ba515ecb
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - typeguard
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 70881
+  timestamp: 1759134603441
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np126py312h3bd2861_10.conda
   sha256: 98f6fdd49e83b3c82f8a5e4a8ece736d89a4e79e0859bc0a4d5c0932f1ebc8cc
   md5: b44c3ce4a96fa7db5eea3e27ded3e72b
@@ -25346,6 +32569,154 @@ packages:
   license: BSD-3-Clause
   size: 122347
   timestamp: 1759134278870
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 81eb994fd1f746c5d976ba68347f04225df9d3e2842ed22fc4873926bad594a2
+  md5: 4206176fee26ed26ad49d32430b809ae
+  depends:
+  - python
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 244019
+  timestamp: 1759141176411
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gpio-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: de980a41b359bd2877deabecaade4e9a0c12def802ac6ba9d146c1d630232f30
+  md5: 49f09b59c586943a107d469711d6f13e
+  depends:
+  - python
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 240078
+  timestamp: 1759140422629
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 7952bbdf3383f1ffda0001014925df931f4eb1f4b33920fa0b9329511f1ade09
+  md5: ad08fcf4f9cbf470d789b9ac93d0a0a4
+  depends:
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 152266
+  timestamp: 1759141158915
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gps-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 6f00dd8ab99c4e643e2e842781d830c567f3039048211c5a8a55b7feb731b34d
+  md5: 9c4e37d8a68ee2d659acedc69e96241a
+  depends:
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 152193
+  timestamp: 1759140401894
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 3cb53bc240875cc97e12d297736244890c435acf8e2b33d67008eaf345e3b30f
+  md5: 0eb4051e9c6079f11404134e528489af
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 155756
+  timestamp: 1759141161043
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gripper-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: ab3ae8c2841a8596d28fa388edaecfe914e32413fa37e44b20dfc13975755f6d
+  md5: 71d15af5d2cd0627a1b3bc557433ff4b
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 152037
+  timestamp: 1759140411562
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np126py312h3bd2861_10.conda
   sha256: 25a1b01f399bcbafb4412ab0b5efe4b90a6b49ea3a637e862cfe0249a4f5c1e3
   md5: d70d6583728901de9696557fca2f30e5
@@ -25378,6 +32749,224 @@ packages:
   license: BSD-3-Clause
   size: 208718
   timestamp: 1759134194096
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h3bd2861_10.conda
+  sha256: a2c28acbd2e65eb9b650b12a05fbc9716f5f9d41fb0f3adb40d26a5aca94d8cc
+  md5: 320feb88e07dd3b22e7dd0c1a506ccd5
+  depends:
+  - gz-cmake3
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 24435
+  timestamp: 1759134843754
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-cmake-vendor-0.0.10-np126py312h01c0cb9_10.conda
+  sha256: 031914cf815f6407086008e65482288a222f53b15502f3214b85bc52d8a382ad
+  md5: c67f3d69989750fe9d34972facf53978
+  depends:
+  - gz-cmake3
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgz-cmake3 >=3.5.3,<4.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 24501
+  timestamp: 1759135000814
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h3bd2861_10.conda
+  sha256: d69388d02ba36ee0ffa4d898aea8ca1484054df551254eba1f49032e8d40f1df
+  md5: b92b3af57222902f7766a3c8c6f11662
+  depends:
+  - eigen
+  - gz-math7
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-gz-utils-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - libgz-math7 >=7.5.2,<8.0a0
+  license: BSD-3-Clause
+  size: 27847
+  timestamp: 1759135546682
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-math-vendor-0.0.8-np126py312h01c0cb9_10.conda
+  sha256: ed4bf1359189b289b116fc5484e4df5ab00a4a43ffb2a2c4264ad934caad83a6
+  md5: 393545c5277dcb16f886bd2cb7f3e394
+  depends:
+  - eigen
+  - gz-math7
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-gz-utils-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgz-math7 >=7.5.2,<8.0a0
+  license: BSD-3-Clause
+  size: 27978
+  timestamp: 1759135480088
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np126py312h3bd2861_10.conda
+  sha256: a0da61c02791e401dbc3ccc58196bec7229c7b26a5a0965ee76c031e88a9c60c
+  md5: 9e6af6f2e9e8d76288b9291336132332
+  depends:
+  - gz-tools2
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - ruby
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgz-tools2 >=2.0.3,<3.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 27473
+  timestamp: 1759135148848
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-tools-vendor-0.0.7-np126py312h01c0cb9_10.conda
+  sha256: 7529cbaad58dda34937939c5b9e905dbab41e3076dbc8e3b0dba7862ad3aa4d5
+  md5: 3d48e882b47b94b68146c28c4b8ccb7d
+  depends:
+  - gz-tools2
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - ruby
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-tools2 >=2.0.3,<3.0a0
+  license: BSD-3-Clause
+  size: 27449
+  timestamp: 1759135226229
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h3bd2861_10.conda
+  sha256: 7910cc33699aa5cc4de352af5ac8b0eda4c5f8b3ed97c1cb78b31cde4c6018ed
+  md5: 8a9cdcb0d0292a5e963aa48a1b7b83a3
+  depends:
+  - gz-utils2
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-utils2 >=2.2.0,<3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 25766
+  timestamp: 1759135143290
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-utils-vendor-0.0.5-np126py312h01c0cb9_10.conda
+  sha256: 1e6ce471311f02575177937a8883f6b77cf1dc2a91ec29c2bc6cf44755c5edec
+  md5: b005ca8b8ba200fdf2e4b175485b0dc3
+  depends:
+  - gz-utils2
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-utils2 >=2.2.0,<3.0a0
+  license: BSD-3-Clause
+  size: 25904
+  timestamp: 1759135219179
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.37.0-np126py312h3bd2861_10.conda
+  sha256: 7651c4acacb9afb401e05c2d0784244dba9dc907ef289f27c7464b05fb987971
+  md5: 65e905b175dc41d9fe861ff9eaa43db9
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-joint-limits
+  - ros-jazzy-lifecycle-msgs
+  - ros-jazzy-pal-statistics
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-rcutils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sdformat-urdf
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 426204
+  timestamp: 1759139499957
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-hardware-interface-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: 0d42222d6f774d29246e5fc308012b2095a54822c7420afb29d20ee1e48dee14
+  md5: 52bd607bb83f03cc694b758bc748dff8
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-joint-limits
+  - ros-jazzy-lifecycle-msgs
+  - ros-jazzy-pal-statistics
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-rcutils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sdformat-urdf
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 414115
+  timestamp: 1759139086373
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np126py312h3bd2861_10.conda
   sha256: a0f6cb479e432c1e49ab9a5baf837e8c2a40c15999b98c1da6db7c4068da15e9
   md5: c5bd1e766e134b1eba20db9ea3db187b
@@ -25482,6 +33071,444 @@ packages:
   license: BSD-3-Clause
   size: 577051
   timestamp: 1759134283951
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np126py312h3bd2861_10.conda
+  sha256: 6bb95146d40565b21750bcdf01f75122aa41d5470bb875742bae83df159c6927
+  md5: b95fbb1a3ff9e3222c241a5b4a325f6e
+  depends:
+  - python
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 578403
+  timestamp: 1759138982065
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-image-transport-5.1.7-np126py312h01c0cb9_10.conda
+  sha256: b902143522ab24f5b4616ada7217a2ee7698f9dd54f6bfd7260616bd9d35ef8d
+  md5: 544e753a6e73be717f071a70980391ac
+  depends:
+  - python
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 583408
+  timestamp: 1759138654430
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: b9ab2dbc77826847aaf79434855d610998f63e245f638891f9908306f2da42ad
+  md5: 2af5eddfbcde7732d4111c99f61a0669
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 151621
+  timestamp: 1759141124186
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-imu-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 790b6838fb03cc0cd3b9b78d7bf213f7cd281c3adee0badd12f5f30b059cf4a8
+  md5: 863059920fd6748bbfc9e05a79c28223
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 152801
+  timestamp: 1759140354606
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.4-np126py312h3bd2861_10.conda
+  sha256: 1cf16f833d708e09e94988e4f1b014e769675866bd632da68373d45fa43b3411
+  md5: 8506a1d913fef0b77b2b6e7f4f5ff078
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-rcutils
+  - ros-jazzy-rmw
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-visualization-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 306785
+  timestamp: 1759139586281
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-interactive-markers-2.5.4-np126py312h01c0cb9_10.conda
+  sha256: eeee1e71e9ad49fb951f3f39e87443347dd25c68b06962064d216fd77252ef61
+  md5: 8c3b3c23519502b9ae62f12421143724
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-rcutils
+  - ros-jazzy-rmw
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-visualization-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 306047
+  timestamp: 1759139182306
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.37.0-np126py312h3bd2861_10.conda
+  sha256: 09d3fbdffd01ddac96acf840d47d215968b3833e1471966fbc951d157c9088ba
+  md5: ca90b7099920287de0a35ae9767f3949
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-trajectory-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 146582
+  timestamp: 1759139175249
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-limits-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: dd63b015114daa41f1fd0b6d12b0767a539f73abbac46562032d8aa322e5a0e1
+  md5: 884fbba6ce74b67c89f2e521a9440c5e
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-trajectory-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 146237
+  timestamp: 1759138821320
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 10d9490049892ddce09f30e0d32d3f9fa94ef12b24b31637a29d3b72fa17fbdf
+  md5: 8de9de7bdedae9d934e5d9126382c654
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 185999
+  timestamp: 1759141251139
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-state-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: f9130ddc0abb6feca3411071eec29611c0cab1fdfcef897cc941b36d9a405a8c
+  md5: e3fa07fa65142389e4a614102c69961a
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 183839
+  timestamp: 1759140546723
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: c11b3548a46b4fccd28035197fa87b64ea86e19dd4cbead3160dd9963cb6d067
+  md5: 94dc9fe9338411311ddfd1bb816bed55
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tl-expected
+  - ros-jazzy-trajectory-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 394031
+  timestamp: 1759141216730
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-trajectory-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 9f74179b48ead34a7b69ecf432e8752448629043bf564de4511895d70667e7d8
+  md5: fbd81ba9e139cec65a00f41b6cf6c0ef
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tl-expected
+  - ros-jazzy-trajectory-msgs
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 379807
+  timestamp: 1759140506772
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np126py312h3bd2861_10.conda
+  sha256: b0582c3dd1b398a7a29069dc7ecd1aad2d3deec0efba74e9b23fb70aac85d08d
+  md5: 27c591ed624b3f3dadab12f1d064c743
+  depends:
+  - python
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdf
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 46827
+  timestamp: 1759136183528
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kdl-parser-2.11.0-np126py312h01c0cb9_10.conda
+  sha256: 7e10c409aafdb0996fad266f00bbcf2619228871be97f6bb8ca464f5ec3f9f49
+  md5: a5d59430e57a2f71e952d7ee9555a356
+  depends:
+  - python
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdf
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 48092
+  timestamp: 1759136304921
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.5.0-np126py312h3bd2861_10.conda
+  sha256: aabe6139381cdf017335bffa3d8bde206c044b86be039ec1300c0b6fdf147d30
+  md5: f0e50d31107cf8d128dc01425219d5f6
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 46086
+  timestamp: 1759138546429
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kinematics-interface-1.5.0-np126py312h01c0cb9_10.conda
+  sha256: 1eaca064b9f67d3b4ef7865ad64df6f9ef1212ad3c3cf167666bd2b4e87b5307
+  md5: 7639db65b155c5c2d91bc25cb4980776
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 47063
+  timestamp: 1759138313978
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.1-np126py312h3bd2861_10.conda
+  sha256: 46114ae39a02998fe3384f29f78edc768a1267ac325c489af8fcdc4677a96efc
+  md5: 6e939d0fca0dc1de5383a83e86847fe2
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-sensor-msgs-py
+  - ros-jazzy-tf2
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 61104
+  timestamp: 1759138292165
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-laser-geometry-2.7.1-np126py312h01c0cb9_10.conda
+  sha256: e08c5401fc33976a706c7a223f90b613eee4debe5c01de13801d1a4d39240a9d
+  md5: 4b52d5aee79855a57cb1316a96ad2208
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-sensor-msgs-py
+  - ros-jazzy-tf2
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 60585
+  timestamp: 1759138048043
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.6-np126py312h3bd2861_10.conda
   sha256: a7fcdc856ee4477544a37854b136a024e7c24602357ae87f7aaff5562384679a
   md5: 326bbc2e67a04b1e23e25bb2d4fc3480
@@ -25763,6 +33790,43 @@ packages:
   license: BSD-3-Clause
   size: 26555
   timestamp: 1759134801925
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h3bd2861_10.conda
+  sha256: 41015760b8efee178b35b36c7224f5cdd2940c5faa5f240dd1e98b71a7e7e7bf
+  md5: 414627a2421a5b2f78cc2b500287b2ac
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libcurl >=8.14.1,<9.0a0
+  license: BSD-3-Clause
+  size: 23734
+  timestamp: 1759134507600
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libcurl-vendor-3.4.4-np126py312h01c0cb9_10.conda
+  sha256: 81b9c63d27fb2d71c2612ba980aeb2e48c419f701edd69183132dec948ad4b54
+  md5: 82e4d18d47adedbebb17fb13f8a6079a
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 23710
+  timestamp: 1759134679735
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np126py312h3bd2861_10.conda
   sha256: e928c84cff58af3e436b3bf16e39d9e0ad9acb37e1b739ebd358171c7aad97a4
   md5: d4a046a08d54c85300b5ed9c0297f44b
@@ -25881,6 +33945,149 @@ packages:
   license: BSD-3-Clause
   size: 276189
   timestamp: 1759136766232
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np126py312h3bd2861_10.conda
+  sha256: 1eff4107bc2d61c2acaa8ddd7140f7e90b6915082184c5d4c9aaacab39dc3ed7
+  md5: 7b169411354347b577b40bd22a6cb972
+  depends:
+  - python
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 346101
+  timestamp: 1759137241981
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-map-msgs-2.4.1-np126py312h01c0cb9_10.conda
+  sha256: 3b9bd7f265d741eed6ebe9e5e7281106925252b9e43ae97159494cc91db30e5e
+  md5: 06d150f700eacdac5df2ef3676008a75
+  depends:
+  - python
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 354365
+  timestamp: 1759137312467
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: dddc3337261161b854a3e5dede6ac3c495013fe9a156af096b3e3f90ed23040e
+  md5: 17d79f719f9fe5f16a1d40c29aff7181
+  depends:
+  - python
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 291690
+  timestamp: 1759141187196
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-mecanum-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: bc61a0770811c011d2c96876ec3c4fbd7502763af1c2431b09d84a45537f1125
+  md5: e34093ff7edea4b0ae4fe575d6e3ccff
+  depends:
+  - python
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 284764
+  timestamp: 1759140475275
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.7-np126py312h3bd2861_10.conda
+  sha256: 54d7694ab42a3d76fbd6eecd7427b89e1851472316b577930dfa1ac44913ce0f
+  md5: 09bd33dc72e836ac22dd66fef868a631
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 81063
+  timestamp: 1759138525501
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-message-filters-4.11.7-np126py312h01c0cb9_10.conda
+  sha256: c070feeda330bb0a8029da5f12a47b1844b0434ee1d4ecd055ac049b961ab41e
+  md5: 6b718ef972537a0d0ee2701f1234ef2c
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclpy
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 81279
+  timestamp: 1759138292543
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np126py312h3bd2861_10.conda
   sha256: 563ff9aaaa0354246a9fd943466c1e80cd6dac2754e365d94075d9972868763b
   md5: 9c49e0a5c328ff0fb570448a37ff689b
@@ -25922,6 +34129,102 @@ packages:
   license: BSD-3-Clause
   size: 323595
   timestamp: 1759137108047
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 5e8c92a64397721ac82e81e86c60c22d7f1badef8e3a6a887600ddd51ab37295
+  md5: fc4d2248f8372bfc013c4f503addcede
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 394081
+  timestamp: 1759141156378
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-omni-wheel-drive-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: bf993604fb1266678bdb6170b5d8394ed60405c2e6218b8820f3095df27f17ce
+  md5: bee314faa924047b6f1edf9087880d18
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 379682
+  timestamp: 1759140429139
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
+  sha256: 81cbeea376699425b90740844f842d2f357fc23c619431a4efa8e6c5cfff0ac5
+  md5: 1f68c127fabe330d36821aaa453f7010
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27832
+  timestamp: 1759135159739
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-orocos-kdl-vendor-0.5.1-np126py312h01c0cb9_10.conda
+  sha256: a7ade64eaa0c8b0637c00e8314fcba741acf3437a937177ccb1264c2dacbe99c
+  md5: 25e97fd0c864d7edad0766be890958eb
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 27918
+  timestamp: 1759135238061
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np126py312h3bd2861_10.conda
   sha256: 2d00d4558e363230e5088ea8ae395a92ececf27aacf625c93f543792d6cba2e7
   md5: 014b2eb2645428433f6200bbdc1b889b
@@ -25956,6 +34259,236 @@ packages:
   license: BSD-3-Clause
   size: 64518
   timestamp: 1759134193985
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np126py312h3bd2861_10.conda
+  sha256: 78c51c03378bd1781c1b7c13ff3131807f9ea6aced3c8d5dad582625a15663a4
+  md5: fb1363e09b258d546e636dbebcd7e63a
+  depends:
+  - libboost-devel
+  - python
+  - ros-jazzy-pal-statistics-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 171436
+  timestamp: 1759138533436
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-2.7.0-np126py312h01c0cb9_10.conda
+  sha256: e4fe272038881b745e85335e8325234734ab61522b8c8172256735059182e150
+  md5: 821971116c0b87972ff277eecb457d0e
+  depends:
+  - libboost-devel
+  - python
+  - ros-jazzy-pal-statistics-msgs
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - libboost >=1.86.0,<1.87.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 170109
+  timestamp: 1759138316805
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np126py312h3bd2861_10.conda
+  sha256: 6d78c09ab096818c5647c790756225b8c45d42a54943764a2d36ccffe7b0e64c
+  md5: 0bba435b7bd04310f83bbe0a256c4bcc
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 127100
+  timestamp: 1759136825361
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-msgs-2.7.0-np126py312h01c0cb9_10.conda
+  sha256: ed7c6fe4ba93b45be0aede144b8a4898e81fb4add7191e3a7f963acfc5243596
+  md5: ab41a2a89262c4b0577053d7815d0221
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 131966
+  timestamp: 1759136976528
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 6525289a6cf033f2f4a8b79dad83132162d1ed5542e2e195a4a2f9df0e0d2adc
+  md5: 9317d12ad127c580b1d449139e4ab128
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 155245
+  timestamp: 1759141120510
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parallel-gripper-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 7cdb39a0bdd6266e0887f92f9d7876d3c14ddd4d2ed0fcdddf5e01213b2cb1f1
+  md5: f1fae3fa010eb54b35c997d06e9e435a
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 152206
+  timestamp: 1759140357873
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.5.0-np126py312h3bd2861_10.conda
+  sha256: f6fd73ad54218e6382e341e64bd46f419533927e9036f1066505190aeb7d626b
+  md5: c2b9db7149f35ac2783187018f6dfa15
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 50590
+  timestamp: 1759138491031
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parameter-traits-0.5.0-np126py312h01c0cb9_10.conda
+  sha256: 5260ef4595dab4ca6479671c40b11b3a8a8dd8b749eed4f5fbf5497ada77c0a4
+  md5: dfa17227d51a09568983485acd264b36
+  depends:
+  - fmt
+  - python
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rsl
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 50342
+  timestamp: 1759138254816
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 756a5aa187fc9442e100ca646ef0298bc202db9786ae9e6bae6c9155ede2e137
+  md5: 6b2ba85d6518587828a4ed8b59ee43a4
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-parameter-traits
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 303953
+  timestamp: 1759141259754
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pid-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 2580c82ef6835e2cfd63e5030f55c26e2b8b9894e752f2065edda693392ddbe1
+  md5: 028e5749e867077af9c7e305b9870865
+  depends:
+  - python
+  - ros-jazzy-angles
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-control-toolbox
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-parameter-traits
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 295939
+  timestamp: 1759140497320
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.2-np126py312h3bd2861_10.conda
   sha256: 39a0d734a0b41c602b11d7f193b56da78b6866c506bd4404bc12b207c55de8b6
   md5: fc60f4769217c95dfcd6c4220fd5bbf7
@@ -25998,6 +34531,178 @@ packages:
   license: BSD-3-Clause
   size: 41070
   timestamp: 1759136016808
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h3bd2861_10.conda
+  sha256: 439e66082547225944565d4c0865804b767ce9a1d036d9c44230162df52bb651
+  md5: 7efab3c1f4bb0c3c393c474d2af00caa
+  depends:
+  - python
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-rcpputils
+  - ros-jazzy-rmw
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 456606
+  timestamp: 1759138934093
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-point-cloud-transport-4.0.4-np126py312h01c0cb9_10.conda
+  sha256: 3e3ca78f86bd37cb6c6a06487d55d928b34a42243ad0e142ebcada9413c5a6ce
+  md5: e22ce6b2b61eb5d01c6268677e903c1e
+  depends:
+  - python
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-rcpputils
+  - ros-jazzy-rmw
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 457094
+  timestamp: 1759138610583
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 98ca26e927926a2d027ea1e6bcbccc471810d5de33c0872611ccbb7bdfe8a70c
+  md5: f443be45262e36412eb0f837765f35f6
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 171687
+  timestamp: 1759141239609
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pose-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 3039181b0e8ddd5d6cfc9723279b79dff7beb709353a6fd29c096ccdd7a8919f
+  md5: bd30b2e9e8d4e5d65b20f927589d7760
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 170859
+  timestamp: 1759140476360
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 2c0261cee8e2f3b9dbe45303ec797c4cc3540acd36ca26ee1b354aff785e39de
+  md5: db8fbeebbaa017afdb2023865d79001d
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 75592
+  timestamp: 1759141556354
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-position-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: dfceda22bc8d3e6049a1acf8927858258f2dd6eca4c74dca17a2a5375f738c7f
+  md5: 52074b2ef69aacd3da6b931575b85dff
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 76287
+  timestamp: 1759140740239
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h3bd2861_10.conda
+  sha256: 531fc2b9f72a66aee15aafe92abeba472bf874e773ad37c84e49d6c9b4535c43
+  md5: 8a9427040947a6fec2cf13041b52c4ed
+  depends:
+  - pybind11
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23052
+  timestamp: 1759134499243
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pybind11-vendor-3.1.3-np126py312h01c0cb9_10.conda
+  sha256: 60afc94a04062379d92141a6744ce2fd40b2102e09d7afb893b85068506c7542
+  md5: 505845ac8e4c3c650b2fcc9107eebb77
+  depends:
+  - pybind11
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23034
+  timestamp: 1759134673899
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np126py312h3bd2861_10.conda
   sha256: 7e63c152f78759fe99d79f4f2218a16edebfb0f0e406b585c35d2c31782b0959
   md5: 8d8268a354f258950e2381bce6c628c0
@@ -26029,6 +34734,96 @@ packages:
   license: BSD-3-Clause
   size: 27695
   timestamp: 1759135206100
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h3bd2861_10.conda
+  sha256: ff596163b73b99c77b87f2c5ea9407db42d110977377d926e93d625959f600d1
+  md5: 5712f9a4ff564f044404044f79c56c29
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-pybind11-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 27335
+  timestamp: 1759135553018
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np126py312h01c0cb9_10.conda
+  sha256: 9e8631636761930f933cdf5397b218c494ce1c51473f1ee8ac6240ebd4b935e5
+  md5: 8841ed8ca384899fe1176053e4c7b8d6
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-pybind11-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 27427
+  timestamp: 1759135484934
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 86399b1acc4fac51a964047db9ade80c8af84aedb42c981aa3ae99e2bca0f303
+  md5: ea9e56c934ad4b9db4f958c679a7f235
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 147703
+  timestamp: 1759141221664
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-range-sensor-broadcaster-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: ca3dd1ddf68c02e87ae68da64e19884ac80674fe975964edf2daa5838a084c4d
+  md5: 7c5b097f0f7fce6a3f687cd034230458
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 146784
+  timestamp: 1759140457656
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.7-np126py312h3bd2861_10.conda
   sha256: 9bf9e007a2f7986731e8cb6ce6359a9ae98ce58a1d966575d7899659e3ed1119
   md5: 6abad32f74bfe8f8583c73cfdb82a909
@@ -26678,6 +35473,90 @@ packages:
   license: BSD-3-Clause
   size: 126746
   timestamp: 1759135595288
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.9.0-np126py312h3bd2861_10.conda
+  sha256: a066102dc91dfad2fd2a31e1d8e6eee0f71971cfeffca99da9eae7709ebd6f02
+  md5: cdaa597390115e1fb082cbfc250106d3
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-jazzy-ament-cmake
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libcap >=2.76,<2.77.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 78029
+  timestamp: 1759138514556
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-realtime-tools-3.9.0-np126py312h01c0cb9_10.conda
+  sha256: 2b89bcd4ae0fc9c3398bb52b658348c107e95080293b3511d3542abddb89f6cb
+  md5: 79f8d32364d843599a7eeb05cbd8e3f9
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-jazzy-ament-cmake
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - libcap >=2.76,<2.77.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 81585
+  timestamp: 1759138280978
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np126py312h3bd2861_10.conda
+  sha256: cce7c268b3e1b9b1767c5d6289eefc587a669680e2aa1c9e351d50534ef34bb6
+  md5: 2cfb053769857c61ef2033376b5492da
+  depends:
+  - python
+  - ros-jazzy-ament-index-cpp
+  - ros-jazzy-ament-index-python
+  - ros-jazzy-libcurl-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 44775
+  timestamp: 1759135559085
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-resource-retriever-3.4.4-np126py312h01c0cb9_10.conda
+  sha256: a1b755996f2b816a9e5ea8de286bb9b51f5f3e0c94a41063244cb7f86e3d36d3
+  md5: 7060ede945aa2c20db4ae2770b252efc
+  depends:
+  - python
+  - ros-jazzy-ament-index-cpp
+  - ros-jazzy-ament-index-python
+  - ros-jazzy-libcurl-vendor
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 45622
+  timestamp: 1759135489914
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np126py312h3bd2861_10.conda
   sha256: 57f23ae2beb22304328e2cee8535e9d547190700e73fcd169e3538eba79c7947
   md5: 630603ba196ed5efebd28d281bfa848d
@@ -27166,6 +36045,59 @@ packages:
   license: BSD-3-Clause
   size: 29303
   timestamp: 1759135426406
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h3bd2861_10.conda
+  sha256: c8833ae7b3ec0fc4d31fb3a774c849c85012fafa9d711cd964311d7477008199
+  md5: 6c8fa7a2175dce9d6224d4025598a4f6
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-kdl-parser
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-rcl-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 270797
+  timestamp: 1759139223476
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-robot-state-publisher-3.3.3-np126py312h01c0cb9_10.conda
+  sha256: 9d6194da81708925f5d6a239abe48bf042a166212c8926326c633693ab0fd6f5
+  md5: 4a7c9b203bea7258c98184185b299ebc
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-kdl-parser
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-rcl-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-urdf
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 268161
+  timestamp: 1759138878960
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np126py312h3bd2861_10.conda
   sha256: 78e70094f96dbd1833c488ebea406a6ac885c3676c0e7dc0d2fb51c83eaa1c6b
   md5: 5f9ef851bcbd220526d56aa3995d87f8
@@ -27323,6 +36255,121 @@ packages:
   license: BSD-3-Clause
   size: 35366
   timestamp: 1759134127288
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-control-test-assets-4.37.0-np126py312h3bd2861_10.conda
+  sha256: f979d28b07f19c7044a83e9faa545ae91ef35b817e506c35eac38b6af4d87f16
+  md5: ca77c194c0524faee5dfe3ee49fd0909
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 31131
+  timestamp: 1759134500444
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2-control-test-assets-4.37.0-np126py312h01c0cb9_10.conda
+  sha256: 22feb0ff7c15dc839770439e34c6fddbb4c9c8ec3168f7651cf6ae4a2cf2d57a
+  md5: df8c7065be57ff8bf7cffb10037c7425
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 31106
+  timestamp: 1759134671355
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: c7420c1bcaf275fe4d65cd4d52b0bf20473a1bc958b9c76450c1a7b2b1a285ff
+  md5: eaab0b9e850f5ee6d39a486be4ddd3fd
+  depends:
+  - python
+  - ros-jazzy-ackermann-steering-controller
+  - ros-jazzy-admittance-controller
+  - ros-jazzy-bicycle-steering-controller
+  - ros-jazzy-chained-filter-controller
+  - ros-jazzy-diff-drive-controller
+  - ros-jazzy-effort-controllers
+  - ros-jazzy-force-torque-sensor-broadcaster
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-gpio-controllers
+  - ros-jazzy-gps-sensor-broadcaster
+  - ros-jazzy-gripper-controllers
+  - ros-jazzy-imu-sensor-broadcaster
+  - ros-jazzy-joint-state-broadcaster
+  - ros-jazzy-joint-trajectory-controller
+  - ros-jazzy-mecanum-drive-controller
+  - ros-jazzy-omni-wheel-drive-controller
+  - ros-jazzy-parallel-gripper-controller
+  - ros-jazzy-pid-controller
+  - ros-jazzy-pose-broadcaster
+  - ros-jazzy-position-controllers
+  - ros-jazzy-range-sensor-broadcaster
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-steering-controllers-library
+  - ros-jazzy-tricycle-controller
+  - ros-jazzy-tricycle-steering-controller
+  - ros-jazzy-velocity-controllers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22935
+  timestamp: 1759141842749
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: fdba9f2da0621538406d0cd8bf194c49345c7aaf31ff4f9a2f75fa10a9ce3224
+  md5: dd36616da0a2b0caa27b9d6b3c950a9e
+  depends:
+  - python
+  - ros-jazzy-ackermann-steering-controller
+  - ros-jazzy-admittance-controller
+  - ros-jazzy-bicycle-steering-controller
+  - ros-jazzy-chained-filter-controller
+  - ros-jazzy-diff-drive-controller
+  - ros-jazzy-effort-controllers
+  - ros-jazzy-force-torque-sensor-broadcaster
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-gpio-controllers
+  - ros-jazzy-gps-sensor-broadcaster
+  - ros-jazzy-gripper-controllers
+  - ros-jazzy-imu-sensor-broadcaster
+  - ros-jazzy-joint-state-broadcaster
+  - ros-jazzy-joint-trajectory-controller
+  - ros-jazzy-mecanum-drive-controller
+  - ros-jazzy-omni-wheel-drive-controller
+  - ros-jazzy-parallel-gripper-controller
+  - ros-jazzy-pid-controller
+  - ros-jazzy-pose-broadcaster
+  - ros-jazzy-position-controllers
+  - ros-jazzy-range-sensor-broadcaster
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-steering-controllers-library
+  - ros-jazzy-tricycle-controller
+  - ros-jazzy-tricycle-steering-controller
+  - ros-jazzy-velocity-controllers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 22892
+  timestamp: 1759140989818
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.6-np126py312h3bd2861_10.conda
   sha256: 69bd4ce547a8e13565d157d693848e950779c8bc91d2a9dca6218d9c5864b6c8
   md5: 4261dd0395dd7a2f118dc8263b0ee2cc
@@ -29175,6 +38222,52 @@ packages:
   license: BSD-3-Clause
   size: 26218
   timestamp: 1759134654093
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np126py312hd4d1b83_10.conda
+  sha256: cf9f65c0048fc2557946af8a1061c21ef38f2fd0df2bffc52c55d0bce35d1082
+  md5: 263ece5872ccdc17d9537870b68ebb29
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - graphviz >=13.1.2,<14.0a0
+  license: BSD-3-Clause
+  size: 61146
+  timestamp: 1759138254146
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rsl-1.2.0-np126py312hcea3410_10.conda
+  sha256: 46f05091db3c9e7f673245e42d7bcf86b50be17457bda6b4034540ab344df372
+  md5: 035c948f5e0ed73c76dbed121377d420
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tcb-span
+  - ros-jazzy-tl-expected
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - graphviz >=13.1.2,<14.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 62294
+  timestamp: 1759138062802
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.1-np126py312h3bd2861_10.conda
   sha256: 939f02511575d68e5e213faf011a2cc83bdde7d158a931259334470a0959a0d2
   md5: a814fd56f1d32c08c552c78599d04971
@@ -29208,6 +38301,503 @@ packages:
   license: BSD-3-Clause
   size: 31459
   timestamp: 1759135421402
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h3bd2861_10.conda
+  sha256: d51251931f0b4be140cc862490d07674c71e43bec253e7cfb48016814410a0a1
+  md5: 768c532c8973aafe963b0bf155d07743
+  depends:
+  - assimp
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 24810
+  timestamp: 1759135089466
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-assimp-vendor-14.1.15-np126py312h01c0cb9_10.conda
+  sha256: 7a2b3c005e7c25bf7903a993910b641bef0a01a1879b84a437a8204c640c73f1
+  md5: 88b1e1dc562f7bd4cd2b9f5b590cbeed
+  depends:
+  - assimp
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 24762
+  timestamp: 1759135172446
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.15-np126py312h3bd2861_10.conda
+  sha256: 4148f838974e0dccafb38827221f6ee150f5ad146f4fcb7632d2c3a045583f26
+  md5: a2a69da9f9be2fe1158df1260b211c19
+  depends:
+  - python
+  - qt-main
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-ogre-vendor
+  - ros-jazzy-rviz-rendering
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros-jazzy-yaml-cpp-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 889510
+  timestamp: 1759139178899
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-common-14.1.15-np126py312h01c0cb9_10.conda
+  sha256: 05bb78276bbf61f8d1736f280731257195b333700e79095099ab9ccdb0b12af7
+  md5: 056e1256a918ecb6d1a790cf1089b4a8
+  depends:
+  - python
+  - qt-main
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-message-filters
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-ogre-vendor
+  - ros-jazzy-rviz-rendering
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros-jazzy-yaml-cpp-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 881650
+  timestamp: 1759138821990
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h3bd2861_10.conda
+  sha256: b9c6fcede16d94a7d2daf109fab9597d8efbc87ac3daa1574ba0b690bdfca137
+  md5: c87ef245ad83fbf05cd57eb4ccfb9ccd
+  depends:
+  - python
+  - qt-main
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-gz-math-vendor
+  - ros-jazzy-image-transport
+  - ros-jazzy-interactive-markers
+  - ros-jazzy-laser-geometry
+  - ros-jazzy-map-msgs
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-point-cloud-transport
+  - ros-jazzy-rclcpp
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-common
+  - ros-jazzy-rviz-ogre-vendor
+  - ros-jazzy-rviz-rendering
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-urdf
+  - ros-jazzy-visualization-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 2285873
+  timestamp: 1759140028444
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-default-plugins-14.1.15-np126py312h01c0cb9_10.conda
+  sha256: 0ecd6713efab7d0b2ddd7062a54ad4a30e105f5312ac57e2b20ef237db7c1deb
+  md5: 8898c1b171ea7eeeb6c1f06991c5ca2a
+  depends:
+  - python
+  - qt-main
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-gz-math-vendor
+  - ros-jazzy-image-transport
+  - ros-jazzy-interactive-markers
+  - ros-jazzy-laser-geometry
+  - ros-jazzy-map-msgs
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-point-cloud-transport
+  - ros-jazzy-rclcpp
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-common
+  - ros-jazzy-rviz-ogre-vendor
+  - ros-jazzy-rviz-rendering
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-urdf
+  - ros-jazzy-visualization-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 2306357
+  timestamp: 1759139533264
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312h39124df_10.conda
+  sha256: 4081bce459c4d31b506dc3314b9d9032320ddc8c3ffa7c8b625ff6bf5a14a55a
+  md5: 9ffd6fc4b4c271d5578b29c8f4725748
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - assimp >=5.4.3,<5.4.4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libglu >=9.0.3,<9.1.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - pugixml >=1.15,<1.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 5377597
+  timestamp: 1759134848838
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-ogre-vendor-14.1.15-np126py312hc3c81ed_10.conda
+  sha256: 3f9f0efcedb871c810d3c7938517b0a8ca3bb36735d5e4c023008f17d6722fb1
+  md5: 8623b4fa079fd2121e82c1368c046c77
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - libglu >=9.0.3,<9.1.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - python_abi 3.12.* *_cp312
+  - xorg-libxext >=1.3.6,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - pugixml >=1.15,<1.16.0a0
+  license: BSD-3-Clause
+  size: 5261734
+  timestamp: 1759135005575
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.15-np126py312h3bd2861_10.conda
+  sha256: 1d5e4748a83e5515a66f00e8a13626df0c016c1ed2a576dabec66e8005c83609
+  md5: 7b499dabea440a986f2b3d4638b48947
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-jazzy-ament-index-cpp
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-assimp-vendor
+  - ros-jazzy-rviz-ogre-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: BSD-3-Clause
+  size: 937128
+  timestamp: 1759135657587
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-rendering-14.1.15-np126py312h01c0cb9_10.conda
+  sha256: 9077806219efba923a5f173a5f50b76dc129e76ba8e9f4ab15c29e85511bc367
+  md5: f81ccb10ad2b53eac1da5a442bf567ef
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-jazzy-ament-index-cpp
+  - ros-jazzy-eigen3-cmake-module
+  - ros-jazzy-resource-retriever
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-assimp-vendor
+  - ros-jazzy-rviz-ogre-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - glew >=2.1.0,<2.2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: BSD-3-Clause
+  size: 929753
+  timestamp: 1759135631965
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.15-np126py312h3bd2861_10.conda
+  sha256: a166b0b2289c9de429818b58f5cc9b0ea35e3c057a1a4c3eb0cf360677f3ab84
+  md5: 57345cdcf4230d648e45206218ec3667
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-common
+  - ros-jazzy-rviz-default-plugins
+  - ros-jazzy-rviz-ogre-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 76045
+  timestamp: 1759140831984
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz2-14.1.15-np126py312h01c0cb9_10.conda
+  sha256: 649ff4a8714e27f12cc548b0b79aae8cb4813f8cee9b9679775364a8f787a750
+  md5: d268cb046c0cdeffcc0b2037e26609e6
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rviz-common
+  - ros-jazzy-rviz-default-plugins
+  - ros-jazzy-rviz-ogre-vendor
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 77116
+  timestamp: 1759140185768
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np126py312h3bd2861_10.conda
+  sha256: fe369a69329c26501913e56468d8eb3288588c10379d71b315872d883f73f920
+  md5: 9aeffe5785e36b770e15c7e847df45d6
+  depends:
+  - python
+  - ros-jazzy-ament-cmake-ros
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sdformat-vendor
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros-jazzy-urdf-parser-plugin
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - urdfdom_headers
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 85339
+  timestamp: 1759136172745
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-urdf-1.0.2-np126py312h01c0cb9_10.conda
+  sha256: 9f94e073c64cd86168bfec906aeb168ffb5d39e2a3d5bc88a943feeaf6e8bb36
+  md5: c47bf8d4fc50f955c44f6e8223ab5f34
+  depends:
+  - python
+  - ros-jazzy-ament-cmake-ros
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sdformat-vendor
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf
+  - ros-jazzy-urdf-parser-plugin
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - urdfdom_headers
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 88236
+  timestamp: 1759136294120
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np126py312hbd70b12_10.conda
+  sha256: f1d2c875dfb67bedd6cfb1d81b8a71efa8556600e637f986d5f5900c8701c475
+  md5: f038a81faa4361e34d814693b2b43838
+  depends:
+  - pybind11
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-gz-math-vendor
+  - ros-jazzy-gz-tools-vendor
+  - ros-jazzy-gz-utils-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdfdom
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - sdformat14
+  - tinyxml2
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libsdformat14 >=14.8.0,<15.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  license: BSD-3-Clause
+  size: 31837
+  timestamp: 1759135760960
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-vendor-0.0.10-np126py312hac67124_10.conda
+  sha256: d626fe9846eb12f6c1ce7d6e3f64b340b02e5d82dfaa9a640c2f1a499a89da9a
+  md5: 89187964658d7d685f0456564b357c94
+  depends:
+  - pybind11
+  - python
+  - ros-jazzy-gz-cmake-vendor
+  - ros-jazzy-gz-math-vendor
+  - ros-jazzy-gz-tools-vendor
+  - ros-jazzy-gz-utils-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdfdom
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - sdformat14
+  - tinyxml2
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - python_abi 3.12.* *_cp312
+  - libsdformat14 >=14.8.0,<15.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  license: BSD-3-Clause
+  size: 31803
+  timestamp: 1759135721636
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np126py312h3bd2861_10.conda
   sha256: 65926e9bd0725c11a170d9263502cd08dbd75f67c69d3ab9b15f8edf0aca0692
   md5: 477cf9584895a578c653b40c0df1da4e
@@ -29248,6 +38838,43 @@ packages:
   license: BSD-3-Clause
   size: 555650
   timestamp: 1759137162615
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h3bd2861_10.conda
+  sha256: 620c211b274a399b29d8f4e3c9d2cfe74e54ac72d617c49ba3e854663634beda
+  md5: 2aa778ab9342a18b183ecadeda6792e5
+  depends:
+  - numpy
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 30492
+  timestamp: 1759137231637
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sensor-msgs-py-5.3.6-np126py312h01c0cb9_10.conda
+  sha256: b56e9ac354f33b5e29f056dffda754cf915a72f0651f540c765b1b87d21b08a3
+  md5: 0199cf9ee7ff95dd643ca5eefdc4a707
+  depends:
+  - numpy
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 30496
+  timestamp: 1759137297438
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np126py312h3bd2861_10.conda
   sha256: 58f5a585a42773ac153529a7a23b63bfbf5a4c5fa1299c6bb9af671847582934
   md5: a0c36bf475e340a819d8b781bd798058
@@ -29548,6 +39175,70 @@ packages:
   license: BSD-3-Clause
   size: 174017
   timestamp: 1759136807876
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 6a301a2c0e7918e5a098a166bd7023257dffbcf3e83a9942e6431d5e28248917
+  md5: 16f9d35c1ffd698caadcf74cd1dd0d35
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 299510
+  timestamp: 1759141191945
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-steering-controllers-library-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: da79f7d189b5f1d0b8ee13e4517f253269d6f84bb8e36b98efefad67ca717e9d
+  md5: ea65035f1659bd139b6ec75f9655be03
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-generate-parameter-library
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-geometry-msgs
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 290339
+  timestamp: 1759140448969
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np126py312h3bd2861_10.conda
   sha256: 58b940930d7eb8e1d8e9dd4623848b2865b1795916919c6c5a993c79cef71e5c
   md5: 76f33262a398c8320890860d3e39416a
@@ -29587,6 +39278,384 @@ packages:
   license: BSD-3-Clause
   size: 86878
   timestamp: 1759137424600
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.0.2-np126py312h3bd2861_10.conda
+  sha256: 0bdbaa75806d1c57727c497a10b4c14d54d95324ed6b74e04b5572e3053ba096
+  md5: dd48f9089f5c916d5512a4b33662d3a5
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 27768
+  timestamp: 1759134511066
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tcb-span-1.0.2-np126py312h01c0cb9_10.conda
+  sha256: dbbb85bbb96041644ba2bd9354f0e3831fad8b002426478e01547c811e88eddb
+  md5: c95648c8270bd7822a0299b6762a56a8
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27746
+  timestamp: 1759134683699
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 3e0e8bc92bf1fa2cf9d165b7fc12df751d9ddeaa0f32677576269da9ed7941eb
+  md5: 023d8670910a31fb8952ed211d1edaa9
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 135313
+  timestamp: 1759137051595
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: 68476da4e238c0088e75b95f518fae8c16a2f8cbbb160a583b200aa8f3ea8002
+  md5: c9bf050a6886372212fb4c2f47457056
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rcutils
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 132153
+  timestamp: 1759137149958
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.14-np126py312h3bd2861_10.conda
+  sha256: b42f3a2b125b4a3e0140e01bc3df5359ac705f4f34ce96b87cb75963856a55f6
+  md5: e11c0996f2e94d4aa9b5675aa7c46343
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 45726
+  timestamp: 1759139209962
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-eigen-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: a4fa5caab7079fad70f03c4f1ae9c22698455017cd8f120746de684548766943
+  md5: 4efa72efd25b817d8696dc5428e25ad6
+  depends:
+  - eigen
+  - python
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 45608
+  timestamp: 1759138865358
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 675b3240a29cb38be97b6369f8c8b93581b355a942666b75e2b27f74ec1accd2
+  md5: eed7a734010d4d468415fe2bd03312c8
+  depends:
+  - numpy
+  - python
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tf2-ros-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 57650
+  timestamp: 1759139173325
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-geometry-msgs-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: 3ff292196bfb22af40fdf6705af909816751abab085df365b2f8b79d110999a3
+  md5: 21695987ca8fd39db7608afadd483479
+  depends:
+  - numpy
+  - python
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tf2-ros-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 57569
+  timestamp: 1759138821081
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 058712bc28454547f8c2fbdb2b35c9ab9a2beb9dfe75b6297653c5871faa71c2
+  md5: a848b4fc65282fe6f55578e58c489c96
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-python-orocos-kdl-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tf2-ros-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 47225
+  timestamp: 1759139203220
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-kdl-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: 89974d129fae7169674b9fad905e7c80b502f584059f6ec720012778d4b360db
+  md5: bc55c90f826cd3c8c761516f33aac38a
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-orocos-kdl-vendor
+  - ros-jazzy-python-orocos-kdl-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-ros
+  - ros-jazzy-tf2-ros-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 47039
+  timestamp: 1759138853852
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 4abd8e41ad7f82e89f8857eede0e00135986f2c262fc886a22469dc782f4109a
+  md5: a11bc4a57bc7cb43d5a144b8aba6b18b
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 256026
+  timestamp: 1759137020823
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-msgs-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: d3b2481150a0472efcc8eace4df15c256e70b247400606d598a485edf6ad2552
+  md5: 0eec4906240263ae596ca4aae64690d8
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rosidl-default-runtime
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 262117
+  timestamp: 1759137109346
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 332d1062f7645bf195c14a9712a7aede4cdf79b23ea734483f28ebcf8390d9a4
+  md5: c4d17504df0d4cfc2546f0c94b85ffd8
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rpyutils
+  - ros-jazzy-tf2
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 58858
+  timestamp: 1759138282022
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-py-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: ded463c6a7a55c860137e114ae0484bf362c6741d5fd7b6e459683cebb9ea7f7
+  md5: 9e943b3fdd91d5ae4a97d6745dfe1711
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-rpyutils
+  - ros-jazzy-tf2
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 57166
+  timestamp: 1759138087222
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 5abb275a02ee9dbaa3ea35cdf79040c9c080a5af961eff471ad2ceb53c8ebf21
+  md5: 17efb45a654c668411f121bd2b1d01cd
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-message-filters
+  - ros-jazzy-rcl-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 466480
+  timestamp: 1759138967417
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: 102d42c9473e82968e5ef7d65e981c9dcabdfeeb220150f70ddd8db6e7d0b828
+  md5: 38df7768caf669726349992173812f32
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-message-filters
+  - ros-jazzy-rcl-interfaces
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-action
+  - ros-jazzy-rclcpp-components
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 475453
+  timestamp: 1759138651921
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h3bd2861_10.conda
+  sha256: 4b74718a81327f22c9f5ccd7e701122354150efef92630e3cfe40206fc25c7ba
+  md5: b480decf703ef801b0c591ebd08c5624
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2-msgs
+  - ros-jazzy-tf2-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 48787
+  timestamp: 1759138495464
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-py-0.36.14-np126py312h01c0cb9_10.conda
+  sha256: 79f63b1d65f2e32c73e5c21762f59ce72b0d4afd59cdce50ce4f8e204bee5170
+  md5: 4df7830f99b20ba1a4850d12c01b0d96
+  depends:
+  - python
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-rclpy
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-sensor-msgs
+  - ros-jazzy-std-msgs
+  - ros-jazzy-tf2-msgs
+  - ros-jazzy-tf2-py
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 48676
+  timestamp: 1759138254072
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.1-np126py312h3bd2861_10.conda
   sha256: 1826bf7e955fec0c5d74f28e58851fae90d56ed47b1e58ad84f6e0cc567b9ad7
   md5: 3e859a033dd175dddd2864a10824f247
@@ -29623,6 +39692,38 @@ packages:
   license: BSD-3-Clause
   size: 24288
   timestamp: 1759134687841
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.0.2-np126py312h3bd2861_10.conda
+  sha256: bb9d5816cb3c635b8ea7f76900d44232c7e77e9f29201ca568219e7e5b0377b6
+  md5: 2c2a73c15c6ebf9615e9255bc6fe4684
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 33353
+  timestamp: 1759134506272
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tl-expected-1.0.2-np126py312h01c0cb9_10.conda
+  sha256: 0e5c34848602577e49c0c3102f330d2ca251ef886c1058fb998452edc393dd04
+  md5: 3f2efd03d498af37b2d61654924fbce3
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 33340
+  timestamp: 1759134679194
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np126py312h3bd2861_10.conda
   sha256: f25d0f1a214c27118745c3ca772ffa64631489be4e9868c9daaf300ca11b26af
   md5: af1df22dc8dd175c42fe14c84fcfb71b
@@ -29701,6 +39802,119 @@ packages:
   license: BSD-3-Clause
   size: 153991
   timestamp: 1759137202836
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: ff43433e276c0799d490ec8059daa832fb9a97d3f73019fdceffb5a0b76f0ad6
+  md5: da979047af9eb2cd2d5ccb4a412ae55a
+  depends:
+  - python
+  - ros-jazzy-ackermann-msgs
+  - ros-jazzy-backward-ros
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 313621
+  timestamp: 1759141180530
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 252b028ebdc534d2ada33bc56b8ac51b39486b8d6d61f8208c27e09dc6aa6110
+  md5: a96903d6e74ccae6167d574dbe514698
+  depends:
+  - python
+  - ros-jazzy-ackermann-msgs
+  - ros-jazzy-backward-ros
+  - ros-jazzy-builtin-interfaces
+  - ros-jazzy-controller-interface
+  - ros-jazzy-geometry-msgs
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-nav-msgs
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-rcpputils
+  - ros-jazzy-realtime-tools
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-tf2
+  - ros-jazzy-tf2-msgs
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 303613
+  timestamp: 1759140414999
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.32.0-np126py312h3bd2861_10.conda
+  sha256: e263c54f346b549f3d02fc5f07573d9434e04c5436a7f4179cb6826fbb9c10e4
+  md5: 418881c70fd6104f7940ba258205c6c7
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 104139
+  timestamp: 1759141687186
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-steering-controller-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 5a8165529fa3aff64d55130d062cb7eca14aec2edcda9034f3c90ea8573c6b95
+  md5: e366e37648433ed8607e6beef7d22f7f
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-control-msgs
+  - ros-jazzy-controller-interface
+  - ros-jazzy-hardware-interface
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-rclcpp-lifecycle
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-std-srvs
+  - ros-jazzy-steering-controllers-library
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 102028
+  timestamp: 1759140876397
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np126py312h3bd2861_10.conda
   sha256: 14368876873331ac7451cbf86be9ca2e19266d359bf583112b65bf3d5f06f776
   md5: 148ab2d471c3f2c05ece1bef1a74aa33
@@ -29806,6 +40020,188 @@ packages:
   license: BSD-3-Clause
   size: 77638
   timestamp: 1759136480421
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np126py312h3bd2861_10.conda
+  sha256: 6f82c0ad060265a4e44d5eb636b8249cc336cf93bbf66b6a8c6ff4649cec889a
+  md5: 03ddeb2220090ded429a18fcb63b2eb5
+  depends:
+  - python
+  - ros-jazzy-pluginlib
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf-parser-plugin
+  - ros-jazzy-urdfdom
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 155698
+  timestamp: 1759136011042
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-2.10.0-np126py312h01c0cb9_10.conda
+  sha256: 6a0a4c24820e281438aba7cbcd88f9a3dd82501153596801a63ee851aaba4e5f
+  md5: 1ddae0d867e0fa5e95a95518cf33e1bd
+  depends:
+  - python
+  - ros-jazzy-pluginlib
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdf-parser-plugin
+  - ros-jazzy-urdfdom
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 155006
+  timestamp: 1759136134429
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h3bd2861_10.conda
+  sha256: daf76d316eab5af498999c6e3b59d84957540176ac8d6f8b663888f05f82a2d6
+  md5: 1e6605f33ce8f839c4b38d5fc95d7b6f
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 31820
+  timestamp: 1759135533626
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-parser-plugin-2.10.0-np126py312h01c0cb9_10.conda
+  sha256: 7b23419ff387fb4bfbad7b60432b263195305fd53e8e07b9f46ca7c52d58d034
+  md5: bc42b57d9a656c1644075fa52951526c
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 31822
+  timestamp: 1759135464294
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_10.conda
+  sha256: a0a91bcf54de765bca95a7d49265bf33fb4cae66843004bcd9427ce396b7df78
+  md5: 4c5c0f01d6ed4f67279203376113bda8
+  depends:
+  - console_bridge
+  - python
+  - ros-jazzy-console-bridge-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - tinyxml2
+  - urdfdom >=4.0.1,<4.1.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 8062
+  timestamp: 1759135655375
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-4.0.1-py312h9804fc4_10.conda
+  sha256: 546ae5d343a1d00106c0ac39e724ee186bd625c3020b383a7e563c49b00bbd5d
+  md5: 026754a1b78aaa438d58c93238945f4f
+  depends:
+  - console_bridge
+  - python
+  - ros-jazzy-console-bridge-vendor
+  - ros-jazzy-ros-workspace
+  - ros-jazzy-tinyxml2-vendor
+  - ros-jazzy-urdfdom-headers
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - tinyxml2
+  - urdfdom >=4.0.1,<4.1.0a0
+  - python_abi 3.12.* *_cp312
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 7922
+  timestamp: 1759135630565
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_10.conda
+  sha256: a8600df10433692cd78648cbc25505084e97a78e54c9ab41df5ff267adde73a8
+  md5: 205a659da7d45091f845eb916bfbf7f1
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - urdfdom_headers >=1.1.2,<1.2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 7285
+  timestamp: 1759133953538
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-headers-1.1.2-py312h9804fc4_10.conda
+  sha256: ed46cbd4757deb30edabdee68e98935aed1c62eb5413a3ac915557b301ab60d1
+  md5: 283e25bb19a5af3d51d29f8d1a4070a1
+  depends:
+  - python
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - urdfdom_headers >=1.1.2,<1.2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  license: BSD-3-Clause
+  size: 7164
+  timestamp: 1759134196506
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.32.0-np126py312h3bd2861_10.conda
+  sha256: 7055b4509768d9296e54372bfb5c1b05ae93945a0a145a84bc3bdb9310a6db64
+  md5: 2d7459c694f082e973c10ee6f9179208
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 76472
+  timestamp: 1759141672750
+- conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-velocity-controllers-4.32.0-np126py312h01c0cb9_10.conda
+  sha256: 545e2672b770fec7ae3a7749ba9f4294ff91d2aba34d4371a124cc27d9225059
+  md5: 85ba74353d1bc46644b12fdd5df150de
+  depends:
+  - python
+  - ros-jazzy-backward-ros
+  - ros-jazzy-forward-command-controller
+  - ros-jazzy-pluginlib
+  - ros-jazzy-rclcpp
+  - ros-jazzy-ros-workspace
+  - ros2-distro-mutex 0.11.* jazzy_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.11.0,<0.12.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 77452
+  timestamp: 1759140848887
 - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np126py312h3bd2861_10.conda
   sha256: 824e0c796d3702e4fc0d08910d34139896c85aa990f29fa9faf7c02a6aa93e6e
   md5: 48cc837470469c7e55f8e6dc2ef870db
@@ -29884,6 +40280,91 @@ packages:
   license: BSD-3-Clause
   size: 22869
   timestamp: 1759134681751
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ackermann-msgs-2.0.2-np2py312h31f38b3_14.conda
+  sha256: df649d0b19a2a5b392e20e6f162c5771a714cb43e321c2163a674ef8db75f610
+  md5: 63549210355cc9332b99bf0427abc532
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 87826
+  timestamp: 1759312585444
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ackermann-msgs-2.0.2-np2py312h2c707e6_14.conda
+  sha256: 6a5916bd2d442e9ac24331cd979c2bed122de74d0628df7a2df42af21da60736
+  md5: 9cdb6af8ad58d8c6f2a98f76d6149633
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 91352
+  timestamp: 1759317106691
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ackermann-steering-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 382879c0ad1ffb32997a378afe391c36554bde469b30a980aeec41c04ac1dcb4
+  md5: ccd223cf94053b2dd734d158e8efcbfb
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 104443
+  timestamp: 1759317102055
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ackermann-steering-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: efcd6368fd9bcce73a4f60d8a5b908c2ad384d89edbfdf485120d77fd328cf51
+  md5: a797ef0ced1fbdd75181e7dacb578ba7
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 104252
+  timestamp: 1759321134250
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h31f38b3_14.conda
   sha256: cd18ce49b10f009de08053c8c217cd6c258b9615bab1e88bed7a6b008c67fd62
   md5: e52f361b2e40fd23c662f37c0441bf09
@@ -29962,6 +40443,75 @@ packages:
   license: BSD-3-Clause
   size: 113667
   timestamp: 1759317088755
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-admittance-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 4754416204ae8e2ee331faf50cba2a73ddfb2f60efc583b3bb2c958e22be2309
+  md5: c692e662651c4378a128ae57379660d1
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-kinematics-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-eigen
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-kdl
+  - ros-kilted-tf2-ros
+  - ros-kilted-trajectory-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 414938
+  timestamp: 1759316636255
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-admittance-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 69e6a9d3c49e3f6355c151cf5d7f71d18c65b3d3c4f6cf3df32528a5c995fc4e
+  md5: ea128e0932435e02bf28a6f7a2845fb6
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-kinematics-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-eigen
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-kdl
+  - ros-kilted-tf2-ros
+  - ros-kilted-trajectory-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 403803
+  timestamp: 1759320636146
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.3-np2py312h31f38b3_14.conda
   sha256: 655ae089e73b91f28d62ce86c40c9a527bc42be2aa00df54800a353d448f4ed0
   md5: 93fe4f1d8371e1fda1b340fd6c24d995
@@ -31578,6 +42128,126 @@ packages:
   license: BSD-3-Clause
   size: 27894
   timestamp: 1759314972293
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h31f38b3_14.conda
+  sha256: f6e87c7ab2caa5a2b61ed7b52e58e571f9d71fac7d10e7e4bc010c1826dc602d
+  md5: 54c8454b6a713512351de2e40360baa3
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 33817
+  timestamp: 1759310586944
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h2c707e6_14.conda
+  sha256: f6c3b9b5df1c91df01dab59c230517d878a1ed4b734806caa2f4bea24ad24d21
+  md5: d2de3bbc76d002609bd2bf78cdb69b73
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 33763
+  timestamp: 1759315102060
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h31f38b3_14.conda
+  sha256: 805c81229c5f48286532d653186dc15a75e0445e6069201d0db34af00d048a24
+  md5: 87418a6eb712153620b15b9d9c38226e
+  depends:
+  - elfutils
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - elfutils >=0.193,<0.194.0a0
+  license: BSD-3-Clause
+  size: 338815
+  timestamp: 1759310223167
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h2c707e6_14.conda
+  sha256: f4e981921099f0aecbfe6168f4c4054fc7a6d3a1e36fdbb3b5deb107b270c2e2
+  md5: f76e2f8ed6f583cef67fd7f594f8589c
+  depends:
+  - elfutils
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - elfutils >=0.193,<0.194.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 328668
+  timestamp: 1759314694469
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-bicycle-steering-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 5fddfb28ea1296b1a456f9404e49b1c1d7e28f5d26c3322339033130b943183e
+  md5: b1a33fd568ba407ec771fd32b642db6f
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 102614
+  timestamp: 1759317084183
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-bicycle-steering-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 6dfe76cc3099769125d2d10ab79935872003553afbb079a5aac2bdb090086f76
+  md5: 81c72f0df8209e29e12c64a3b7452616
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 102337
+  timestamp: 1759321115250
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h31f38b3_14.conda
   sha256: 507b42d73b4d9ce9259899bfb13e07a86fea50b92e7490ec891c5a252a2274f0
   md5: 83c58dc63deca446446399c0413f3a72
@@ -31613,6 +42283,50 @@ packages:
   license: BSD-3-Clause
   size: 81711
   timestamp: 1759316706571
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-chained-filter-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: cdb74c88ce8644bfe14e42141bfe80ff267c38a05e4a05f54f90470acd42cb6d
+  md5: 4f230c4cf01c73e6be24a9698ca546b8
+  depends:
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-filters
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 209976
+  timestamp: 1759316750277
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-chained-filter-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 1b5ac96a8cb18471c8d761be1e95f6495ffb64f4fda10f28b785a545b113f6c4
+  md5: 1221823c138df79cb8c47f8adc69edda
+  depends:
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-filters
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 210028
+  timestamp: 1759320788132
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.0-np2py312h31f38b3_14.conda
   sha256: 1811acc37d8c97bd44c565c90a86c1dd6a64947a8a979bd4da9044d65a98ebf8
   md5: 804ccaf6b67fa17ab4d7a34e44587a02
@@ -31779,6 +42493,266 @@ packages:
   license: BSD-3-Clause
   size: 27464
   timestamp: 1759316039283
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.5.0-np2py312h31f38b3_14.conda
+  sha256: aa9b611a79dc0ad19c31f39a105dddd771beeeed4e6208708b999957b0a85b3b
+  md5: 9b4a85d35336c4b121cbde720b24d9e0
+  depends:
+  - python
+  - ros-kilted-action-msgs
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-diagnostic-msgs
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-trajectory-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 1507140
+  timestamp: 1759312832551
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.5.0-np2py312h2c707e6_14.conda
+  sha256: c8b823c50ad7a549ba36085d03fe030e26edf9945ea9ef9f38d389406cc5636a
+  md5: a07bde04a64a6bd76174eddcc7812ac3
+  depends:
+  - python
+  - ros-kilted-action-msgs
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-diagnostic-msgs
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-trajectory-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 1502544
+  timestamp: 1759317337356
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 94b846b053beba57623a428fa31b1da771acf649849a6148fcce9585e73eecd7
+  md5: 5fd802567872d41dfe435c7bcf3a486d
+  depends:
+  - eigen
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-filters
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcutils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 276142
+  timestamp: 1759315287561
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.7.0-np2py312h2c707e6_14.conda
+  sha256: f7e37265e798093fb6c6d1c1e771db431232aef5448daba27641fee9afa20db8
+  md5: 01b6b9c534034b208e232f157eadd6b2
+  depends:
+  - eigen
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-filters
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcutils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 273872
+  timestamp: 1759319516113
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.6.0-np2py312h31f38b3_14.conda
+  sha256: f652b26884af18d6f844ede7b6565712f09670b595aa49be16b8cf672317aada
+  md5: 38c9ba82905352f83b2341a7311e6cde
+  depends:
+  - python
+  - ros-kilted-hardware-interface
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 120591
+  timestamp: 1759315492535
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.6.0-np2py312h2c707e6_14.conda
+  sha256: da7d1bc40061b3845a331f1aafa1174cc42b3794cb0ebdab999ad870d706aba7
+  md5: 0b80bc3ede01cb814cef372ba3b8e37c
+  depends:
+  - python
+  - ros-kilted-hardware-interface
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 120987
+  timestamp: 1759319706978
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.6.0-np2py312h31f38b3_14.conda
+  sha256: fc73b37cb109b1e6c115b88dc5f7b03adbb8a9f533a0d3b73f1d2f002c8b6f2f
+  md5: d6edd86efd32a07d86c294d41362de12
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-controller-manager-msgs
+  - ros-kilted-diagnostic-updater
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-libstatistics-collector
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2-control-test-assets
+  - ros-kilted-ros2param
+  - ros-kilted-ros2run
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 630658
+  timestamp: 1759316281798
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.6.0-np2py312h2c707e6_14.conda
+  sha256: a352ccddc164ab17e2247ce20cee37c30ec397ff07d2bd628d606b472ee2cd69
+  md5: c71579f55a8701b4b3aaee87819057d1
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-controller-manager-msgs
+  - ros-kilted-diagnostic-updater
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-launch
+  - ros-kilted-launch-ros
+  - ros-kilted-libstatistics-collector
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-ros2-control-test-assets
+  - ros-kilted-ros2param
+  - ros-kilted-ros2run
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 601684
+  timestamp: 1759320279020
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.6.0-np2py312h31f38b3_14.conda
+  sha256: b8f7dc468daf442812442426978d57aaf05b8083ede7ee2e8ee42d8ac55b0942
+  md5: 9fd05c19fbcdd0966a1060b4e3298b82
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 555746
+  timestamp: 1759312534548
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.6.0-np2py312h2c707e6_14.conda
+  sha256: 51ab887dcb0dc95faf68879163bc121a3087b687e0cff57e22c615fdc5c2ec57
+  md5: 0eb39e8d549508a676186a0d1e73c56c
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 557259
+  timestamp: 1759317059897
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h31f38b3_14.conda
   sha256: ff2d6efe581c2c7257e527d5d02bb1205893cba7428db702c1046d1f56bd2eab
   md5: e748294eb8a1bc67ed697cd5f253c3a1
@@ -31861,6 +42835,177 @@ packages:
   license: BSD-3-Clause
   size: 215730
   timestamp: 1759317164340
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h31f38b3_14.conda
+  sha256: 19d6a46bb7dd6a9a2962e1aac3adb7622df8e6a434e41a8142974fdc97b2c581
+  md5: d88ec46d33b24d0bf6bcb5f3e8a10bb8
+  depends:
+  - python
+  - ros-kilted-diagnostic-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 185072
+  timestamp: 1759314637403
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2c707e6_14.conda
+  sha256: 32bdde45c93439d0daf226c31308e760f7f2dc51a28663ab94f87dbbec69aab9
+  md5: 0bd666aa3edd531b4dcdbe45f5a8eb0a
+  depends:
+  - python
+  - ros-kilted-diagnostic-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 187920
+  timestamp: 1759319018271
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diff-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 24817811fbd5697472c03593f25b64797b196d42f7a6c91c4279347eae01ccc2
+  md5: a2c747d9c62973365737521eacf65339
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 319380
+  timestamp: 1759316634832
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diff-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 50284688d691a7d6077dc1e1cdca671340e854e5a0d75624b2532c55acaf9c6f
+  md5: 63e39dbcadcee8a38ba6010fd9bf1950
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 305100
+  timestamp: 1759320638543
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-effort-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 5905d3b1bfc422ce0359cd79ac8be31bddfb61d8cc51fe80548ed12aa3615332
+  md5: 033e93b79c1b7183bb4bafe8191f16d8
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 81469
+  timestamp: 1759317053107
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-effort-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 0e54e174ff62ea5095846ffb76822c10716fcc945b1b09cf674ecf6c6f67d385
+  md5: 7551d8476e62ecf1fc0176bf8e56b225
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 82862
+  timestamp: 1759321076228
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h31f38b3_14.conda
+  sha256: 8ec120467ada7c3bb14ba1366f5f42c7ec21850a0a527dd0f2d23e456fec4329
+  md5: d76bb4b688d63b15273a83463790abf2
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23403
+  timestamp: 1759310868002
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2c707e6_14.conda
+  sha256: 1e75c3372cfc8306b8caa5648a39e00c4ba78aff3279b2b9d3811a4f325142ca
+  md5: 5d15ba0b80703c79108c04d4dd9b929c
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 23317
+  timestamp: 1759315389496
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.0-np2py312h31f38b3_14.conda
   sha256: e230223ee52bc9e79513ac11aafb4221f0d9ccbae9c3263b93312b1eb931b135
   md5: d49e20a0ffea33e54426f395ec5aeee8
@@ -31937,6 +43082,45 @@ packages:
   license: BSD-3-Clause
   size: 4638102
   timestamp: 1759315700928
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h31f38b3_14.conda
+  sha256: d04de568f1b01e2285316702e3fc6a1009e8dc7adc04958c02965c22e4aef209
+  md5: aec0a98296a4ab89f3c1ebbbc9e4c3e1
+  depends:
+  - libboost-devel
+  - python
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  license: BSD-3-Clause
+  size: 134759
+  timestamp: 1759314149714
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h2c707e6_14.conda
+  sha256: dcb71c3a486413114ff9070e7b284832b5af49a2b4cd5eec22cd4724d3b75379
+  md5: 63c4b87f5c42bf6c376594094c894172
+  depends:
+  - libboost-devel
+  - python
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - libboost >=1.86.0,<1.87.0a0
+  license: BSD-3-Clause
+  size: 135159
+  timestamp: 1759318611328
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h31f38b3_14.conda
   sha256: b1e731c5e31966e1eb431ace17a10cc7e47f6f5262fb45448f39ce20ef41533e
   md5: c6a428ca8ce83ba4fef28cc4ccf582a6
@@ -31974,6 +43158,199 @@ packages:
   license: BSD-3-Clause
   size: 19389
   timestamp: 1759315473522
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-force-torque-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: f6a9e33ba50ba4a0438a9e5fbf132b38bb43d50674ff102dfe536abd530b9dd9
+  md5: 355dd7b883f0a3f62cc690424103fc5e
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-filters
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 274622
+  timestamp: 1759316692885
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-force-torque-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 94f635b8a70a7e726b4f59259bbd4373519576cd5b442202be9467b3d5fee1d3
+  md5: f4a1b483980b62f61897d08b85695a83
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-filters
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 267925
+  timestamp: 1759320716270
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-forward-command-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: cb2594d498ed13b44aa997ef5cace2e267ae315032523fb09584d93aa3ebd482
+  md5: 0936068d3448d4dc095405e1648a2c2f
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 230038
+  timestamp: 1759316638095
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-forward-command-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: e2f20881ebcf912309c8aa4ac140e4ba8ada0a7f8899b2c2ec58bd6dcbba7e31
+  md5: c71b70cb749b6a38dab9836a6b31651e
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 224973
+  timestamp: 1759320636548
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.5.0-np2py312h31f38b3_14.conda
+  sha256: 29470c0b412720cd0db8a255656dffa8ef02bf1354dcef86a1e1c0fa91d844d2
+  md5: 688baeba94721b6485930e99a1b016e9
+  depends:
+  - fmt
+  - python
+  - ros-kilted-generate-parameter-library-py
+  - ros-kilted-parameter-traits
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 49354
+  timestamp: 1759314601831
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.5.0-np2py312h2c707e6_14.conda
+  sha256: 8bd2f2d89339740b062c3b1e5461aae210b20fb6fd875c2a001792295de58789
+  md5: 91a05fb6c8866c8c53e955a51514be8f
+  depends:
+  - fmt
+  - python
+  - ros-kilted-generate-parameter-library-py
+  - ros-kilted-parameter-traits
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 49297
+  timestamp: 1759318985562
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.5.0-np2py312h31f38b3_14.conda
+  sha256: 4a21d811fe95d8d655eb969ee44b8ba8a8a17a00623f1a60edf13cefd3ceaf01
+  md5: 0ac983029df650344aeb619197ed22ea
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - typeguard
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 70828
+  timestamp: 1759310462819
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.5.0-np2py312h2c707e6_14.conda
+  sha256: 3879a52f8c7168843a7773bd065bf5db392e20286f9c52deee63334b4716b7a4
+  md5: fdfc93c33a6ba3a50d42478dd95adcc3
+  depends:
+  - jinja2
+  - python
+  - pyyaml
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - typeguard
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 70862
+  timestamp: 1759314997081
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.0-np2py312h31f38b3_14.conda
   sha256: b049429ab24887be8d0136a3eb1a93dd040f241443f1f5ee593bcee60194a3d6
   md5: d078d7e4092b717b87fdb82fa11eb7d3
@@ -32044,6 +43421,99 @@ packages:
   license: BSD-3-Clause
   size: 122308
   timestamp: 1759314659385
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gpio-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: fc6d3016a6a118c9b731e1bd1aa5d48f371f8bcbd33bda6902b2fded164bfc95
+  md5: 70e6968008d8fe21d59bd5afbf5832b8
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 249326
+  timestamp: 1759316725549
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gpio-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 2bf5f0d1bce839f994e9c2a365d5d7a4e80163487444cc8f3dad91d0b6321b59
+  md5: cdbaa046da6eac222bae13874e033999
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 246270
+  timestamp: 1759320761087
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gps-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 7bff041bd7a2ceebff02f8a7eb5ebd86b949fcbc8f85f94d590fe07fa0df7709
+  md5: 4b3c6b36150f99080b629637e7326a7d
+  depends:
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 153172
+  timestamp: 1759316707443
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gps-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: ba593f9778d2e27ddb51efcb8d725e986c7b7ea4ae43b5cdc814ac96ea62b578
+  md5: da6d2234e28ab487981344b8a7292e0e
+  depends:
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 153564
+  timestamp: 1759320740787
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h31f38b3_14.conda
   sha256: 1c221c912c2f841fd386c6e800dc0eb611d0ddb301348d608148a6ba55374e00
   md5: 10d812ffa7281e3be081ab50d5e6bc27
@@ -32075,6 +43545,225 @@ packages:
   license: BSD-3-Clause
   size: 208713
   timestamp: 1759314593917
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h31f38b3_14.conda
+  sha256: c8611f5208c2885b54cd16d6e540379f9ae894159e238ae0c755dc3f9a0ba875
+  md5: f82aaefcb8b4e9a42712c74af56f6af1
+  depends:
+  - gz-cmake4
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 23910
+  timestamp: 1759310919801
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h2c707e6_14.conda
+  sha256: 4659ce21cac258441310661f87a4c57ec9aafd29290fdd9ae95e69aa0e32c068
+  md5: caca1410a146a0c29ae51124b01b4626
+  depends:
+  - gz-cmake4
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 23958
+  timestamp: 1759315477391
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h31f38b3_14.conda
+  sha256: 9a137dcf2d6751125c1f9d871294f2f5ddea8c2a8457face4df10db85f193bbf
+  md5: 771a7e841cfadd86b4f94278ae059433
+  depends:
+  - eigen
+  - gz-math8
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-gz-utils-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  license: BSD-3-Clause
+  size: 27837
+  timestamp: 1759311747240
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.5-np2py312h2c707e6_14.conda
+  sha256: 7ee0c7ee34dc8e2b1fdf1d4572ba956322cc72470483198297093c93c0040847
+  md5: 2f589c09179ccaa04d75396adf934cbe
+  depends:
+  - eigen
+  - gz-math8
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-gz-utils-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libgz-math8 >=8.2.0,<9.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 27821
+  timestamp: 1759316087959
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h31f38b3_14.conda
+  sha256: 75fead82f6241f9d7043bc946dd70d357d79e077ca9993594fac60a06d8061ea
+  md5: 8fdd246781b94eb63ffcd96ad3635297
+  depends:
+  - gz-tools2
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - ruby
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - libgz-tools >=2.0.3,<3.0a0
+  license: BSD-3-Clause
+  size: 27552
+  timestamp: 1759311191475
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2c707e6_14.conda
+  sha256: 2d5fbfafd48697da33957766878fe68a9dc2857f8d59e0f3c78ada24158ac213
+  md5: e1aaf2cc7d58f08559ff757e6c050f8c
+  depends:
+  - gz-tools2
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - ruby
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - libgz-tools >=2.0.3,<3.0a0
+  license: BSD-3-Clause
+  size: 27470
+  timestamp: 1759315699853
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h31f38b3_14.conda
+  sha256: de337e8a251dbd55118c55d7ec79d00d56bf2109ce5a7ebdaab9e2bd3847ab1b
+  md5: 7df7add25a818260ec0af9218948fe6a
+  depends:
+  - gz-utils3
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-spdlog-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 25885
+  timestamp: 1759311573227
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2c707e6_14.conda
+  sha256: 41d236c859b284c205cdf32c6528b2105110574159e7e228cfa2e61dfbcec998
+  md5: 2127d8fe6520b5d476167894bb0e66ac
+  depends:
+  - gz-utils3
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-spdlog-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - libgz-utils3 >=3.1.1,<4.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 25954
+  timestamp: 1759316005079
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.6.0-np2py312h31f38b3_14.conda
+  sha256: fea9e284218b675facbd6c814a03066903a1ecebbad3be50dc051a4f8a6aaa90
+  md5: 7b780077bc9f25629827bc3726dfd552
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-joint-limits
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-pal-statistics
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sdformat-urdf
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 426627
+  timestamp: 1759315190195
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.6.0-np2py312h2c707e6_14.conda
+  sha256: bc72537c15f452fb92058332a0595be46b1bdd80a1b4e7d836e36d84e694cd69
+  md5: 560c1cad08b730dce399b92c63eed120
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-joint-limits
+  - ros-kilted-lifecycle-msgs
+  - ros-kilted-pal-statistics
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-rcutils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sdformat-urdf
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 417601
+  timestamp: 1759319437437
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h31f38b3_14.conda
   sha256: fb5ca1b0e68a9d2255f78fa35589840627fd90ad0dba44a0203bafaaa4bb9770
   md5: 1153d03f8633c67ff4eaacca65b684ab
@@ -32176,6 +43865,444 @@ packages:
   license: BSD-3-Clause
   size: 572451
   timestamp: 1759314663301
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.2-np2py312h31f38b3_14.conda
+  sha256: 75c99546c408b79e28904965aa956e14fb49c5fc40ad47030c41abccafcbc63b
+  md5: d456b2ce4d4950e6c5198aa53d8ecd3d
+  depends:
+  - python
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 561832
+  timestamp: 1759314652820
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.2-np2py312h2c707e6_14.conda
+  sha256: e201900c4e7868ca08d4c5b2f2fc38d96c3f219bb1b1980ab12cd8051b9908bd
+  md5: e4f22bedbad4ef2bcc4e7e2ee5e45c12
+  depends:
+  - python
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 565335
+  timestamp: 1759319027136
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-imu-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: c0b4bdf6f89171bddc259de13b9d55e2679da18db2a983c978083d782d837630
+  md5: 952666e192e64910127042bcdce74c69
+  depends:
+  - eigen
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 166124
+  timestamp: 1759316686937
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-imu-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 3cdbcd9bfa5765711a6929f746bd7e7935c17e2776cebd86d168f3929ac9125b
+  md5: a050c0ea4b0491071deea3f490a39448
+  depends:
+  - eigen
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 165250
+  timestamp: 1759320718286
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.0-np2py312h31f38b3_14.conda
+  sha256: f664cacc1db1878307e4cf1616676513cd0db711175b6cc9d965c2af7a53ab4a
+  md5: 176c350a7e6ab7dde7495d4669ad436f
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 312894
+  timestamp: 1759315317503
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.0-np2py312h2c707e6_14.conda
+  sha256: 916e1cba6a075decb82937663ffbd1dda329dbad558b15edba515da1bba60efb
+  md5: cd3a523633086df59cc6f2e3913f46e3
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 309025
+  timestamp: 1759319555722
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.6.0-np2py312h31f38b3_14.conda
+  sha256: 83eb02a706815f2f0d47b8512488091e4283b7de8dd6cbb3443eda4d2b5a9b94
+  md5: 7975d201220fb1291845b6a34b936751
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-trajectory-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 145977
+  timestamp: 1759314939094
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.6.0-np2py312h2c707e6_14.conda
+  sha256: addd8d1a11af2d9b96109018be4dad33ea593bb6a4f6fab5792ae430875a31d6
+  md5: 255d804701c2f031075a64a2a1c7e454
+  depends:
+  - fmt
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-trajectory-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - fmt >=11.2.0,<11.3.0a0
+  license: BSD-3-Clause
+  size: 145895
+  timestamp: 1759319239581
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 889e981ad6a6b6751a48cc583cccb09b23d2af0a192bb46b3f1b61736dec3728
+  md5: 3ae02a91e504952aacb8da6d8c6a5662
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 186485
+  timestamp: 1759316834215
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 3af3aaf65c64b11db9892f7857a9e291ae948db49cb37ecc109e3031ac44540e
+  md5: 7b4c2032b18ad03c1e87fa9e0b215c93
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 183976
+  timestamp: 1759320840095
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: c95bf19b10c335c8fa34c84f0c4289a408d94e45febfb2245bae1e2c9fb8cbce
+  md5: a69be84d1cf924d3aa704fb7d71eaf88
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tl-expected
+  - ros-kilted-trajectory-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 436490
+  timestamp: 1759316663851
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 5d17d62e04e01b20a66cf8d13856f089e9d4214552b2b487a3d22f33d38b5c90
+  md5: 51fdad65a6f0c11df06a848f7a078e97
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tl-expected
+  - ros-kilted-trajectory-msgs
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 418660
+  timestamp: 1759320683971
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h31f38b3_14.conda
+  sha256: 4bca899d0302a0574f67979c246955e8b41468bea366e1a98a74f26c294d0372
+  md5: 495f8e0c263c2148b323c4c7bdff333d
+  depends:
+  - python
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdf
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 50171
+  timestamp: 1759313879544
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h2c707e6_14.conda
+  sha256: 7b6a85fc84e065794691d1b27f18f7f97eb73b94e1cd7a16625da09794aaad91
+  md5: 2d3fd13edc8d3e4f469a074c0839576e
+  depends:
+  - python
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdf
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 51038
+  timestamp: 1759318360002
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kinematics-interface-2.2.0-np2py312h31f38b3_14.conda
+  sha256: d3842b6f7bdd0372abe9068eaf2969daf3cfa68a4d4849d15d6508f61e6b047e
+  md5: fba0571fbe402a885da2d73a1b0020a1
+  depends:
+  - eigen
+  - python
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 46333
+  timestamp: 1759314566979
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kinematics-interface-2.2.0-np2py312h2c707e6_14.conda
+  sha256: d321384ea7ce5888999b2864d192d4a7315c15c46acdcf51de238f2be23516ab
+  md5: 1f6f9d4374841d6b9239c6d1f70d6009
+  depends:
+  - eigen
+  - python
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 47071
+  timestamp: 1759318943197
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.1-np2py312h31f38b3_14.conda
+  sha256: 5da60d8223860623a2ad89fcb36f5582271515b4f2527986e96674b3cf4832ff
+  md5: 872565d9309235254e2e11407c341a1d
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-sensor-msgs-py
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 63141
+  timestamp: 1759314144741
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.1-np2py312h2c707e6_14.conda
+  sha256: 0c1d7f8f7e3dcf963293213a48cdd0cfc97870ac8fd90d05d8796cccccc8f2c3
+  md5: 582a530c5f6d5d7a1e008f762320a4a0
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-sensor-msgs-py
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 62941
+  timestamp: 1759318582200
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.3-np2py312h31f38b3_14.conda
   sha256: f1c060dcbf10a361a715d0246b9a069fb07d3d675f4eb88ff4d51ae3751e12b2
   md5: f6974d1f562e6689da563b42a054eb13
@@ -32459,6 +44586,44 @@ packages:
   license: BSD-3-Clause
   size: 26253
   timestamp: 1759315372726
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.0-np2py312h31f38b3_14.conda
+  sha256: 88b69b5d365d71c09f4e12c0cd8c9c3f7afc8982e49e12525e56064070914a49
+  md5: fb216f0c74a2cc79631999f1aca8071b
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - libcurl >=8.14.1,<9.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 23759
+  timestamp: 1759310586289
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.0-np2py312h2c707e6_14.conda
+  sha256: 5ad0862a898f6477c8d19b86155f81c99779c6177b1ab1ca1263c309fe29c6f3
+  md5: f66829fda3c466ca3971b11a4e7fec69
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libcurl >=8.14.1,<9.0a0
+  license: BSD-3-Clause
+  size: 23619
+  timestamp: 1759315097993
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h31f38b3_14.conda
   sha256: 9ef1dc270c0691230100ccb859b7294562a9d43065455e9adb2d1247e8d1a8f7
   md5: bdae1170bc009c49ba70165b1db67096
@@ -32580,6 +44745,197 @@ packages:
   license: BSD-3-Clause
   size: 273546
   timestamp: 1759316865146
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h31f38b3_14.conda
+  sha256: a0f5ff0af2971a0bb9fb96c8762db0d9635196760af4c91af5fe0459c0467320
+  md5: 4ef448f4b5239838a352266f14ed5c2c
+  depends:
+  - python
+  - ros-kilted-nav-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 346732
+  timestamp: 1759312815970
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h2c707e6_14.conda
+  sha256: 85993f66b0f9eecce7995bcd65df77be2b8ee3f4ad38dd8b0f2156b14f9da936
+  md5: b57691a72594b025ef62cbd9c6af4896
+  depends:
+  - python
+  - ros-kilted-nav-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 352767
+  timestamp: 1759317319735
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mecanum-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 149dc442fc1a83d604f30a844dcdb0b6343dd52e7881ee767987efd8ec125c21
+  md5: 44f4e4a04f8ee9da6c6b26a4c738371d
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 298060
+  timestamp: 1759316637505
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mecanum-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: dbd500636b646d858f600b594df0bb0ec97485b40e802f4334982adeae2b62c8
+  md5: 33dd83dda818604de2024c29e5f176ae
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 288569
+  timestamp: 1759320640855
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.2-np2py312h31f38b3_14.conda
+  sha256: 955d721a9555e99619c9fec13b211d5d4bcd76120a33ab5d6ef82e82e3326e90
+  md5: 3a901a270d0b15a9826529d18ff865cd
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 86500
+  timestamp: 1759314328833
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.2-np2py312h2c707e6_14.conda
+  sha256: 2bb56a1d44ab4325f5144a4c34f5a65a7182e324949a23cfcfb30057704285eb
+  md5: a0df76380899232c1160219f26fbc3a2
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclpy
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 86854
+  timestamp: 1759318746312
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-motion-primitives-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 643677afe07fb6a1649ae5b9d1ca06a53b731b2b25fc2d09207de86bf4104251
+  md5: 134bf56b5b697966799251943818c6fe
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 161125
+  timestamp: 1759316751636
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-motion-primitives-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: b5c090ba2de33bf8ab9f52ba9808179e039f12a4644fb59d123ff96411c70e32
+  md5: 2b488c32b4925c18d99b375c7af1ad24
+  depends:
+  - python
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 157521
+  timestamp: 1759320767642
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.0-np2py312h31f38b3_14.conda
   sha256: 014ad1ece10651449f62cac9ae98a789598ed7a11fc7780228e8760c3a27dcfe
   md5: 0c7c17f432d25d215d522d4340c0a9a2
@@ -32621,6 +44977,103 @@ packages:
   license: BSD-3-Clause
   size: 326524
   timestamp: 1759317218183
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-omni-wheel-drive-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 7b8527d0974cf97c2806caaa629222a5738bbce52058d2b724a50a5e7b973d8f
+  md5: 4cb216119a16c0a1705cc0085001cb8a
+  depends:
+  - eigen
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 394330
+  timestamp: 1759316721631
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-omni-wheel-drive-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: b1e6f5354f600ff6ddb7dc2fd86bda1494b2d7c3473aaa1f871eb46b4ee11b73
+  md5: 6c1648f745da9afa31e3afdac458fea6
+  depends:
+  - eigen
+  - python
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 375984
+  timestamp: 1759320735362
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+  sha256: cb8e66be4d8d0368f63c8010d2e05e4396c4cf75d1e01992cede5281c0d9c22b
+  md5: 96a91044a4d54702a5dbcf69f4defd1e
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 27848
+  timestamp: 1759311210262
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2c707e6_14.conda
+  sha256: 22f3889cc2a8ed8488b160cf60720ea3bc890df552474ced771c0785c620f1e5
+  md5: d726c980aeb6297b1b4035abfe220c46
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 27863
+  timestamp: 1759315727305
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h31f38b3_14.conda
   sha256: 79a689a3ab80e40cf5e9f81cd2ff9cc14019ad5337f40529a263d5dd40d53c78
   md5: f77f054b05f31a42f318d83ecd2bbc1b
@@ -32655,6 +45108,235 @@ packages:
   license: BSD-3-Clause
   size: 64497
   timestamp: 1759314571738
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h31f38b3_14.conda
+  sha256: 0e5300c0e6f0ec788337522d47a8dc53607bdd77fae6a589e198ea90d19ad190
+  md5: a8a80cdac02f4f6555bc7d4b95722b9b
+  depends:
+  - libboost-devel
+  - python
+  - ros-kilted-pal-statistics-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - libboost >=1.86.0,<1.87.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 169964
+  timestamp: 1759314336255
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h2c707e6_14.conda
+  sha256: f2857f3a6996d091893c930fa20d4cc342b0a5e6c9925fd5911ffd1c78f68390
+  md5: edc06921d753372afd0546f8f4eb3847
+  depends:
+  - libboost-devel
+  - python
+  - ros-kilted-pal-statistics-msgs
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 168780
+  timestamp: 1759318760212
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h31f38b3_14.conda
+  sha256: f2109dd54cf458d7e573a43f2a6c8112a4444c27782ffe8fe6ae726299741d7b
+  md5: 0d46c2061c1ebdf2bcda3688ba4c360f
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 125927
+  timestamp: 1759312521793
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2c707e6_14.conda
+  sha256: 50e1870bb2f03119ae2e5f7b7480fbaf922a6c4a088d4cc3f98bade22d9d4081
+  md5: 58ef38ccb82f1f2a4928088e89154172
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 129915
+  timestamp: 1759317048897
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parallel-gripper-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 5b982d144f3b4d0dd7a769d0877c7d06adec46fb5add7c00d4c7d43b0c6bfec9
+  md5: fdbb7af3a766bd27539b4e8867e82efd
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 163861
+  timestamp: 1759316702787
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parallel-gripper-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 416b220a58fed8d213198cc32ca231ce88bf0c058dac349074cfc703b33dc0eb
+  md5: 00a0d6650a599f1adc1c31cef837da8a
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 159879
+  timestamp: 1759320714829
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.5.0-np2py312h31f38b3_14.conda
+  sha256: 7623f4b1260b0a6c1225351a735a8a25cbc328ecd0e612eea152c0db17bd334a
+  md5: a9a5bebdd7d27118ed93e24e40ac1c69
+  depends:
+  - fmt
+  - python
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - fmt >=11.2.0,<11.3.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 49800
+  timestamp: 1759314297848
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.5.0-np2py312h2c707e6_14.conda
+  sha256: 44134d64d795eb6d8072a974f8bb6ef85dd1d4a2d452fc923e6be6cd5c8d38bf
+  md5: 31ceb181848340c0c3cbf4a6123bf83a
+  depends:
+  - fmt
+  - python
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-rsl
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 49679
+  timestamp: 1759318706430
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pid-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: bab6821384e9bbb475452f7f95905782f58180065c4d04579479f22ce2b0c8f0
+  md5: 299899b6bc8c0f94a44cb1e2595a736b
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-parameter-traits
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 298206
+  timestamp: 1759316673488
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pid-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 746a33d13dfed5ce72fb675d04d05b176b0ea47d817ba736c7108e1794a536a5
+  md5: e555883e4f97a15f85ceaa19dd710fcf
+  depends:
+  - python
+  - ros-kilted-angles
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-control-toolbox
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-parameter-traits
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 288342
+  timestamp: 1759320681278
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.0-np2py312h31f38b3_14.conda
   sha256: 8321fcd0af84e8adfce3eb238fddddbfb4d15b9a5606dce75b05ac61e71599d8
   md5: 9336f57375044be6e3d8d3209b78f4fe
@@ -32697,6 +45379,262 @@ packages:
   license: BSD-3-Clause
   size: 44500
   timestamp: 1759317984761
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.3-np2py312h31f38b3_14.conda
+  sha256: 462e0749cac0345e91e195e21c77023b1278e663adc8eaee249dfda2b04a27fb
+  md5: 02be6bc7b72ee5f6808618fa7c9b7682
+  depends:
+  - python
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcpputils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 454766
+  timestamp: 1759314602810
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.3-np2py312h2c707e6_14.conda
+  sha256: c27bf5570ab8d7709c6d0688197a430cac83ae8e87b9d126433bfb92184bfc22
+  md5: 5d4ff2135e7bafea02c14b1a159101a8
+  depends:
+  - python
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-rcpputils
+  - ros-kilted-rmw
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 462501
+  timestamp: 1759318986843
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pose-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 6723efae26e2dde7389354358ace561d8417fae209d51b31036bbc108029a47d
+  md5: cd1bb6e650082bd62294f5d6eef9159f
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 170174
+  timestamp: 1759316676536
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pose-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 6776d18f0e4175ff2d5eaf4f3c4c8b314144b4f1efd8f3cc29eef57d4850d588
+  md5: 934fb4e146b6b8eff76e2cb2e49b3913
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 168882
+  timestamp: 1759320695608
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-position-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 39b90155ec635363465eecb648bee613616bcf843b34cea0e31440a1195d468b
+  md5: 36d5dae60c274b2220c6f73641395c60
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 79827
+  timestamp: 1759317053225
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-position-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 3073c6f95de7cb094e0b0a7d785f58c0d1e5284d69900ab6ba306cd4a01a3360
+  md5: 5b890086d4bb6671a712d5c1730c2473
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 80795
+  timestamp: 1759321078009
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h31f38b3_14.conda
+  sha256: 5db32d7341147306802e0bc7361f9849648296a0a97fb1939c7f7e462ef9f109
+  md5: 8952cb018e2171b9962e6f949c9658ad
+  depends:
+  - pybind11
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 23058
+  timestamp: 1759310582303
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2c707e6_14.conda
+  sha256: 3d2154c766b401b787d6938b9b24806c76505302630095a980af48d77bec058d
+  md5: 3decde499f81a7d352b18b12c66bd4e2
+  depends:
+  - pybind11
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 23008
+  timestamp: 1759315097774
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h31f38b3_14.conda
+  sha256: 09d83127d121adddad524cd6d790edc25ebac1664f173b15bcf91715697c1416
+  md5: 90bb257072626aa0912d511dfe17e449
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-pybind11-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  license: BSD-3-Clause
+  size: 27274
+  timestamp: 1759311585704
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2c707e6_14.conda
+  sha256: 6d31cf2d62c7e1f377725c72832c45dbf987901e5c31d4686bb0e9f8c72f11b9
+  md5: d5257e3faf2c009b880d8e32c004e6f8
+  depends:
+  - python
+  - python-orocos-kdl
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-pybind11-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python-orocos-kdl >=1.5.1,<1.6.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 27290
+  timestamp: 1759316018862
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-range-sensor-broadcaster-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 4fc879b7fbbf8e202b91092402f10f5c5dacfb6b1c3dc2d78e21ae75e1242199
+  md5: c3407673316b3cfb73b859a4afd48139
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 149300
+  timestamp: 1759316638334
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-range-sensor-broadcaster-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 90fecb3de80c3902e1143200c399961252b6632741cd247ad6bcbc9cf324b59a
+  md5: edfba50bc42f292a311b5227f8748e13
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 148346
+  timestamp: 1759320637153
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.1-np2py312h31f38b3_14.conda
   sha256: 83c36157d0d7bcdec4fbf8915093eb3989b054823c4971ccae669292fa143ad0
   md5: a57680fa1b91a95378d1467ce7d61ac6
@@ -33347,6 +46285,90 @@ packages:
   license: BSD-3-Clause
   size: 128089
   timestamp: 1759316020887
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.6.0-np2py312hdba20d8_14.conda
+  sha256: 000407cd91a84b1cd9342cbc42c2bfb706832099872cb09b693e2b78d8dd9184
+  md5: b0846e1362dfeeb022c954a9ab2f42c5
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libcap >=2.75,<2.76.0a0
+  - python_abi 3.12.* *_cp312
+  - libboost >=1.86.0,<1.87.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 66707
+  timestamp: 1759314319173
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.6.0-np2py312h96cef23_14.conda
+  sha256: c66f2fbae16b8daa573a747e5f0a6b04e0af889ad4c8f6f2aeb16315574db49d
+  md5: 503160461ae48609ee416c097f39fc15
+  depends:
+  - libboost-devel
+  - libcap
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - libcap >=2.75,<2.76.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 68713
+  timestamp: 1759318735096
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.0-np2py312h31f38b3_14.conda
+  sha256: cb913d25d246820476f2fe22b43339c64e8909d78cbb6cc1bb6f4f0d430deb63
+  md5: 976033a18fa9d61a5f1bd9ac358cdfa1
+  depends:
+  - python
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-ament-index-python
+  - ros-kilted-libcurl-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 58503
+  timestamp: 1759313375957
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.0-np2py312h2c707e6_14.conda
+  sha256: 0518a5dfd40f2508e359d58ee379582add1712e8df744d483fc7a176de7676f5
+  md5: e5811547457dc20d70b65ef831c652b6
+  depends:
+  - python
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-ament-index-python
+  - ros-kilted-libcurl-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 58995
+  timestamp: 1759317784292
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h31f38b3_14.conda
   sha256: 513b37e999756faa84d0fba3dc9e0a1a86c3f1e2ac2866e3ddbc00e570cfdbd4
   md5: 9051b564a101bce6d11208d01f373234
@@ -34012,6 +47034,61 @@ packages:
   license: BSD-3-Clause
   size: 328191
   timestamp: 1759316609930
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.2-np2py312h31f38b3_14.conda
+  sha256: 5594d113f1d49db669935eabaf1b39e2b205965511ae205cd6296472bbd564a1
+  md5: 339a85dd6459469b4d3fcaec124705d1
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-kdl-parser
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 266660
+  timestamp: 1759314983138
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.2-np2py312h2c707e6_14.conda
+  sha256: 9e4b129ac205e4dd84fe8d14a8c099f1d74f9184ad5df99115d38f284d9661e3
+  md5: 9527079aaf55902bd6e2b98879382105
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-kdl-parser
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 264106
+  timestamp: 1759319327511
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h31f38b3_14.conda
   sha256: 12f4c47e69c1a444e5428c797741d95b7836db1efc816f52bbad76e92e46c7b8
   md5: f1cbe5f0ba7aba686ebf54905a190a24
@@ -34169,6 +47246,121 @@ packages:
   license: BSD-3-Clause
   size: 35305
   timestamp: 1759314534167
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2-control-test-assets-5.6.0-np2py312h31f38b3_14.conda
+  sha256: 80c9bd84a72e345ace867396e527d7f1772a2ffc5440fb48181c0837153d8d40
+  md5: 5a6eba97f2917470f585c4786466aebe
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 31126
+  timestamp: 1759310573594
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2-control-test-assets-5.6.0-np2py312h2c707e6_14.conda
+  sha256: d12292efe7641aab30587ea8857f38b83f5de14b575b5bcd03761865fd9b04f4
+  md5: cf81cb0eb64676c1ab84895597ea2fac
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 31108
+  timestamp: 1759315085345
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: d1f20fc930b0f74c13a92a8c8e9c94feacf2cfc8f1253ec8cf0aee5a33341b88
+  md5: fcbdb80aaf205ecf94ff33979c4f9290
+  depends:
+  - python
+  - ros-kilted-ackermann-steering-controller
+  - ros-kilted-admittance-controller
+  - ros-kilted-bicycle-steering-controller
+  - ros-kilted-chained-filter-controller
+  - ros-kilted-diff-drive-controller
+  - ros-kilted-effort-controllers
+  - ros-kilted-force-torque-sensor-broadcaster
+  - ros-kilted-forward-command-controller
+  - ros-kilted-gpio-controllers
+  - ros-kilted-gps-sensor-broadcaster
+  - ros-kilted-imu-sensor-broadcaster
+  - ros-kilted-joint-state-broadcaster
+  - ros-kilted-joint-trajectory-controller
+  - ros-kilted-mecanum-drive-controller
+  - ros-kilted-motion-primitives-controllers
+  - ros-kilted-omni-wheel-drive-controller
+  - ros-kilted-parallel-gripper-controller
+  - ros-kilted-pid-controller
+  - ros-kilted-pose-broadcaster
+  - ros-kilted-position-controllers
+  - ros-kilted-range-sensor-broadcaster
+  - ros-kilted-ros-workspace
+  - ros-kilted-steering-controllers-library
+  - ros-kilted-tricycle-controller
+  - ros-kilted-tricycle-steering-controller
+  - ros-kilted-velocity-controllers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 22957
+  timestamp: 1759317311588
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 7f283cdf253795baddf6b7bfb00584918dadd3e7085f8670219f20e4de778451
+  md5: 71976bb62f9cbb153bc694f37b0ad1d6
+  depends:
+  - python
+  - ros-kilted-ackermann-steering-controller
+  - ros-kilted-admittance-controller
+  - ros-kilted-bicycle-steering-controller
+  - ros-kilted-chained-filter-controller
+  - ros-kilted-diff-drive-controller
+  - ros-kilted-effort-controllers
+  - ros-kilted-force-torque-sensor-broadcaster
+  - ros-kilted-forward-command-controller
+  - ros-kilted-gpio-controllers
+  - ros-kilted-gps-sensor-broadcaster
+  - ros-kilted-imu-sensor-broadcaster
+  - ros-kilted-joint-state-broadcaster
+  - ros-kilted-joint-trajectory-controller
+  - ros-kilted-mecanum-drive-controller
+  - ros-kilted-motion-primitives-controllers
+  - ros-kilted-omni-wheel-drive-controller
+  - ros-kilted-parallel-gripper-controller
+  - ros-kilted-pid-controller
+  - ros-kilted-pose-broadcaster
+  - ros-kilted-position-controllers
+  - ros-kilted-range-sensor-broadcaster
+  - ros-kilted-ros-workspace
+  - ros-kilted-steering-controllers-library
+  - ros-kilted-tricycle-controller
+  - ros-kilted-tricycle-steering-controller
+  - ros-kilted-velocity-controllers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 22862
+  timestamp: 1759321376632
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.1-np2py312h31f38b3_14.conda
   sha256: b9067769f7253971b95093a0cfa2cdfbe145f59a27d3edc880b53983d416804b
   md5: 7a1085b37fbcd5a322035bb488f56176
@@ -36021,6 +49213,53 @@ packages:
   license: BSD-3-Clause
   size: 27203
   timestamp: 1759315167627
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.2.0-np2py312h2cad078_14.conda
+  sha256: 5d508a969f7352ef0eb4ad106e48980f66803b3b89f3713b73028143d0efca84
+  md5: 33705cf7845fe702fe90068597689319
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - graphviz >=13.1.2,<14.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 62354
+  timestamp: 1759314105386
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.2.0-np2py312hcb96c97_14.conda
+  sha256: 95bf8b0fbf828a575837a0c1b558dee44dfe5c79d5dc9a69b6461fee98d289b0
+  md5: 1c4ffebda2d4bad5789f51e97f5ac65a
+  depends:
+  - eigen
+  - fmt
+  - python
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros-kilted-tcb-span
+  - ros-kilted-tl-expected
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - graphviz >=13.1.2,<14.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=11.2.0,<11.3.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 63668
+  timestamp: 1759318534338
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.0-np2py312h31f38b3_14.conda
   sha256: 30f4bd38ace26022eaa24d6d3276ed5bca644c9fcf63ffa57c5f349ac1134dc9
   md5: ae11d140e3ed3205234f3ea03a3fde76
@@ -36056,6 +49295,534 @@ packages:
   license: BSD-3-Clause
   size: 31441
   timestamp: 1759315947619
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 47146c977fc2b4b16ce6b0779b4f3d70d0fbbc05f3fca43bbac2c57c470a3ebe
+  md5: 02cc8fb336c7296bd685043dbcaa6ed3
+  depends:
+  - assimp
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - assimp >=5.4.3,<5.4.4.0a0
+  license: BSD-3-Clause
+  size: 24820
+  timestamp: 1759311129264
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.6-np2py312h2c707e6_14.conda
+  sha256: 7b94d9838850df288990833fec6378d52c7bfd30ec02fc8630205700bbc7407c
+  md5: 46f5789d77a89c93058af15b598c4ba4
+  depends:
+  - assimp
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 24700
+  timestamp: 1759315625811
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.6-np2py312h31f38b3_14.conda
+  sha256: cfb01e6a8e598fdd7bb4fd93318b7328ee4657c292b37825544e33bfbd953e11
+  md5: 7de2562aea6079920595f195d28f7df9
+  depends:
+  - python
+  - qt-main
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 872672
+  timestamp: 1759314972201
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.6-np2py312h2c707e6_14.conda
+  sha256: a108456346a4bbfaf63f629405362662d175e0f85ff28fc83144ee8c83c2c90c
+  md5: 7a34b8ff0795def8b27c3377c58f644b
+  depends:
+  - python
+  - qt-main
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros-kilted-yaml-cpp-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 867896
+  timestamp: 1759319272576
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 2e26e5f02f1fd4dee20dda6cbd0a16bacce86b49a129e52ec6edbbe3fc63d373
+  md5: 81ffd58d4751369add24162530d24e36
+  depends:
+  - python
+  - qt-main
+  - ros-kilted-geometry-msgs
+  - ros-kilted-gz-math-vendor
+  - ros-kilted-image-transport
+  - ros-kilted-interactive-markers
+  - ros-kilted-laser-geometry
+  - ros-kilted-map-msgs
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-point-cloud-transport
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-rviz-resource-interfaces
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 2304032
+  timestamp: 1759315782395
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.6-np2py312h2c707e6_14.conda
+  sha256: 281130bfd2724a8c4eca68d9ba37489ad9264c3f1c3a170dc70d0c28f06b012c
+  md5: f2d78072462375f54710cd274aff3f84
+  depends:
+  - python
+  - qt-main
+  - ros-kilted-geometry-msgs
+  - ros-kilted-gz-math-vendor
+  - ros-kilted-image-transport
+  - ros-kilted-interactive-markers
+  - ros-kilted-laser-geometry
+  - ros-kilted-map-msgs
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-point-cloud-transport
+  - ros-kilted-rclcpp
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-ogre-vendor
+  - ros-kilted-rviz-rendering
+  - ros-kilted-rviz-resource-interfaces
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-ros
+  - ros-kilted-urdf
+  - ros-kilted-visualization-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 2316715
+  timestamp: 1759319924009
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hb5dd976_14.conda
+  sha256: 921c0df5f205784677e944a508ad324616c58abb46eede1af1c6cbab03083b30
+  md5: b7b4de657b5f9937e26c5a30e1567928
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - pugixml >=1.15,<1.16.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libglu >=9.0.3,<9.1.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - glew >=2.1.0,<2.2.0a0
+  - python_abi 3.12.* *_cp312
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - freeimage >=3.18.0,<3.19.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  license: BSD-3-Clause
+  size: 5287574
+  timestamp: 1759310893597
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.6-np2py312hdb042cc_14.conda
+  sha256: 70a6ba51e0007ef261ddb423794092789e952c033b61528a9f16a74577a5783c
+  md5: 832000d829b2fb709b5ebf2eec7c596d
+  depends:
+  - assimp
+  - freetype
+  - glew
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - xorg-libxext >=1.3.6,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libglu >=9.0.3,<9.1.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - pugixml >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 5173036
+  timestamp: 1759315450383
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 641e0cf15e4e5f26b47f3333e92b4e45dbc0d559616cb096cdff139a11f4e9e8
+  md5: f4f5fabb4c53a021add6677d34e34523
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-assimp-vendor
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - glew >=2.1.0,<2.2.0a0
+  license: BSD-3-Clause
+  size: 940718
+  timestamp: 1759313609249
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.6-np2py312h2c707e6_14.conda
+  sha256: 778738fab8e02fdd1dd155e24bed881a56e4cb8be1371e2917366de1629ceb0c
+  md5: 69bba8f7ede82282e285455a0495c9d5
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-kilted-ament-index-cpp
+  - ros-kilted-eigen3-cmake-module
+  - ros-kilted-resource-retriever
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-assimp-vendor
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
+  - glew >=2.1.0,<2.2.0a0
+  - python_abi 3.12.* *_cp312
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 932940
+  timestamp: 1759317990085
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 2189c4771d5bfc0f0f2908dd0b34ab6638e22e422e2d821d5641c7bb916fedb6
+  md5: bd6a0d08f7f22c5dd98e6f1f3d486137
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 126450
+  timestamp: 1759312300235
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.6-np2py312h2c707e6_14.conda
+  sha256: ded645c08c396f7f59c434386b60c796dfe9506c5cd8be538f383d37de90e3f1
+  md5: c23e3300254dcfa51055d26f482215b1
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 130941
+  timestamp: 1759316864203
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.6-np2py312h31f38b3_14.conda
+  sha256: 10102f02227a8518fda2c9e0849375986fff03f6b675eecdb1db54b5cc9291d4
+  md5: 39aac8a66fcee137a7a04560388b510c
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-default-plugins
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 77948
+  timestamp: 1759316283890
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.6-np2py312h2c707e6_14.conda
+  sha256: 2972ee38291b99d71fc0107abf6e1afa7236032d51ed6984836fe047b65cd294
+  md5: 971273e26ff62e2a7f1fe7a10a2ae37c
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-rviz-common
+  - ros-kilted-rviz-default-plugins
+  - ros-kilted-rviz-ogre-vendor
+  - ros2-distro-mutex 0.12.* kilted_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - libgl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 78972
+  timestamp: 1759320277483
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h31f38b3_14.conda
+  sha256: baa787af6a994d00582660a0fe9b3fb8ffefa8f29022547f98f1a0bc416e4c7d
+  md5: a83f3c8166d062d53de9a878c2a7e8c6
+  depends:
+  - python
+  - ros-kilted-ament-cmake-ros
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-sdformat-vendor
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros-kilted-urdf-parser-plugin
+  - ros2-distro-mutex 0.12.* kilted_*
+  - urdfdom_headers
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 88037
+  timestamp: 1759313868061
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h2c707e6_14.conda
+  sha256: df67c340461ef807f8c837628723b4a923fb19fd878eb9cc2c620c1a68e728ad
+  md5: b123043f93728c2b8f32c8a7db6101b2
+  depends:
+  - python
+  - ros-kilted-ament-cmake-ros
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-sdformat-vendor
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf
+  - ros-kilted-urdf-parser-plugin
+  - ros2-distro-mutex 0.12.* kilted_*
+  - urdfdom_headers
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 91384
+  timestamp: 1759318348357
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.6-np2py312ha3ea0c0_14.conda
+  sha256: 8359a482c984af86ceb496a5d1f042382081d0fcdfc262749d240a6f30ebe9cc
+  md5: abceaf5af9a61e4c7c86d14386f641ec
+  depends:
+  - pybind11
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-gz-math-vendor
+  - ros-kilted-gz-tools-vendor
+  - ros-kilted-gz-utils-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdfdom
+  - ros2-distro-mutex 0.12.* kilted_*
+  - sdformat15
+  - tinyxml2
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libsdformat15 >=15.3.0,<16.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 32001
+  timestamp: 1759311820837
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.6-np2py312hca9473c_14.conda
+  sha256: ead4b7f84cc0f386cb56961bd3850070ea0beebb1d9ce19dedc18460a7020389
+  md5: 277398b49afd5ca49361bb33d5886f97
+  depends:
+  - pybind11
+  - python
+  - ros-kilted-gz-cmake-vendor
+  - ros-kilted-gz-math-vendor
+  - ros-kilted-gz-tools-vendor
+  - ros-kilted-gz-utils-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdfdom
+  - ros2-distro-mutex 0.12.* kilted_*
+  - sdformat15
+  - tinyxml2
+  - libstdcxx >=13
+  - libgcc >=13
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - libxml2 >=2.13.8,<2.14.0a0
+  - python_abi 3.12.* *_cp312
+  - libsdformat15 >=15.3.0,<16.0a0
+  license: BSD-3-Clause
+  size: 31958
+  timestamp: 1759316183769
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.0-np2py312h31f38b3_14.conda
   sha256: 3421ea3741f3933c695e450e6e98c75f43dbecff9991312addcb0d63765ed559
   md5: 64380666a25f8ff034fcb5f8552b66ab
@@ -36096,6 +49863,45 @@ packages:
   license: BSD-3-Clause
   size: 554605
   timestamp: 1759317242493
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h31f38b3_14.conda
+  sha256: 0e60856e1945275334f50c24708ac78cfde76c94c6e1850172e04df5e5845ab9
+  md5: 277ccf11f40147a85c6b7024f3a42b3e
+  depends:
+  - numpy
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 30746
+  timestamp: 1759312875115
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.0-np2py312h2c707e6_14.conda
+  sha256: 1d7624b1b6e6eca5ea44f8f024cb7b4b7af366799a7f5837ff53906e89d7a894
+  md5: 5eb55e9cb74ebfa0f4c249b8c13d1d55
+  depends:
+  - numpy
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 30840
+  timestamp: 1759317383083
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h31f38b3_14.conda
   sha256: 819e548ec1d453053ce9a11f89309ca1e9c344719753856c579cca9c4b5ca444
   md5: 92fcab071a437f8800a55948469178dc
@@ -36392,6 +50198,70 @@ packages:
   license: BSD-3-Clause
   size: 172595
   timestamp: 1759316901741
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-steering-controllers-library-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 2bf06c7856c5c6d7f861b1db1b73af8fe6065963488a347ed5886c015b03588b
+  md5: b634dd601ff224e69cd2a3f2373a85e1
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 298775
+  timestamp: 1759316803333
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-steering-controllers-library-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 5eb28c0cc4ff0f19732f9834c5de800c0f4388450637e046adbd8e6f97d7694b
+  md5: acc10de7e5f84f70a6498599c21f681e
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-generate-parameter-library
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-geometry-msgs
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 290084
+  timestamp: 1759320808600
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.0-np2py312h31f38b3_14.conda
   sha256: 5518360853b03fef83ced1de2de11ea16f5d962970cbcfd7af7ecbca73c95040
   md5: fa2ce7ae65bd4be6346053632750aa33
@@ -36431,6 +50301,386 @@ packages:
   license: BSD-3-Clause
   size: 85096
   timestamp: 1759317449991
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.0.2-np2py312h31f38b3_14.conda
+  sha256: 5a9ac07b69b34587935660bfe5890da932680ad9a7e47785466ae7e5875e7488
+  md5: 9377927fdb83761dbb300cf410f0f79d
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 27817
+  timestamp: 1759310592057
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.0.2-np2py312h2c707e6_14.conda
+  sha256: 8177d32d8d4b5100852e0c513e166bf4ceaa5813208247ddcb1211c20858332e
+  md5: 8f5a97813bf99cc02ad930390ee8d20a
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 27708
+  timestamp: 1759315107473
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 0e82022c58250244fead9fdee101c20ec87cfaeb459a4a532f20a8ae9d878d3b
+  md5: f0bcbace2c659dd37e7de38ed29988fe
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 135241
+  timestamp: 1759313405626
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 2f9eb7f151442476031d89327cd10d37cc00a89a01a4c052cb312740e586c0e1
+  md5: e1e7f65a190e7886879c3b01877626be
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 131745
+  timestamp: 1759317833258
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.2-np2py312h31f38b3_14.conda
+  sha256: f47907a22233c1431544a989313a5e573da5f3040db2e623d37c2cdd55e14fda
+  md5: 32305e97b6809bdae24378d3850bf323
+  depends:
+  - eigen
+  - python
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 45055
+  timestamp: 1759314966081
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 8baf039192dea6d12aa303b61e9dfea70b47bc0ba7210f9cac66e65be566b656
+  md5: cab7cbc52d7e9fd00571dbee6c712144
+  depends:
+  - eigen
+  - python
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 45103
+  timestamp: 1759319266478
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h31f38b3_14.conda
+  sha256: dd9ce78181cd57a880d7df0334fb0c329e06a7681dd3e10a0161859271367f23
+  md5: bbd1c26df93c03d93937e42b5370cc2c
+  depends:
+  - numpy
+  - python
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 57642
+  timestamp: 1759314958338
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 5b60b58420eead7dfcce5bab95a7af21b52e3cc6f22634d5b1b2fa395c79e189
+  md5: 814c4ebcc2acfa352a4568bec62cbfcb
+  depends:
+  - numpy
+  - python
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 57704
+  timestamp: 1759319259116
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.2-np2py312h31f38b3_14.conda
+  sha256: da44bfad8f60c26756a57d137221c9574def10fe05c032fde5f9ad0a49eab5dc
+  md5: 7dec5dd5543200e5e6fc62fef685c785
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-python-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 46569
+  timestamp: 1759314940647
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 1690fc971cd84e489aa7dd52c35972680e2579e6282f12516934eb0b38f1a742
+  md5: 042ef9480f7d35d1bffe6eb859b450d1
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-orocos-kdl-vendor
+  - ros-kilted-python-orocos-kdl-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-ros
+  - ros-kilted-tf2-ros-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 45227
+  timestamp: 1759319233330
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.2-np2py312h31f38b3_14.conda
+  sha256: cafa456644eb71935ad3c2f1918ec747ad13ad9e58b7d9f418bddd65182ee607
+  md5: ce51ccce8f106e349e665cc2f98ddab4
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 258479
+  timestamp: 1759312673587
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 2bc26dad33ff669b501329eabf8b6c1417204b672464b7b05b2e77a0ff35ef83
+  md5: 9decb7b093683472a4f947d198272fe4
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 263573
+  timestamp: 1759317190604
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 36221497e622a668ec22e541613b69bf21a8e557206a0a56730441920c285531
+  md5: d155c3e828d8a5fbf338acae195989f1
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rpyutils
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 55612
+  timestamp: 1759314129362
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 818408f16b347c407b176247c8c5cf5d283e648c72715a20647a919e4240d759
+  md5: e66e30049def0b2a8e0cb2f46999d8e6
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-rpyutils
+  - ros-kilted-tf2
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 54184
+  timestamp: 1759318573962
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.2-np2py312h31f38b3_14.conda
+  sha256: 8413ab802da172deffffb361f2c15a80693ef0cf24030ec6ad1f6db99f438d01
+  md5: b99fc62a76f4a868e15b13183255ae04
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 467964
+  timestamp: 1759314636321
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.2-np2py312h2c707e6_14.conda
+  sha256: 29c610e6de40037e58fc80188356d3c624858ac8eb8f0d07e3a7eaccbd775cdf
+  md5: 31e731b7fcdb170f746b3271f6db8da8
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-message-filters
+  - ros-kilted-rcl-interfaces
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-action
+  - ros-kilted-rclcpp-components
+  - ros-kilted-ros-workspace
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 474822
+  timestamp: 1759319045410
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.2-np2py312h31f38b3_14.conda
+  sha256: df6143fa14de312f8480c8476afad4c935cdad58aa9e74cb8d0cd113807d2db7
+  md5: eab06e6404bbf90827d57edd1a77fcbc
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-msgs
+  - ros-kilted-tf2-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 48731
+  timestamp: 1759314332236
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.2-np2py312h2c707e6_14.conda
+  sha256: a269c719003fe4ecf1430c06b0c862c03b6ff03157710824a394db7ad27fe471
+  md5: 533bd261b943860de871fb821fbea373
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-geometry-msgs
+  - ros-kilted-rclpy
+  - ros-kilted-ros-workspace
+  - ros-kilted-sensor-msgs
+  - ros-kilted-std-msgs
+  - ros-kilted-tf2-msgs
+  - ros-kilted-tf2-py
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 48754
+  timestamp: 1759318744271
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.0-np2py312h31f38b3_14.conda
   sha256: 664a4d0e41a758f6f193de8e9512ca143e7c36e4e7f5a9f5c179393e8baf9a9f
   md5: d3d4fd3b0961da8dcfefb10e491be400
@@ -36467,6 +50717,38 @@ packages:
   license: BSD-3-Clause
   size: 24274
   timestamp: 1759315062241
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.0.2-np2py312h31f38b3_14.conda
+  sha256: 2b2edc98f2bf0aab768609d178d4d0d82f579e81e36790b516793c7a053c24e7
+  md5: b1d37693f75aa912a2be67ad2ec6acd6
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 33346
+  timestamp: 1759310587514
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.0.2-np2py312h2c707e6_14.conda
+  sha256: 8023205b8e1d48b7f4f26ebfe28f36810171eff23f06c51949583ce20535640b
+  md5: 4f5322f195717fb3edb01d44d5d76697
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 33271
+  timestamp: 1759315103308
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h31f38b3_14.conda
   sha256: d5566180b6d0b80437f921482c1326cc19a1317177b1e4401d33eea055ca9517
   md5: 61a009492f44fa9c8c53ee58e30abe07
@@ -36543,6 +50825,117 @@ packages:
   license: BSD-3-Clause
   size: 151561
   timestamp: 1759317280796
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tricycle-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 757bf08a39ff313b3eb670e2fa9890957eba2336fa02fc2f29d28991d9bfbec1
+  md5: fcbb37a65935381c3ae3287e7f10f885
+  depends:
+  - python
+  - ros-kilted-ackermann-msgs
+  - ros-kilted-backward-ros
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 316770
+  timestamp: 1759316727453
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tricycle-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: 2c8a00d9e2bb511091c557c554e4d489bacab7a43052d9e78a82d00c5de3a87e
+  md5: 65dd142f09d04b102b52ca04dc99843c
+  depends:
+  - python
+  - ros-kilted-ackermann-msgs
+  - ros-kilted-backward-ros
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-controller-interface
+  - ros-kilted-geometry-msgs
+  - ros-kilted-hardware-interface
+  - ros-kilted-nav-msgs
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-rcpputils
+  - ros-kilted-realtime-tools
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-tf2
+  - ros-kilted-tf2-msgs
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 304029
+  timestamp: 1759320759061
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tricycle-steering-controller-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 1927daf7dd9adcdef04b279acec02ae58c45a06ee097e167195b13ee8b0f5a7d
+  md5: d85b147250d84ccbf30ca10ce12f2182
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 104249
+  timestamp: 1759317229240
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tricycle-steering-controller-5.7.0-np2py312h2c707e6_14.conda
+  sha256: d27b0fb20fd7a63d4636d9b2027704ff9791173b30d8af9dc89dc306cbb594ba
+  md5: 6d168b1ea6701e828dffb9f800f7c3cc
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-control-msgs
+  - ros-kilted-controller-interface
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-rclcpp-lifecycle
+  - ros-kilted-ros-workspace
+  - ros-kilted-std-srvs
+  - ros-kilted-steering-controllers-library
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 103266
+  timestamp: 1759321252624
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h31f38b3_14.conda
   sha256: 5d110f81291d7d35c9f49a4cd12ba8c0a98346dd11f9b7e7cf9fe5cabe02efb7
   md5: b3170b9c4d7f084ada2f5c0b4feacd89
@@ -36650,6 +51043,192 @@ packages:
   license: BSD-3-Clause
   size: 75286
   timestamp: 1759316715880
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.2-np2py312h31f38b3_14.conda
+  sha256: e01ea4a3b15d6047d768a0d425c63a8397c074f65ddaf1aed2ef4ed87bdb4ded
+  md5: 10fc4a3b24552f0106e23a0379b8e932
+  depends:
+  - python
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf-parser-plugin
+  - ros-kilted-urdfdom
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 157992
+  timestamp: 1759313704911
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.2-np2py312h2c707e6_14.conda
+  sha256: 4878c12d9386ffa92db52c5d028b9880b7232c65b5c975a42af741c027712b88
+  md5: 661126711b221fa5e7bdbfed19ef196c
+  depends:
+  - python
+  - ros-kilted-pluginlib
+  - ros-kilted-rcutils
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdf-parser-plugin
+  - ros-kilted-urdfdom
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  license: BSD-3-Clause
+  size: 158240
+  timestamp: 1759318106784
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h31f38b3_14.conda
+  sha256: 9f1f097b7f40d5721b63bf43603a3458305207c8a0d8d27bde54298ea6301e83
+  md5: 6dc2127774486b4d274b079d80921037
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 35339
+  timestamp: 1759313400256
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.2-np2py312h2c707e6_14.conda
+  sha256: 70df2f25a41be47a9c61e806b95cc47e0d955363f1e0efc37ddf8dcddc0dbabf
+  md5: 78f0dbd7884728bd3dc16dfb8c11b4e4
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 35341
+  timestamp: 1759317827352
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_14.conda
+  sha256: 41d74d8a275f9900b0467527640675e31e7acc7f0f0f7372611ca07d735e7dd0
+  md5: 9e10c205e7b8be8f7170244d9765c842
+  depends:
+  - console_bridge
+  - python
+  - ros-kilted-console-bridge-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - tinyxml2
+  - urdfdom >=4.0.1,<4.1.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 8043
+  timestamp: 1759311771528
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_14.conda
+  sha256: dda94b0d8b5f39f567d9ea251bcf21bd03a2ccdbb4982b51d041ada1316c1170
+  md5: 1661e2017b74d217a722e0d35a9fc89e
+  depends:
+  - console_bridge
+  - python
+  - ros-kilted-console-bridge-vendor
+  - ros-kilted-ros-workspace
+  - ros-kilted-tinyxml2-vendor
+  - ros-kilted-urdfdom-headers
+  - ros2-distro-mutex 0.12.* kilted_*
+  - tinyxml2
+  - urdfdom >=4.0.1,<4.1.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 7901
+  timestamp: 1759316128072
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_14.conda
+  sha256: 7ad307e8e5f93ade280789cebd98e4d7b7f9743ed546baa55b081f183125ff7d
+  md5: a54e127dab8ede674732ec3865adeca0
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - urdfdom_headers >=1.1.2,<1.2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 7188
+  timestamp: 1759310088496
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_14.conda
+  sha256: 8e28522e0780f7bf5bb93f460f2faf26b9e96b98d4bc76b5b061819056cfe363
+  md5: ff95abbcc979f988f8b4b9acefd8fb44
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - urdfdom_headers >=1.1.2,<1.2.0a0
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 7025
+  timestamp: 1759314570204
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-velocity-controllers-5.7.0-np2py312h31f38b3_14.conda
+  sha256: 7c412d6e3c755f9a73fd47f0265ebfd90abd01035166d1bba41dc8d5adb50803
+  md5: f0dd36c04eed75f64434b05cc09d07b3
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  license: BSD-3-Clause
+  size: 81509
+  timestamp: 1759317156092
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-velocity-controllers-5.7.0-np2py312h2c707e6_14.conda
+  sha256: b08a708108cf242ce83a58e2d461623c0b6493d43efc246990a073196aa9b328
+  md5: bd234876ea3197027b8552cd771329d3
+  depends:
+  - python
+  - ros-kilted-backward-ros
+  - ros-kilted-forward-command-controller
+  - ros-kilted-pluginlib
+  - ros-kilted-rclcpp
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.12.* kilted_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.12.0,<0.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  size: 82780
+  timestamp: 1759321185835
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.0-np2py312h31f38b3_14.conda
   sha256: 3fbe5c4c8cd0aacf5179d030aab6ddcd849823d8730e482457fce0f1bce235c6
   md5: c000d1bb682daff341c9366522ce0b77
@@ -37290,6 +51869,144 @@ packages:
   - pkg:pypi/scipy?source=hash-mapping
   size: 17180049
   timestamp: 1757682509799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat14-14.8.0-h5bb51b8_2.conda
+  sha256: ee7c5db752b71cd03442eee21673f20748a30d57651db98fa2acbee1caa037ef
+  md5: 4559b2fc2081cddbc0a6b0764664e825
+  depends:
+  - libsdformat14 ==14.8.0 py312h1f51ce1_2
+  - sdformat14-python >=14.8.0,<14.8.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 14078
+  timestamp: 1759339825312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat14-14.8.0-hb4dca6f_2.conda
+  sha256: 4ebda896d769015de0374935e594700ffce1a7c0d04aa69c14ca91949385d116
+  md5: ae4d282bf81fe69ec7a19675ab1e5d05
+  depends:
+  - libsdformat14 ==14.8.0 py312h39f64fe_2
+  - sdformat14-python >=14.8.0,<14.8.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 14075
+  timestamp: 1759339827373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat14-python-14.8.0-py312h22a3d64_2.conda
+  sha256: 451f69e0b83e54e686b0dde799adaabccf7a73b5988771443f4cb39c1c2d0dc3
+  md5: 737b20358b5526be5da04407044520b8
+  depends:
+  - libsdformat14 ==14.8.0 py312h1f51ce1_2
+  - python
+  - gz-math7-python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgz-math7 >=7.5.2,<8.0a0
+  - pybind11-abi ==11
+  - python_abi 3.12.* *_cp312
+  - libsdformat14 >=14.8.0,<15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 680439
+  timestamp: 1759339825312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat14-python-14.8.0-py312he22bb7a_2.conda
+  sha256: 1ba257aef3191051b20b2b133b7a905fed392091052444a66b8ae1588cdb7388
+  md5: eb21b46d63a7d034b48be42403042828
+  depends:
+  - libsdformat14 ==14.8.0 py312h39f64fe_2
+  - python
+  - gz-math7-python
+  - python 3.12.* *_cpython
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-math7 >=7.5.2,<8.0a0
+  - pybind11-abi ==11
+  - python_abi 3.12.* *_cp312
+  - libsdformat14 >=14.8.0,<15.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 591957
+  timestamp: 1759339827373
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
+  sha256: b775ad1b64ea8653891ec76b028211bce1ba23fe23701542e826787b322edcc4
+  md5: 8d9dba9bb6673cccdb6d73627e533737
+  depends:
+  - libsdformat15 ==15.3.0 py312h1f51ce1_3
+  - sdformat15-python >=15.3.0,<15.3.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9229
+  timestamp: 1759340798807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
+  sha256: d2ec4c8b2bbafb8f8d6c90befb4707f2e296ef124f94cd0bbf192677083a732b
+  md5: 66735c771d2882213b1b2a7d7f53a2b9
+  depends:
+  - libsdformat15 ==15.3.0 py312h39f64fe_3
+  - sdformat15-python >=15.3.0,<15.3.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 9230
+  timestamp: 1759340813824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-python-15.3.0-py312he766b8f_3.conda
+  sha256: 697167ae0b742f05d861e26ed68607660186b85d41c24a1dfeee30012b310710
+  md5: c5e57ccf44dd38b34947120e77a23b22
+  depends:
+  - libsdformat15 ==15.3.0 py312h1f51ce1_3
+  - python
+  - gz-math8-python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - pybind11-abi ==11
+  - libgz-math8 >=8.2.0,<9.0a0
+  - libsdformat15 >=15.3.0,<16.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 671461
+  timestamp: 1759340798807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-python-15.3.0-py312hd1fdc56_3.conda
+  sha256: 44f1411b97f2f310caca1ba4fde5adadb9987972f2707ded4e675fbded117ac1
+  md5: 59980498d4617c10090e9887070a1839
+  depends:
+  - libsdformat15 ==15.3.0 py312h39f64fe_3
+  - python
+  - gz-math8-python
+  - libstdcxx >=14
+  - libgcc >=14
+  - python 3.12.* *_cpython
+  - libgcc >=14
+  - libsdformat15 >=15.3.0,<16.0a0
+  - pybind11-abi ==11
+  - libgz-math8 >=8.2.0,<9.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 582864
+  timestamp: 1759340813824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
+  sha256: 7cd82ca1d1989de6ac28e72ba0bfaae1c055278f931b0c7ef51bb1abba3ddd2f
+  md5: 91f8537d64c4d52cbbb2910e8bd61bd2
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - sdl3 >=3.2.10,<4.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 587053
+  timestamp: 1745799881584
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
   sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
   md5: cdd138897d94dc07d99afe7113a07bec
@@ -37304,6 +52021,19 @@ packages:
   purls: []
   size: 589145
   timestamp: 1757842881
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.54-h5ad3122_0.conda
+  sha256: d83c13fc35ed447d186150d32b8bc48bdd73a047280ba6e06f151d4cce52639d
+  md5: 6b38021cb802b4e5bede7fe38c547883
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - libegl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - sdl3 >=3.2.10,<4.0a0
+  license: Zlib
+  purls: []
+  size: 597383
+  timestamp: 1745799910298
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
   sha256: 47f4ef4cd2313906840f146b18fee95c2a3a4fa9bd0afdb2d519e6c0aa8ca2ed
   md5: 54747a3f3c468c5f446c78974c8c1234
@@ -37317,6 +52047,62 @@ packages:
   purls: []
   size: 597756
   timestamp: 1757842928996
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.14-he3e324a_0.conda
+  sha256: b55edbcbcbfc7cff671ef15b6a663b91cb2ca59ab285c283d02f29c51de59e9e
+  md5: a750ab1e94750185033ea96eadfc925d
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - dbus >=1.13.6,<2.0a0
+  - libxkbcommon >=1.9.2,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libudev1 >=257.4
+  - libunwind >=1.6.2,<1.7.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libusb >=1.0.28,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - liburing >=2.9,<2.10.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1939690
+  timestamp: 1747327532502
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.22-h68140b3_0.conda
+  sha256: 789ae811b7b93b01c2300461345027fd1a19a7a404e1b8729f58fbe81a82b3bc
+  md5: ebfddf2601e082193bb550924bbb9744
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libudev1 >=257.7
+  - libdrm >=2.4.125,<2.5.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libxkbcommon >=1.11.0,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - libunwind >=1.8.2,<1.9.0a0
+  - wayland >=1.24.0,<2.0a0
+  - liburing >=2.12,<2.13.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1936633
+  timestamp: 1756780211365
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
   sha256: 47156cd71d4e235f7ce6731f1f6bcf4ee1ff65c3c20b126ac66c86231d0d3d57
   md5: eeb4cfa6070a7882ad50936c7ade65ec
@@ -37346,6 +52132,56 @@ packages:
   purls: []
   size: 1936357
   timestamp: 1759445826544
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.14-h7e2c5d6_0.conda
+  sha256: 83e07e24de6018133139d21e33cc61623864144cc1bc279d4affaf8d773fa52b
+  md5: ffe115848f7f2406decbe70ff4530c06
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - libxkbcommon >=1.9.2,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libusb >=1.0.28,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - liburing >=2.9,<2.10.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libudev1 >=257.4
+  - libegl >=1.7.0,<2.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libunwind >=1.6.2,<1.7.0a0
+  - dbus >=1.13.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1897812
+  timestamp: 1747327559219
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.22-h506f210_0.conda
+  sha256: 35be724176304e6bffc0bc60679504faaeef7e1407506bdb33994925b83ffd25
+  md5: 1edfd371c8c0923f375cb92f9d5c5338
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - libegl >=1.7.0,<2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libunwind >=1.8.2,<1.9.0a0
+  - liburing >=2.12,<2.13.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - libudev1 >=257.7
+  - libusb >=1.0.29,<2.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - wayland >=1.24.0,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libxkbcommon >=1.11.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1930038
+  timestamp: 1756780258166
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.24-h506f210_0.conda
   sha256: fb8915f5cb1aab477b6ba7b6176f2f324d4e50884502909aa0cf2c94c9f25205
   md5: e165931e7fdf10278063adfdafe02ae6
@@ -37657,6 +52493,26 @@ packages:
   - pkg:pypi/tifffile?source=hash-mapping
   size: 180936
   timestamp: 1758409651641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+  sha256: d9e3c192c535c06ec139ada7bcd1f12313ebd377208fc8149348e8534229f39e
+  md5: 39dd0757ee71ccd5b120440dce126c37
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  purls: []
+  size: 56535
+  timestamp: 1611562094388
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+  sha256: d7f66bd0ddfbe1b8f2638678d962140e8ab8a63d779b9366247e1f7daabeb575
+  md5: 454eb4b31a1f4313c72ef7f536cae5d9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  purls: []
+  size: 56283
+  timestamp: 1611562275383
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
   sha256: 3ae98c2ca54928b2c72dbb4bd8ea229d3c865ad39367d377908294d9fb1e6f2c
   md5: aeb0b91014ac8c5d468e32b7a5ce8ac2
@@ -38012,6 +52868,17 @@ packages:
   purls: []
   size: 126523
   timestamp: 1743679617387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.0.6-h924138e_2.tar.bz2
+  sha256: 6a799d3f672f100b63bd7cb1a4aec0aced07cf4edc0fac7ecd49c7790a69e1c0
+  md5: f8b2322b72a23562e19a8b9fbd47c176
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18451
+  timestamp: 1649176862187
 - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
   sha256: 9f4090616ed1cb509bb65f1edb11b23c86d929db0ea3af2bf84277caa4337c40
   md5: 4872efb515124284f8cee0f957f3edce
@@ -38024,6 +52891,17 @@ packages:
   purls: []
   size: 19201
   timestamp: 1726152409175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.0.6-hdd96247_2.tar.bz2
+  sha256: 4de95999f7b4f3ea0cac350bce7cb6ae826d87fc1c5f24a97c4e60c85fb902cf
+  md5: 63ae064ec6bfbbfb41cfcfa074c78a2a
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18469
+  timestamp: 1649177102582
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
   sha256: 8ee332fc383fb61652a3ccc7f0362553983e399f36b32abd6678842762e16c0d
   md5: 6f24f2d3af565b2203a4479ad1b7f7e7
@@ -38499,6 +53377,37 @@ packages:
   purls: []
   size: 15873
   timestamp: 1734230458294
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
+  sha256: 105ff923b60286188978d7b3aa159b555e2baf4c736801f62602d4127159f06d
+  md5: 7c0a9bf62d573409d12ad14b362a96e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  - xorg-libxpm >=3.5.17,<4.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 307032
+  timestamp: 1727870272246
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
+  sha256: 6b113e620781efc14c6ae8d6a65436f9c7e5231e2dd9384b7de71abb920eeee2
+  md5: 4c4a80cc042d707a61dfe75f541e0d23
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  - xorg-libxpm >=3.5.17,<4.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 331138
+  timestamp: 1727870334121
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
   sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
   md5: d3c295b50f092ab525ffe3c2aa4b7413
@@ -38672,6 +53581,93 @@ packages:
   purls: []
   size: 48197
   timestamp: 1727801059062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+  sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
+  md5: 5e2eb9bf77394fc2e5918beefec9f9ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 13891
+  timestamp: 1727908521531
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+  sha256: 5f84f820397db504e187754665d48d385e0a2a49f07ffc2372c7f42fa36dd972
+  md5: a7b99f104e14b99ca773d2fe2d195585
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 14388
+  timestamp: 1727908606602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+  sha256: 467cba5106e628068487dcbc2ba2dbd6a434e75d752eaf0895086e9fe65e6a8d
+  md5: f35a9a2da717ade815ffa70c0e8bdfbd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 89078
+  timestamp: 1727965853556
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+  sha256: 18a1d4591976d2266adf6951ce6edaadf9f4994408c6d15e0b5d8f41b8154671
+  md5: 198cb350a783849b5683dbaac3ca96df
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 92167
+  timestamp: 1727965913339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+  sha256: 8ce7ae21dcbbb759c6fb9e5ad2a2f2f4e54172adf160ea59e11712598edbb75c
+  md5: f35bec7fface97f67f44ca952fc740b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 64764
+  timestamp: 1727801210327
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+  sha256: ce7d4a2c075e594b034ee8080271dd7244b0e10a54f1aeb42a5d5eca2f3a950d
+  md5: b9fbc43bcc6bd9aa22f0aa4b81cac173
+  depends:
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 69584
+  timestamp: 1727801259630
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
   sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
   md5: 2de7f99d6581a4a7adbff607b5c278ca
@@ -38735,6 +53731,54 @@ packages:
   purls: []
   size: 14412
   timestamp: 1727899730073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+  sha256: c0830fe9fa78d609cd9021f797307e7e0715ef5122be3f784765dad1b4d8a193
+  md5: 9a809ce9f65460195777f2f2116bae02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12302
+  timestamp: 1734168591429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+  sha256: 9057e4a85a093d733719228d44aa09924e879ee769a9bb79ef7035cd0f260c8e
+  md5: c11f706a5072c34a559848f27d6c28c3
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 13805
+  timestamp: 1734168631514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+  sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+  md5: a9e4852c8e0b68ee783e7240030b696f
+  depends:
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 384752
+  timestamp: 1731860572314
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
@@ -38787,6 +53831,27 @@ packages:
   purls: []
   size: 18185
   timestamp: 1734214652726
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+  md5: 7c21106b851ec72c037b162c216d8f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 565425
+  timestamp: 1726846388217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
+  md5: 91cef7867bf2b47f614597b59705ff56
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 566948
+  timestamp: 1726847598167
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
   sha256: 802725371682ea06053971db5b4fb7fbbcaee9cb1804ec688f55e51d74660617
   md5: 68eae977d7d1196d32b636a026dc015d
@@ -39154,3 +54219,23 @@ packages:
   purls: []
   size: 551176
   timestamp: 1742433378347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+  sha256: a7c3ba25f384c7eb30c4f4c2d390f62714e0b4946d315aa852749f927b4b03ff
+  md5: 6d2d107e0fb8bc381acd4e9c68dbeae7
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later OR MPL-1.1
+  purls: []
+  size: 106915
+  timestamp: 1719242059793
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
+  sha256: 9e3764d1fb2b509bc43ebb059a5bb77ba11af56bb78a5960e1ba8a21aa1939a6
+  md5: 133bf2541e6bc4f7bb7c4e0546776138
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later OR MPL-1.1
+  purls: []
+  size: 115725
+  timestamp: 1719242037690

--- a/pixi.toml
+++ b/pixi.toml
@@ -47,6 +47,7 @@ gtest = ">=1.17.0,<2"
 viser = ">=1.0.11,<2"
 tyro = ">=0.9.32,<0.10"
 matplotlib = ">=3.10.6,<4"
+filelock = ">=3.20.0,<4"
 
 # TODO: Usually installable in ROS dep but unavailable in robostack.
 # We could fix that: https://robostack.github.io/Contributing.html
@@ -69,6 +70,11 @@ ros-kilted-ros-core = "*"
 ros-kilted-trajectory-msgs = "*"
 ros-kilted-yaml-cpp-vendor = "*"
 ros-kilted-tinyxml2-vendor = "*"
+ros-kilted-controller-manager = "*"
+ros-kilted-ros2-controllers = "*"
+ros-kilted-robot-state-publisher = "*"
+ros-kilted-geometry-msgs = "*"
+ros-kilted-rviz2 = "*"
 
 [feature.kilted.activation.env]
 ROS_DISTRO = "kilted"
@@ -81,6 +87,11 @@ ros-jazzy-ros-core = "*"
 ros-jazzy-trajectory-msgs = "*"
 ros-jazzy-yaml-cpp-vendor = "*"
 ros-jazzy-tinyxml2-vendor = "*"
+ros-jazzy-controller-manager = "*"
+ros-jazzy-ros2-controllers = "*"
+ros-jazzy-robot-state-publisher = "*"
+ros-jazzy-geometry-msgs = "*"
+ros-jazzy-rviz2 = "*"
 
 [feature.jazzy.activation.env]
 ROS_DISTRO = "jazzy"
@@ -93,6 +104,11 @@ ros-humble-ros-core = "*"
 ros-humble-trajectory-msgs = "*"
 ros-humble-yaml-cpp-vendor = "*"
 ros-humble-tinyxml2-vendor = "*"
+ros-humble-controller-manager = "*"
+ros-humble-ros2-controllers = "*"
+ros-humble-robot-state-publisher = "*"
+ros-humble-geometry-msgs = "*"
+ros-humble-rviz2 = "*"
 
 [feature.humble.activation.env]
 ROS_DISTRO = "humble"

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(roboplan_ros_cpp PUBLIC
 target_link_libraries(roboplan_ros_cpp
     roboplan::roboplan
 )
-ament_target_dependencies(roboplan_ros_cpp trajectory_msgs)
+target_link_libraries(roboplan_ros_cpp ${trajectory_msgs_TARGETS})
 set_property(TARGET roboplan_ros_cpp PROPERTY CXX_STANDARD 20)
 
 install(

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -18,8 +18,8 @@ target_include_directories(roboplan_ros_cpp PUBLIC
 )
 target_link_libraries(roboplan_ros_cpp
     roboplan::roboplan
+    ${trajectory_msgs_TARGETS}
 )
-target_link_libraries(roboplan_ros_cpp ${trajectory_msgs_TARGETS})
 set_property(TARGET roboplan_ros_cpp PROPERTY CXX_STANDARD 20)
 
 install(

--- a/roboplan_ros_franka/CMakeLists.txt
+++ b/roboplan_ros_franka/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(roboplan_ros_franka)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(roboplan REQUIRED)
+find_package(roboplan_example_models REQUIRED)
+
+install(DIRECTORY config launch 
+        DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/roboplan_ros_franka/CMakeLists.txt
+++ b/roboplan_ros_franka/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(roboplan REQUIRED)
 find_package(roboplan_example_models REQUIRED)
 
-install(DIRECTORY config launch 
+install(DIRECTORY config launch
         DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/roboplan_ros_franka/config/franka_config.rviz
+++ b/roboplan_ros_franka/config/franka_config.rviz
@@ -1,0 +1,244 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1
+        - /TF1
+      Splitter Ratio: 0.5
+    Tree Height: 643
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        fr3_hand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_hand_tcp:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        fr3_leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr3_link8:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        fr3_rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz_default_plugins/TF
+      Enabled: false
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: fr3_link0
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.5963454246520996
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.6853981018066406
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.7053980827331543
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 947
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000311fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f00000311000000cc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000311fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f00000311000000a900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004c40000003efc0100000002fb0000000800540069006d00650100000000000004c40000026f00fffffffb0000000800540069006d00650100000000000004500000000000000000000002530000031100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1220
+  X: 303
+  Y: 133

--- a/roboplan_ros_franka/config/ros2_controllers.yaml
+++ b/roboplan_ros_franka/config/ros2_controllers.yaml
@@ -6,8 +6,15 @@
       fr3_arm_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
+      left_fr3_arm_controller:
+        type: joint_trajectory_controller/JointTrajectoryController
+
+      right_fr3_arm_controller:
+        type: joint_trajectory_controller/JointTrajectoryController
+
       joint_state_broadcaster:
         type: joint_state_broadcaster/JointStateBroadcaster
+
 
   fr3_arm_controller:
     ros__parameters:
@@ -24,3 +31,35 @@
         - fr3_joint5
         - fr3_joint6
         - fr3_joint7
+
+  left_fr3_arm_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - left_fr3_joint1
+        - left_fr3_joint2
+        - left_fr3_joint3
+        - left_fr3_joint4
+        - left_fr3_joint5
+        - left_fr3_joint6
+        - left_fr3_joint7
+
+  right_fr3_arm_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - right_fr3_joint1
+        - right_fr3_joint2
+        - right_fr3_joint3
+        - right_fr3_joint4
+        - right_fr3_joint5
+        - right_fr3_joint6
+        - right_fr3_joint7

--- a/roboplan_ros_franka/config/ros2_controllers.yaml
+++ b/roboplan_ros_franka/config/ros2_controllers.yaml
@@ -9,7 +9,6 @@
       joint_state_broadcaster:
         type: joint_state_broadcaster/JointStateBroadcaster
 
-/**:
   fr3_arm_controller:
     ros__parameters:
       command_interfaces:

--- a/roboplan_ros_franka/config/ros2_controllers.yaml
+++ b/roboplan_ros_franka/config/ros2_controllers.yaml
@@ -1,0 +1,27 @@
+/**:
+  controller_manager:
+    ros__parameters:
+      update_rate: 100  # Hz (the real Franka uses 1000 but we don't need this in sim)
+
+      fr3_arm_controller:
+        type: joint_trajectory_controller/JointTrajectoryController
+
+      joint_state_broadcaster:
+        type: joint_state_broadcaster/JointStateBroadcaster
+
+/**:
+  fr3_arm_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - fr3_joint1
+        - fr3_joint2
+        - fr3_joint3
+        - fr3_joint4
+        - fr3_joint5
+        - fr3_joint6
+        - fr3_joint7

--- a/roboplan_ros_franka/launch/franka_example.launch.py
+++ b/roboplan_ros_franka/launch/franka_example.launch.py
@@ -19,7 +19,8 @@ def generate_launch_description():
         "fr3.urdf",
     )
     robot_description = xacro.process_file(
-        franka_xacro_filepath, mappings={},
+        franka_xacro_filepath,
+        mappings={},
     ).toprettyxml(indent="  ")
 
     controllers_yaml_filepath = os.path.join(
@@ -68,6 +69,6 @@ def generate_launch_description():
             name="rviz2",
             output="log",
             arguments=["-d", rviz_config_filepath],
-        )
+        ),
     ]
     return LaunchDescription(nodes)

--- a/roboplan_ros_franka/launch/franka_example.launch.py
+++ b/roboplan_ros_franka/launch/franka_example.launch.py
@@ -1,0 +1,73 @@
+"""
+Example launch file for a Franka arm using ros2_control mock hardware.
+"""
+
+import os
+import xacro
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import Shutdown
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    franka_xacro_filepath = os.path.join(
+        get_package_share_directory("roboplan_example_models"),
+        "models",
+        "franka_robot_model",
+        "fr3.urdf",
+    )
+    robot_description = xacro.process_file(
+        franka_xacro_filepath, mappings={},
+    ).toprettyxml(indent="  ")
+
+    controllers_yaml_filepath = os.path.join(
+        get_package_share_directory("roboplan_ros_franka"),
+        "config",
+        "ros2_controllers.yaml",
+    )
+    rviz_config_filepath = os.path.join(
+        get_package_share_directory("roboplan_ros_franka"),
+        "config",
+        "franka_config.rviz",
+    )
+
+    nodes = [
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            parameters=[{"robot_description": robot_description}],
+            output="screen",
+        ),
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            parameters=[
+                controllers_yaml_filepath,
+                {"robot_description": robot_description},
+            ],
+            output="screen",
+            on_exit=Shutdown(),
+        ),
+        Node(
+            package="controller_manager",
+            executable="spawner",
+            arguments=["joint_state_broadcaster"],
+            output="screen",
+        ),
+        Node(
+            package="controller_manager",
+            executable="spawner",
+            arguments=["fr3_arm_controller"],
+            output="screen",
+        ),
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            name="rviz2",
+            output="log",
+            arguments=["-d", rviz_config_filepath],
+        )
+    ]
+    return LaunchDescription(nodes)

--- a/roboplan_ros_franka/package.xml
+++ b/roboplan_ros_franka/package.xml
@@ -14,7 +14,6 @@
   <depend>roboplan_example_models</depend>
 
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
 
   <export>

--- a/roboplan_ros_franka/package.xml
+++ b/roboplan_ros_franka/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>roboplan_ros_franka</name>
+  <version>0.1.0</version>
+  <description>Franka arm ROS example for Roboplan.</description>
+  <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
+  <maintainer email="eholum@gmail.com">Erik Holum</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>roboplan</depend>
+  <depend>roboplan_example_models</depend>
+
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Depends on https://github.com/open-planning/roboplan/pull/84 to go in first.

Creates a `roboplan_ros_franka` package that will contain the Franka based example. This is completely arbitrary; we could also have one package with all examples, etc.

```
ros2 launch roboplan_ros_franka franka_example.launch.py 
```

<img width="1222" height="983" alt="image" src="https://github.com/user-attachments/assets/344f7fb2-19c4-4c24-9bba-b27be3e2bac4" />


EDIT: With some small tweaks, this kinda just works too (note I moved the arms to be side by side in https://github.com/open-planning/roboplan/pull/80)

<img width="1222" height="983" alt="image" src="https://github.com/user-attachments/assets/eceb0a23-4864-413e-8dae-a211b6fa6ab7" />
