### PR TITLE
Add missing rosdeps for controller installs

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -14,7 +14,6 @@ SHELL ["/bin/bash", "-c"]
 
 # Install core dependencies.
 RUN apt update -y \
-    && apt upgrade -y \
     && apt install -y libgmock-dev python3-pip
 
 # Install Python dependencies needed for bindings.
@@ -38,6 +37,7 @@ WORKDIR /workspace/roboplan_ws
 # Copy package manifests for installing rosdeps
 COPY --from=package-manifests /roboplan_ros ./src/roboplan_ros
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
+    && apt update -y \
     && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y
 
 # Copy in remaining source and build

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(bindings PRIVATE
   roboplan_bindings::roboplan_bindings_utils
   ${rosidl_generator_cpp_LIBRARIES}
 )
+ament_python_install_package(${PROJECT_NAME})
 ament_get_python_install_dir(PYTHON_INSTALL_DIR)
 install(TARGETS bindings
   LIBRARY DESTINATION "${PYTHON_INSTALL_DIR}/roboplan_ros_cpp"

--- a/roboplan_ros_franka/package.xml
+++ b/roboplan_ros_franka/package.xml
@@ -15,6 +15,8 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>topic_tools</exec_depend>
 
   <export>


### PR DESCRIPTION
Otherwise they're not pulled in to the docker builds and the example doesn't launch..

Also @ndunkelb-nasa was using this on humble and pointed out the bindings didn't import properly because the library was installed in a different location than future ros versions. Fun times.