### PR TITLE
Sanitize docker tag names for branches with slashes (roboplan-ros's version)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Sanitize tag name
+        id: sanitize_tag
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          TAG="${BRANCH//\//-}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           context: .
           file: .docker/Dockerfile
-          tags: roboplan_ros_wrapper:${{ github.head_ref || github.ref_name }}
+          tags: roboplan_ros_wrapper:${{ steps.sanitize_tag.outputs.tag }}
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
           push: false
@@ -98,7 +98,7 @@ jobs:
       - name: Run tests
         run: |
           docker run --rm \
-            roboplan_ros_wrapper:${{ github.head_ref || github.ref_name }} \
+            roboplan_ros_wrapper:${{ steps.sanitize_tag.outputs.tag }} \
             bash -c "
               colcon test && \
               colcon test-result --verbose


### PR DESCRIPTION
Equivalent of https://github.com/open-planning/roboplan/pull/105 for this repo