### PR TITLE
Install nanobind from rosdep and pixi

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -7,8 +7,7 @@ environments:
     - https://pypi.org/simple
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
@@ -17,7 +16,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-6.0.3-hecf2907_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
@@ -59,7 +58,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -71,7 +70,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-19.1.7-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -87,7 +86,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h558b6b9_911.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -109,7 +108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -133,10 +132,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.5-gpl_hc2c16d8_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
@@ -170,18 +169,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
@@ -192,7 +191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-hf7376ad_2.conda
@@ -205,28 +204,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h52d6ec5_601.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312hbe9d83b_602.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h7a07914_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h7a07914_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h78e8023_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.1-hb80d175_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.4-h2fe6a88_5.conda
@@ -235,13 +234,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.21.0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
@@ -294,14 +293,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.4-h40f6f1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.1-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.1-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
@@ -310,7 +309,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_601.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h3a6da57_602.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -353,15 +352,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-2.1.0-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.21-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
@@ -378,7 +377,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
@@ -406,7 +405,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
@@ -414,7 +413,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-6.0.3-he8c3857_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.3.0-py312h3d8e7d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
@@ -456,7 +455,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -468,7 +467,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-aarch64-19.1.7-hfefdfc9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py312hf18b547_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py312hd077ced_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py312hd077ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
@@ -484,7 +483,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h13a1043_911.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -505,7 +504,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hc619b4a_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
@@ -527,9 +526,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.18-h9d5b58d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20250512.1-cxx17_h201e9ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.5-gpl_hbe7d12b_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.4-hcfe818d_0.conda
@@ -563,18 +562,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.1-hdae7a39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
@@ -585,7 +584,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.8-h99ff5a0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.2-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h71be66a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.2-h71be66a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-5_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-5_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-hfd2ba90_2.conda
@@ -598,26 +597,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312h051a780_601.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312hac3c9ff_602.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.4.1-h1915271_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.4.1-h1915271_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.4.1-h3d5001d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.4.1-h3d5001d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.4.1-he07c6df_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.4.1-he07c6df_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.4.1-h07d5dce_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.4.1-h07d5dce_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.4.1-hfae3067_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h38473e3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.4.1-h1915271_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.4.1-h1915271_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.4.1-h3d5001d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.4.1-h3d5001d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.4.1-he07c6df_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.4.1-he07c6df_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.4.1-h558496d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.4.1-h558496d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.4.1-hfae3067_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h2cb6e3c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.54-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.1-hf8816c8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.2-hf8816c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.60.0-h8171147_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.4-h68efd32_5.conda
@@ -626,13 +625,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.21.0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburcu-0.14.0-h0a1ffab_0.conda
@@ -681,14 +680,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.4-hd0c962a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.0-h55827e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.1-h55827e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.1-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.0-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
@@ -697,7 +696,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-hcf98165_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h1743b20_601.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h9d755fc_602.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -740,15 +739,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.3-py312hefbd42c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py312hcd1a082_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hdac3a21_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-2.1.0-hfefdfc9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.21-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.24.0-h4f8a99f_1.conda
@@ -764,7 +763,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.46-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
@@ -799,8 +798,7 @@ environments:
     - https://pypi.org/simple
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
@@ -813,7 +811,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py311h6b1f9c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
@@ -855,7 +853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -867,9 +865,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-19.1.7-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py311h3778330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py311hdb66536_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py311h2005dd1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -887,7 +885,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.1-gpl_h127656b_906.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -923,7 +921,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
@@ -949,7 +947,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
@@ -992,16 +990,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
@@ -1009,7 +1007,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.58-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
@@ -1023,7 +1021,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-cmake2-2.17.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-math6-6.15.1-py311h4d89148_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
@@ -1055,7 +1053,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
@@ -1067,9 +1065,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.4-h3dc2cb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.21.0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h8261f1e_0.conda
@@ -1131,7 +1129,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.1-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
@@ -1435,14 +1433,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py311h49ec1c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.0.6-h924138e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -1461,7 +1459,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
@@ -1498,7 +1496,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
@@ -1510,7 +1508,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.3.0-py311h6ce31b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
@@ -1552,7 +1550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -1564,9 +1562,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-aarch64-19.1.7-hfefdfc9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py311h04741b4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py311h2dad8b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py311h2dad8b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.18.3-py311h8209a4f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.4-py311h7ec736f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py311h7ec736f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
@@ -1584,7 +1582,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-11.2.0-h97e1849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -1619,7 +1617,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.2.0-he4899c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hc619b4a_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.1-pyhd3e5650_1.conda
@@ -1645,7 +1643,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.18-h9d5b58d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20250127.1-cxx17_h18dbdb1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
@@ -1687,16 +1685,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.1-hdae7a39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.2-he84ff74_0.conda
@@ -1704,7 +1702,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.58-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
@@ -1718,7 +1716,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-cmake2-2.17.3-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-math6-6.15.1-py311h9dbc854_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.2-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h71be66a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.2-h71be66a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-5_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-5_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-h2edbd07_1.conda
@@ -1748,7 +1746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.54-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.29.3-h9267e96_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
@@ -1760,9 +1758,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h022381a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.4-h27834fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.21.0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-h7a57436_0.conda
@@ -1821,7 +1819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.3-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.1-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
@@ -2125,14 +2123,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.3-py311hb9158a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py311h19352d5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py311h19352d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hdac3a21_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.0.6-hdd96247_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -2150,7 +2148,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.46-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
@@ -2193,8 +2191,7 @@ environments:
     - https://pypi.org/simple
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
@@ -2207,7 +2204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
@@ -2217,7 +2214,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.23.0-hc31b594_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.0-py312h0b2cbc4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
@@ -2249,7 +2246,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -2261,9 +2258,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-19.1.7-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py312h014360a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -2280,8 +2277,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hf567e27_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h558b6b9_911.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -2308,16 +2305,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.11-h18acefa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h993cebd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
@@ -2328,14 +2325,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils2-2.2.1-hdaf9e28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.1.14-py312h40df4bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
@@ -2357,7 +2354,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
@@ -2367,14 +2364,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h6395336_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h316e467_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hed09d94_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
@@ -2399,23 +2396,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
@@ -2426,7 +2423,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-hf7376ad_2.conda
@@ -2439,7 +2436,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312h52d6ec5_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h52d6ec5_601.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
@@ -2459,8 +2456,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.1-h5c52fec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
@@ -2469,15 +2466,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py312h1f51ce1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.21.0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
@@ -2494,8 +2491,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
@@ -2534,16 +2531,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.4-h40f6f1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.1-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.1-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
@@ -2553,7 +2550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_601.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
@@ -2563,7 +2560,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.1-py312h9da60e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py312h9da60e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
@@ -2576,270 +2573,270 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3c3fd16_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.1-h6f76662_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hc240232_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.2-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.7.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.9.0-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.42.1-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.42.1-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.42.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.6.0-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.42.1-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.42.1-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.7.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.10-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.10-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.9-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.6.0-np2py312h2c89a96_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np2py312h918b84f_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.15-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.15-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.15-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.15-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.8-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.5-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.10.1-np2py312h31007e0_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.10-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2plugin-5.4.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np2py312h88103e5_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.19-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.19-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.19-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.19-np2py312hf3be069_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.19-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.19-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np2py312h6021aa6_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np2py312h918b84f_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-state-interfaces-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.2.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.18-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.2-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.2.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-1.3.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-interfaces-1.3.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np2py312h2ed9cc7_14.conda
-      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.13.0-jazzy_14.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.8.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.9.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.43.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.43.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.43.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.6.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.43.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.43.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.7.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.11-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.11-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.10-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.6.0-np2py312h2c89a96_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.9-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.9-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.9-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np2py312h918b84f_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.9-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.16-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.16-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.16-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.16-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.9-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.10.1-np2py312h31007e0_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.11-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2plugin-5.4.4-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.8-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np2py312h88103e5_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.19-np2py312h4f3ad64_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.19-np2py312hf6702ba_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np2py312h6021aa6_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np2py312h918b84f_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-state-interfaces-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.2.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.19-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.2-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.2.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-1.3.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-interfaces-1.3.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.5-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np2py312h2ed9cc7_16.conda
+      - conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.14.0-jazzy_16.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.4.8-h498564d_0.conda
@@ -2858,7 +2855,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
@@ -2867,14 +2864,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -2893,7 +2890,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
@@ -2930,7 +2927,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
@@ -2942,7 +2939,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.3.0-py312h3d8e7d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
@@ -2952,7 +2949,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-blosc2-2.23.0-hde6442c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.0-py312h007ed8f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
@@ -2984,7 +2981,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -2996,9 +2993,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-aarch64-19.1.7-hfefdfc9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py312hf18b547_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py312hd077ced_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py312hd077ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.18.3-py312h5677ec4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.4-py312hf80642e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py312hf80642e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
@@ -3015,8 +3012,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h1a35955_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h13a1043_911.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -3042,16 +3039,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.3.0-hf9dcc85_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glslang-16.2.0-h124e036_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.17.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.11-hfe111f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-14.1.2-h45e821f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-h4cd1324_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
@@ -3062,14 +3059,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils2-2.2.1-h2ce864c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.2.0-he4899c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hc619b4a_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hb1525cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imagecodecs-2026.1.14-py312h1472198_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
@@ -3089,7 +3086,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.18-h9d5b58d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20250512.1-cxx17_h201e9ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
@@ -3098,14 +3095,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.4-hcfe818d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.3.0-hfe54310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.3.0-h6812acd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-5_haddc8a3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h6339299_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h5651608_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
@@ -3130,23 +3127,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.1-hdae7a39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-h88aa843_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
@@ -3157,7 +3154,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.8-h99ff5a0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.2-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h71be66a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.2-h71be66a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-5_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-5_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-hfd2ba90_2.conda
@@ -3170,7 +3167,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h051a780_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312h051a780_601.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.4.1-h1915271_1.conda
@@ -3188,8 +3185,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.54-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.1-haf03d9f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.2-hf8816c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
@@ -3198,15 +3195,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py312h39f64fe_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h022381a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.21.0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburcu-0.14.0-h0a1ffab_0.conda
@@ -3221,8 +3218,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.1-h3c6a4c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h8591a01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h788dabe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h79dcc73_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h825857f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.43-h6700d25_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzopfli-1.0.3-h01db608_0.tar.bz2
@@ -3259,16 +3256,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.4-hd0c962a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.0-h55827e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.1-h55827e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.3-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.1-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.0-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
@@ -3278,7 +3275,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-hcf98165_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h1743b20_601.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
@@ -3288,7 +3285,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.1-py312h4810df5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.2-py312h4810df5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
@@ -3301,8 +3298,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.1-h9c50542_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-h5343e53_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rav1e-0.7.1-ha3529ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
@@ -3583,7 +3580,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.17.0-h9f97df7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spirv-tools-2026.1-hfefdfc9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-3.1.2-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-4.0.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
@@ -3592,14 +3589,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.3-py312hefbd42c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py312hcd1a082_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hdac3a21_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -3617,7 +3614,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.46-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
@@ -3661,8 +3658,7 @@ environments:
     - https://pypi.org/simple
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
@@ -3675,7 +3671,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
@@ -3685,7 +3681,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.23.0-hc31b594_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.0-py312h0b2cbc4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
@@ -3717,7 +3713,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -3729,9 +3725,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-19.1.7-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py312h014360a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
@@ -3748,8 +3744,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hf567e27_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h558b6b9_911.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -3776,16 +3772,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.3.0-h71661d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.17.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.11-h18acefa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h993cebd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
@@ -3796,14 +3792,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h67c99bb_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.1.14-py312h40df4bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
@@ -3825,7 +3821,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
@@ -3835,14 +3831,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h6395336_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h316e467_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hed09d94_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
@@ -3867,23 +3863,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake3-3.5.5-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-cmake4-4.2.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
@@ -3896,7 +3892,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-5_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-hf7376ad_2.conda
@@ -3909,7 +3905,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312h52d6ec5_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h52d6ec5_601.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
@@ -3929,8 +3925,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.1-h5c52fec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
@@ -3940,15 +3936,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.05.20-hfabd9d1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.21.0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
@@ -3965,8 +3961,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
@@ -4005,16 +4001,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.4-h40f6f1d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.1-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.1-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
@@ -4024,7 +4020,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_601.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
@@ -4034,7 +4030,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.1-py312h9da60e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py312h9da60e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
@@ -4047,8 +4043,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3c3fd16_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.1-h6f76662_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hc240232_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
@@ -4331,7 +4327,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
@@ -4340,14 +4336,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -4366,7 +4362,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
@@ -4403,7 +4399,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
       linux-aarch64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.15.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-asl-1.0.0-h5ad3122_2.conda
@@ -4415,7 +4411,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.3.0-py312h3d8e7d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
@@ -4425,7 +4421,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-blosc2-2.23.0-hde6442c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.0-py312h007ed8f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
@@ -4457,7 +4453,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
@@ -4469,9 +4465,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-aarch64-19.1.7-hfefdfc9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py312hf18b547_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py312hd077ced_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py312hd077ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.18.3-py312h5677ec4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.4-py312hf80642e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py312hf80642e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
@@ -4488,8 +4484,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h1a35955_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h13a1043_911.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -4515,16 +4511,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.3.0-hf9dcc85_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glslang-16.2.0-h124e036_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.17.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.11-hfe111f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-14.1.2-h45e821f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-h4cd1324_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
@@ -4535,14 +4531,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils3-3.1.1-h2347e33_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.2.0-he4899c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hc619b4a_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-12.3.2-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hb1525cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imagecodecs-2026.1.14-py312h1472198_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
@@ -4562,7 +4558,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.18-h9d5b58d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20250512.1-cxx17_h201e9ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
@@ -4571,14 +4567,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.4-hcfe818d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.3.0-hfe54310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.3.0-h6812acd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-5_haddc8a3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h6339299_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h5651608_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
@@ -4603,23 +4599,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.1-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.1-hdae7a39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-h88aa843_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-devel-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake3-3.5.5-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-cmake4-4.2.0-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
@@ -4632,7 +4628,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.8-h99ff5a0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.2-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h71be66a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.2-h71be66a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-5_h88aeb00_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.11.0-5_hb558247_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-hfd2ba90_2.conda
@@ -4645,7 +4641,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h051a780_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312h051a780_601.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.4.1-h1915271_1.conda
@@ -4663,8 +4659,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.54-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.1-haf03d9f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.2-hf8816c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
@@ -4674,15 +4670,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.05.20-h69b1620_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h022381a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.21.0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.8.3-h6470e1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburcu-0.14.0-h0a1ffab_0.conda
@@ -4697,8 +4693,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.1-h3c6a4c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h8591a01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h788dabe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h79dcc73_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h825857f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.43-h6700d25_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzopfli-1.0.3-h01db608_0.tar.bz2
@@ -4735,16 +4731,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.4-hd0c962a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.6.0-h0564a2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.0-h55827e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.1-h55827e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.3-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.1-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.0-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
@@ -4754,7 +4750,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-hcf98165_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_612.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h1743b20_601.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
@@ -4764,7 +4760,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.1-py312h4810df5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.2-py312h4810df5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
@@ -4777,8 +4773,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.1-h9c50542_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-h5343e53_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rav1e-0.7.1-ha3529ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
@@ -5061,7 +5057,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.17.0-h9f97df7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spirv-tools-2026.1-hfefdfc9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-3.1.2-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-4.0.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.3.0-h0eac15c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
@@ -5070,14 +5066,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.3-py312hefbd42c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py312hcd1a082_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hdac3a21_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -5095,7 +5091,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.46-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.7-he30d5cf_0.conda
@@ -5132,40 +5128,31 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/86/f1f61b7a0701f9d1299e5293d083318019f91021a4d449f94d59dbe024e4/pycollada-0.9.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/6b/3fcfd8589d0e319f5fb56f105acbe791198fd36bb54469a91fbe49d828c4/xacro-2.1.1-py3-none-any.whl
 packages:
-- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  md5: d7c89558ba9fa0495403155b64376d81
-  license: None
-  purls: []
-  size: 2562
-  timestamp: 1578324546067
-- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  build_number: 16
-  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  md5: 73aaf86a425cc6e73fcf236a5a46396d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
   depends:
-  - _libgcc_mutex 0.1 conda_forge
+  - __glibc >=2.17,<3.0.a0
   - libgomp >=7.5.0
   constrains:
-  - openmp_impl 9999
+  - openmp_impl <0.0a0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 23621
-  timestamp: 1650670423406
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  build_number: 16
-  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
-  md5: 6168d71addc746e8f2b8d57dfd2edcea
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+  md5: 468fd3bb9e1f671d36c2cbc677e56f1d
   depends:
   - libgomp >=7.5.0
   constrains:
-  - openmp_impl 9999
+  - openmp_impl <0.0a0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 23712
-  timestamp: 1650670790230
+  size: 28926
+  timestamp: 1770939656741
 - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
   build_number: 3
   sha256: 5f9029eaa78eb13a5499b7a2b012a47a18136b2d41bad99bb7b1796d1fc2b179
@@ -5518,30 +5505,30 @@ packages:
   - pkg:pypi/backports-zstd?source=hash-mapping
   size: 243175
   timestamp: 1767044998908
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
-  sha256: 17fbb32191430310d3eb8309f80a8df54f0d66eda9cf84b2ae5113e6d74e24d8
-  md5: e410a8f80e22eb6d840e39ac6a34bd0e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+  sha256: 74341b26a2b9475dc14ba3cf12432fcd10a23af285101883e720216d81d44676
+  md5: 83aa53cb3f5fc849851a84d777a60551
   depends:
-  - ld_impl_linux-64 2.45 default_hbd61a6d_105
+  - ld_impl_linux-64 2.45.1 default_hbd61a6d_101
   - sysroot_linux-64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 3719982
-  timestamp: 1766513109980
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
-  sha256: 7398706fe428530777a7b1e69925c94e46cd45182c52f8a84f34cd601c8d2584
-  md5: 3cee44d70779b513523a9a46146da3f9
+  size: 3744895
+  timestamp: 1770267152681
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
+  sha256: e90ab42a5225dc1eaa6e4e7201cd7b8ed52dad6ec46814be7e5a4039433ae85c
+  md5: df6e1dc38cbe5642350fa09d4a1d546b
   depends:
-  - ld_impl_linux-aarch64 2.45 default_h1979696_105
+  - ld_impl_linux-aarch64 2.45.1 default_h1979696_101
   - sysroot_linux-aarch64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 4848132
-  timestamp: 1766513201703
+  size: 4741684
+  timestamp: 1770267224406
 - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   md5: 2c2fae981fd2afd00812c92ac47d023d
@@ -6881,9 +6868,9 @@ packages:
   - pkg:pypi/colcon-pkg-config?source=hash-mapping
   size: 10397
   timestamp: 1571038968482
-- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_1.conda
-  sha256: 6aeb528c0433e11052d08cd5982ae324c0a2257f8445c5ac9130919ebc5f8e43
-  md5: 7568a13447ca84751fd58eb6542d9768
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 9afc4546ba72326e6a7e0e9874879709e3c14260e49ae11663164bd0f3911106
+  md5: 3f5f803ff3703d28c8ec4cc9b3564257
   depends:
   - colcon-core >=0.3.18
   - python >=3.10
@@ -6891,8 +6878,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/colcon-powershell?source=hash-mapping
-  size: 17321
-  timestamp: 1757616979293
+  size: 17608
+  timestamp: 1770791211378
 - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
   sha256: c3f6cb06b4e1f0fc0efc50ee7ca78fb8d1bcdfff92afcd0e9235c53eb521e61a
   md5: f9e99cee078c732ab49d547fa1a7a752
@@ -7121,9 +7108,9 @@ packages:
   - pkg:pypi/contourpy?source=hash-mapping
   size: 339097
   timestamp: 1769155976173
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py311h3778330_0.conda
-  sha256: f511bc1f8b5c3a61df79b709b6fa41ae31cdc4312f7cf3d947dea95acf85a5d6
-  md5: 620e453607709b49ffdc834da5887217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py311h3778330_0.conda
+  sha256: d165a3b06e2c78bbcc45619c12283a3f0fc45c65d3fe8382c9ce53162c25bfc1
+  md5: 6b1b19bdc407007d5e41079eab797ddc
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -7134,11 +7121,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=compressed-mapping
-  size: 397845
-  timestamp: 1770134661132
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.3-py312h8a5da7c_0.conda
-  sha256: 16eb04124851ca631cf2bbb793fb609aefae8dd8b35d16e29ce8dcb6b7cbf250
-  md5: f3c0bc6e23bd3653d74390aa644b0a95
+  size: 398024
+  timestamp: 1770720590264
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py312h8a5da7c_0.conda
+  sha256: 2c785feaf79c31981ef4a87e41ea1161e1ce6b740ce3f1fb9cf44245cae5cf29
+  md5: a8df7f0812ac4fa6bbc7135556d3e2c4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -7149,11 +7136,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 387346
-  timestamp: 1770134733475
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py311h2dad8b0_0.conda
-  sha256: fabd1391da81faa4e2876e94fd2deaee5ddfcac85360bc65a50786226b8c17bc
-  md5: 752a19eb90f17bfd279ce86563579501
+  size: 388190
+  timestamp: 1770720373428
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py311h2dad8b0_0.conda
+  sha256: 0f89031e6938259a2c08baa1e350f73d8fb0bc01e38df05820c9d52ca857fe08
+  md5: 6fcc144f2f5c3537297288e61d09e8f2
   depends:
   - libgcc >=14
   - python >=3.11,<3.12.0a0
@@ -7163,11 +7150,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 398357
-  timestamp: 1770135837180
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.3-py312hd077ced_0.conda
-  sha256: e854c7cf907e1bd1ca7a4a07a84fb1b9e3511a5934b0a381f1b66c4f4a9b7079
-  md5: ec5977f745c1bed82cb6f72af18dda4d
+  size: 399314
+  timestamp: 1770721667281
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.4-py312hd077ced_0.conda
+  sha256: 3dee4316b0c94eba5f2e08cbd6ec70c60f642e41866325f1252dfdad846854bf
+  md5: 83423794226d44d47f0378847257a4b2
   depends:
   - libgcc >=14
   - python >=3.12,<3.13.0a0
@@ -7177,8 +7164,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 390270
-  timestamp: 1770135872190
+  size: 388204
+  timestamp: 1770721490067
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.18.3-py311hdb66536_1.conda
   sha256: c3ba576d6f98ce1ee1ea94f6994692171a52628e7700a997eee5bf19454249c3
   md5: 64b788c63629ee5bb84d3a0e383ab821
@@ -7253,9 +7240,9 @@ packages:
   - pkg:pypi/cppcheck-htmlreport?source=hash-mapping
   size: 2923791
   timestamp: 1757440286496
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py311h2005dd1_0.conda
-  sha256: c54b29064fa70d6e8da023b11b14ebe13d8a730d832461072cbe090e04464280
-  md5: 158f4e94766e8346771020c1599d03cb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
+  sha256: 0b427b0f353ccf66a926360b6544ea18566e13099e661dcd35c61ffc9c0924e9
+  md5: f9c47968555906c9fe918f447d9abf1f
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
@@ -7268,12 +7255,12 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1713793
-  timestamp: 1769650576440
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py312ha4b625e_0.conda
-  sha256: e2992febc8f869d2aa7cf2e33e7ca2f0db4bfee83d22dab999be52010a423333
-  md5: 014909e4b1e03b5d8375f158e7c59112
+  - pkg:pypi/cryptography?source=compressed-mapping
+  size: 1714583
+  timestamp: 1770772534804
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
+  sha256: 3a20020b7c9efbabfbfdd726ff303df81159e0c3a41a40ef8b37c3ce161a7849
+  md5: 4c69182866fcdd2fc335885b8f0ac192
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
@@ -7287,11 +7274,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/cryptography?source=compressed-mapping
-  size: 1715744
-  timestamp: 1769650803678
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.4-py311h7ec736f_0.conda
-  sha256: e2fd66a9b68eee59a839e4409b8f8f2221344fddd6cfe7234173be65af9b8d91
-  md5: 2bc1dcb014ceee0d78ffab65d3ed9eeb
+  size: 1712251
+  timestamp: 1770772759286
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py311h7ec736f_0.conda
+  sha256: 0b8040d61e2757e909596e398661670b37224c970005b130cf50956838428e86
+  md5: 84b78fb1e2c8531e0f9105e34a4d6e57
   depends:
   - cffi >=1.14
   - libgcc >=14
@@ -7305,11 +7292,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/cryptography?source=hash-mapping
-  size: 1707945
-  timestamp: 1769650455974
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.4-py312hf80642e_0.conda
-  sha256: f815fce0516d1108f7bef1d63f206cd3a531d2e6da4be33f1a10a36b60f0ed2f
-  md5: 63447c23d362e2ffbeb737876262aa9a
+  size: 1707456
+  timestamp: 1770772514027
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py312hf80642e_0.conda
+  sha256: 3560e2499b76ebb375a2a086b0f4d1c806d84ee78857a2d65b255c74eeee8d44
+  md5: d29f4faf486a8f63ec15a3f45df4e3e9
   depends:
   - cffi >=1.14
   - libgcc >=14
@@ -7323,8 +7310,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/cryptography?source=hash-mapping
-  size: 1704532
-  timestamp: 1769650460236
+  size: 1704221
+  timestamp: 1770772496997
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -7885,68 +7872,6 @@ packages:
   purls: []
   size: 12496109
   timestamp: 1769486435109
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hf567e27_908.conda
-  sha256: 961bc070a9246117583a7301ca283efe71913e5a4de7b6f60fa3147d61abb823
-  md5: 0b732ca7cb1fc86f91c09010db7eb4da
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=12.2.0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.4,<0.17.5.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopus >=1.6,<2.0a0
-  - librsvg >=2.60.0,<3.0a0
-  - libstdcxx >=14
-  - libva >=2.23.0,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpl >=2.15.0,<2.16.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.4,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=3.1.2,<3.1.3.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  constrains:
-  - __cuda  >=12.8
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 12504232
-  timestamp: 1766459849052
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.1-gpl_h30b7fc1_906.conda
   sha256: 157dbd7fdd226448343f962c7fcb4c5b5c2fa12dd1e0f1f88f4c16559522c02d
   md5: 74fb3d97aeebfb19ed743f2a2f2e9ec3
@@ -8060,73 +7985,16 @@ packages:
   purls: []
   size: 12031480
   timestamp: 1769486580405
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-8.0.1-gpl_h1a35955_908.conda
-  sha256: 60a2bb822c36e976e150a6c2d1729eb242b3afd8639bd1e8e3273dc7b74f3f3e
-  md5: 0fd2d30d7d189ec7625f225ea2e0f3e5
-  depends:
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=12.2.0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.4,<0.17.5.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-arm-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopus >=1.6,<2.0a0
-  - librsvg >=2.60.0,<3.0a0
-  - libstdcxx >=14
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.4,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=3.1.2,<3.1.3.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  constrains:
-  - __cuda  >=12.8
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 12028458
-  timestamp: 1766459996434
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
-  sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
-  md5: 2cfaaccf085c133a477f0a7a8657afe9
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.24.0-pyhd8ed1ab_0.conda
+  sha256: 32a03a68613bc52c73be410babb6d0cb5bd5bd82999342e6b3ccc4ce1dea03b6
+  md5: 69296c50b5876a09be85c512985b922a
   depends:
   - python >=3.10
   license: Unlicense
   purls:
-  - pkg:pypi/filelock?source=hash-mapping
-  size: 18661
-  timestamp: 1768022315929
+  - pkg:pypi/filelock?source=compressed-mapping
+  size: 24503
+  timestamp: 1771091577981
 - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
   sha256: a32e511ea71a9667666935fd9f497f00bcc6ed0099ef04b9416ac24606854d58
   md5: 04a55140685296b25b79ad942264c0ef
@@ -8795,19 +8663,18 @@ packages:
   purls: []
   size: 612485
   timestamp: 1763672446934
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_0.conda
-  sha256: d5aa3c17a7b6fafff945be2c3f8134d9864a7812a29cd440630fd03229ae8d38
-  md5: 48560c0be24568c3d53a944d2d496818
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.86.3-h5192d8d_1.conda
+  sha256: af2965f0a4951bab26763e02dd5bb22094ddc8aa30803fc5c1d699843067ef28
+  md5: aefbd04e8e6cabe1d24eb8ffa6c48fd5
   depends:
-  - glib-tools 2.86.3 hf516916_0
-  - libffi >=3.5.2,<3.6.0a0
-  - libglib 2.86.3 h6548e54_0
+  - glib-tools 2.86.3 hf516916_1
+  - libglib 2.86.3 h6548e54_1
   - packaging
   - python *
   license: LGPL-2.1-or-later
   purls: []
-  size: 612084
-  timestamp: 1765221962711
+  size: 79272
+  timestamp: 1770929835447
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.2-h8d23fb4_0.conda
   sha256: faf1e556ebfc89dfc921107eb17d807a69a80f2cf0a88b5a2041069d540a1fb9
   md5: 9cf110a08e39763e7773a716918d95a0
@@ -8821,19 +8688,18 @@ packages:
   purls: []
   size: 625872
   timestamp: 1763672195097
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_0.conda
-  sha256: a777c72511a5ed8bd2f9a3ae2850e62e2705b3352fbd4fdb10b35ec6c84bdeba
-  md5: ec0c021efe7251a9be4e4f5219c54e4c
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.86.3-hc66a092_1.conda
+  sha256: 5ca0133bc3ca65df706051947029ff443bdc76bb6767053e9948577c6591566b
+  md5: 2492aee3ebf80adc46458da45f812804
   depends:
-  - glib-tools 2.86.3 hc87f4d4_0
-  - libffi >=3.5.2,<3.6.0a0
-  - libglib 2.86.3 hf53f6bf_0
+  - glib-tools 2.86.3 hc87f4d4_1
+  - libglib 2.86.3 hf53f6bf_1
   - packaging
   - python *
   license: LGPL-2.1-or-later
   purls: []
-  size: 624186
-  timestamp: 1765221848944
+  size: 87817
+  timestamp: 1770929716240
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
   sha256: 5517dae367d069de42c16d48f4b7e269acdedc11d43a5d4ec8d077d43ae00f45
   md5: 14ad79cb7501b6a408485b04834a734c
@@ -8845,17 +8711,18 @@ packages:
   purls: []
   size: 116278
   timestamp: 1763672395899
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_0.conda
-  sha256: 591e948c56f40e7fbcbd63362814736d9c9a3f0cd3cf4284002eff0bec7abe4e
-  md5: fd6acbf37b40cbe919450fa58309fbe1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_1.conda
+  sha256: ee8394e3b857286ece3f61318316f06ace70e76e2224d2312cef4680400765fc
+  md5: 5ebd79c20c7ecf979f20e26fedc0a4fd
   depends:
   - __glibc >=2.17,<3.0.a0
+  - libffi
   - libgcc >=14
-  - libglib 2.86.3 h6548e54_0
+  - libglib 2.86.3 h6548e54_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 116337
-  timestamp: 1765221915390
+  size: 214148
+  timestamp: 1770929777740
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.2-hc87f4d4_0.conda
   sha256: 0be6aadb07525b81b75b422bcb8a114caa53bab6c8f00751ed990cf170c7bc03
   md5: a658d64d82ad2e229afedbe5db948bf1
@@ -8866,16 +8733,17 @@ packages:
   purls: []
   size: 127107
   timestamp: 1763672170454
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_0.conda
-  sha256: 96f13110da7c93b62e81b97f520c6da392a886917f4cf4fe87a224e5816c07b3
-  md5: d8de978ec69147991fc5d9acb96dfb36
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.86.3-hc87f4d4_1.conda
+  sha256: 4ea4b15b1a73586cc2174d3783afbe624c648c8f22bf6031d9fc3543f57968bf
+  md5: b550262c89a90bf5f987ee5ab7963953
   depends:
+  - libffi
   - libgcc >=14
-  - libglib 2.86.3 hf53f6bf_0
+  - libglib 2.86.3 hf53f6bf_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 127526
-  timestamp: 1765221824012
+  size: 228916
+  timestamp: 1770929689120
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
   sha256: 88a5ad3571948bde22957d08ab01328b8a7eb04fdee66268b3125cc322dbde8b
   md5: ba5b655d827f263090ad2dc514810328
@@ -9128,6 +8996,40 @@ packages:
   purls: []
   size: 2859572
   timestamp: 1745093626455
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
+  sha256: f43bc8fd2c8b0c4317cf771f2cf8a9e7eee47105c233bfed00158f6579e41340
+  md5: fd9738c3189541787bd967e19587de26
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.15.1,<1.3.0a0
+  - gstreamer 1.26.10 h17cb667_0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.86.3,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2928142
+  timestamp: 1766699713774
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
   sha256: a13e1059f23497243100b5786e5a7ffac2182885dd56bd7813f518faff959b26
   md5: 2328f6ad67fc8d33402091e3d770ca73
@@ -9160,6 +9062,39 @@ packages:
   purls: []
   size: 2806661
   timestamp: 1745097877029
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
+  sha256: 3a0e73405ead3038e2e52ccc1c8302a417b0c6fcf4c4953a145d98a820328c8c
+  md5: 5c483a9308fbee6d5f7deca21fe36e70
+  depends:
+  - alsa-lib >=1.2.15.1,<1.3.0a0
+  - gstreamer 1.26.10 hc24f651_0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.86.3,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2906491
+  timestamp: 1766705232717
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
   sha256: 6e93b99d77ac7f7b3eb29c1911a0a463072a40748b96dbe37c18b2c0a90b34de
   md5: 056d86cacf2b48c79c6a562a2486eb8c
@@ -9176,6 +9111,22 @@ packages:
   purls: []
   size: 2021832
   timestamp: 1745093493354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
+  sha256: 35044ecb0b08cd61f32b18f0c0c60f8d4aa610352eee4c5902e171a3decc0eba
+  md5: 0c38cdf4414540aae129822f961b5636
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.86.3,<3.0a0
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2059388
+  timestamp: 1766699555877
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
   sha256: 49a399a7c6e2f3d4ad6338fed8d5f3548baa6edeeaec716cca3505f84f3473fb
   md5: 8cc29506178d015d91d8b28725f0bd0c
@@ -9191,6 +9142,21 @@ packages:
   purls: []
   size: 2032739
   timestamp: 1745095972722
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
+  sha256: 5b36e58daf3542dbf798ed8bda28ec1bfd3d382689beb498ebb5a3ad6ce43e3d
+  md5: 9c3c6463c6dd86114e37e8ba195dd651
+  depends:
+  - glib >=2.86.3,<3.0a0
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2080140
+  timestamp: 1766703002402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
   sha256: 1f738280f245863c5ac78bcc04bb57266357acda45661c4aa25823030c6fb5db
   md5: 55e29b72a71339bc651f9975492db71f
@@ -9730,41 +9696,41 @@ packages:
   purls: []
   size: 2046698
   timestamp: 1769449788963
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
-  sha256: aa85acd07b8f60d1760c6b3fa91dd8402572766e763f3989c759ecd266ed8e9f
-  md5: d58cd79121dd51128f2a5dab44edf1ea
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
+  sha256: 1fc50ce3b86710fba3ec9c5714f1612b5ffa4230d70bfe43e2a1436eacba1621
+  md5: c223ee1429ba538f3e48cfb4a0b97357
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libaec >=1.1.4,<2.0a0
+  - libaec >=1.1.5,<2.0a0
   - libcurl >=8.18.0,<9.0a0
   - libgcc >=14
   - libgfortran
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3722799
-  timestamp: 1768858199331
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hc619b4a_105.conda
-  sha256: 043997b9d5fac7981f361ac1a4607a8065c0d96fdb11538670949f91d1352e37
-  md5: cfa71086eb3cd7a66ff2de2e64d159a6
+  size: 3708864
+  timestamp: 1770390337946
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
+  sha256: d906752d30d5d2c15667e38fd68cadb5010cc2fadaad42655a346452ecc2c722
+  md5: 438cd796f1a3f98637c0bdd1691564b7
   depends:
-  - libaec >=1.1.4,<2.0a0
+  - libaec >=1.1.5,<2.0a0
   - libcurl >=8.18.0,<9.0a0
   - libgcc >=14
   - libgfortran
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3904248
-  timestamp: 1768865515680
+  size: 3913046
+  timestamp: 1770397827092
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
   sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   md5: bbf6f174dcd3254e19a2f5d2295ce808
@@ -10492,31 +10458,31 @@ packages:
   purls: []
   size: 293039
   timestamp: 1768184778398
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
-  sha256: 1027bd8aa0d5144e954e426ab6218fd5c14e54a98f571985675468b339c808ca
-  md5: 3ec0aa5037d39b06554109a01e6fb0c6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+  sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
+  md5: 12bd9a3f089ee6c9266a37dab82afabd
   depends:
   - __glibc >=2.17,<3.0.a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-64 2.45
+  - binutils_impl_linux-64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 730831
-  timestamp: 1766513089214
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
-  sha256: 12e7341b89e9ea319a3b4de03d02cd988fa02b8a678f4e46779515009b5e475c
-  md5: 849c4cbbf8dd1d71e66c13afed1d2f12
+  size: 725507
+  timestamp: 1770267139900
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
+  sha256: 44527364aa333be631913451c32eb0cae1e09343827e9ce3ccabd8d962584226
+  md5: 35b2ae7fadf364b8e5fb8185aaeb80e5
   depends:
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-aarch64 2.45
+  - binutils_impl_linux-aarch64 2.45.1
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 876257
-  timestamp: 1766513180236
+  size: 875924
+  timestamp: 1770267209884
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
   sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
   md5: 9344155d33912347b37f0ae6c410a835
@@ -10582,6 +10548,21 @@ packages:
   purls: []
   size: 1310612
   timestamp: 1750194198254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
+  md5: 6f7b4302263347698fd24565fbf11310
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libabseil-static =20260107.1=cxx17*
+  - abseil-cpp =20260107.1
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1384817
+  timestamp: 1770863194876
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20250127.1-cxx17_h18dbdb1_0.conda
   sha256: 55b7f9d8faa4a0a08f9fc7bcbd7f4cdd3c232120bafa2e8f7e19014ea4aa1278
   md5: 71b972e18b2747a9d47bbbafc346b765
@@ -10610,6 +10591,20 @@ packages:
   purls: []
   size: 1327580
   timestamp: 1750194149128
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
+  sha256: 37675140819e10235a8ff342cb09f688f843ac390b64856d8e230700bbd7d5aa
+  md5: 2a19160c13e688710dd200812fc9a6d3
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - abseil-cpp =20260107.1
+  - libabseil-static =20260107.1=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1401836
+  timestamp: 1770863223557
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
   sha256: 1b704cf161c6f84658a7ac534555ef365ec982f23576b1c4ae4cac4baeb61685
   md5: ef8039969013acacf5b741092aef2ee7
@@ -10854,21 +10849,6 @@ packages:
   purls: []
   size: 140323
   timestamp: 1769476997956
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h6395336_2.conda
-  sha256: e3a44c0eda23aa15c9a8dfa8c82ecf5c8b073e68a16c29edd0e409e687056d30
-  md5: c09c4ac973f7992ba0c6bb1aafd77bd4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - libgcc >=14
-  - rav1e >=0.7.1,<0.8.0a0
-  - svt-av1 >=3.1.2,<3.1.3.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 139399
-  timestamp: 1756124751131
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h766b0b6_0.conda
   sha256: 170b51a3751c2f842ff9e11d22423494ef7254b448ef2b24751256ef18aa1302
   md5: f17f2d0e5c9ad6b958547fd67b155771
@@ -10912,20 +10892,6 @@ packages:
   purls: []
   size: 137787
   timestamp: 1746836360100
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.3.0-hfe54310_2.conda
-  sha256: 0b6265d49982a4953350308b70d6030efa0ee7cba733fa31effd367aad1ea49a
-  md5: b195be7724abc09a1a5efc57c0969004
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - libgcc >=14
-  - rav1e >=0.7.1,<0.8.0a0
-  - svt-av1 >=3.1.2,<3.1.3.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 139042
-  timestamp: 1756124783868
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
   build_number: 5
   sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
@@ -11020,24 +10986,6 @@ packages:
   purls: []
   size: 3072984
   timestamp: 1766347479317
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hed09d94_6.conda
-  sha256: 40b334d77229fcceb51d911a153d7ab9ff4f6a6f90e938387bf29129ab956c58
-  md5: 70675d70a76e1b5539b1f464fd5f02ba
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - liblzma >=5.8.1,<6.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 2978265
-  timestamp: 1763017293494
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-h6339299_4.conda
   sha256: 407b5041c0455f424451a937dca4d112a1503e2b84e748ce891f4cb4713f53e4
   md5: a37b21976747c7451d4d60a14be014ae
@@ -11072,23 +11020,6 @@ packages:
   purls: []
   size: 3167446
   timestamp: 1768377608900
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h6339299_6.conda
-  sha256: 19c1f57fd12fdbdc8fb7ede908fed0eea10a78dfa0aef8d13e70f5b1845d9f02
-  md5: c7dd6db54e262c6718f035fe31612397
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - liblzma >=5.8.1,<6.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 3106527
-  timestamp: 1763017607450
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.86.0-hfcd1e18_4.conda
   sha256: 2301427eb210dd3b09ae335856385b040db82ea4ef6afbc92a1aa0d4947bfa9f
   md5: 89014e9211890d097ea823f9a22451b3
@@ -11101,18 +11032,6 @@ packages:
   purls: []
   size: 38690
   timestamp: 1756549508060
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_6.conda
-  sha256: 5abd12f5d09b133e50d97006294e9bddd5ca4fcfd47600f7af2c423ee4248329
-  md5: 34506edc32bf34fe87b9167c1db3c594
-  depends:
-  - libboost 1.88.0 hed09d94_6
-  - libboost-headers 1.88.0 ha770c72_6
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 39998
-  timestamp: 1763017388984
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
   sha256: 249e7a58aee14a619d4f6bca3ad955b7a0a84aad6ab201f734bb21ea16e654e6
   md5: 97ac87592030b16fa193c877538be3d5
@@ -11137,18 +11056,6 @@ packages:
   purls: []
   size: 37704
   timestamp: 1756549634735
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_6.conda
-  sha256: 0559804b7690b7b29ef480fbe08cacfe578d05d5128580aa631df6f234d66bd8
-  md5: f3e086f05dfe57336ba739c5341dd1ac
-  depends:
-  - libboost 1.88.0 h6339299_6
-  - libboost-headers 1.88.0 h8af1aa0_6
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 38803
-  timestamp: 1763017737045
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
   sha256: a71425c2e5c6bbb86f88dba5cb94fef91c83c1b1eb4feca865d523e2f144f2bf
   md5: 4ec101194a9a590712cd8208d73a4e57
@@ -11170,15 +11077,6 @@ packages:
   purls: []
   size: 14055378
   timestamp: 1756549426826
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_6.conda
-  sha256: 47329777ccff1119a2b23cf09c01bbba61af1580f607a6401787d43b6aa3fa1a
-  md5: e186cec17311f2bdc0d83c520c42276c
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 14583444
-  timestamp: 1763017308042
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
   sha256: 88194078f2de6b68c40563871ccf638fd48cd1cf1d203ac4e653cee9cedd31a6
   md5: d9011bcea61514b510209b882a459a57
@@ -11197,15 +11095,6 @@ packages:
   purls: []
   size: 14040148
   timestamp: 1756549554879
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_6.conda
-  sha256: 816bbc0875cafb19cf933cca40088395d783c636feab134b2ada6dd9d26cecbe
-  md5: 0dc43aace408db1dd6bd2c7fc9e48c7f
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 14556248
-  timestamp: 1763017626568
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
   sha256: 29cfb5d19a3a066ab73c350a1ee21c58927a489d319b50a725ecaf930db29e25
   md5: 9e2927011a27044c1b40f8f5b73328c4
@@ -11232,24 +11121,6 @@ packages:
   purls: []
   size: 120348
   timestamp: 1756549659002
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_6.conda
-  sha256: 2892a87a3b29582d82aa1a949825adb436fe6454a12f502f1ee2cde5f8da6dee
-  md5: 595192338e11b3cf5041b4ca978142b9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libboost 1.88.0 hed09d94_6
-  - libgcc >=14
-  - libstdcxx >=14
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - boost <0.0a0
-  - py-boost <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 130214
-  timestamp: 1763017581996
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py312hf890105_7.conda
   sha256: 53983b23517b668eae8a8db06bd47765c6fb33d65947222925462bdc43a87686
   md5: e7b252a7225110779b7e1df8d01ac9a0
@@ -11285,24 +11156,6 @@ packages:
   purls: []
   size: 117481
   timestamp: 1756549809243
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_6.conda
-  sha256: d291a9e5337ba366284c2c9f49c40af5f46018df8f6436b18a47daf769a787ff
-  md5: 5be3dd2322d7fa6ee5f67c592d292019
-  depends:
-  - libboost 1.88.0 h6339299_6
-  - libgcc >=14
-  - libstdcxx >=14
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - py-boost <0.0a0
-  - boost <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 124744
-  timestamp: 1763018090511
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.88.0-py312he84d598_7.conda
   sha256: 51ee1dd284037f8c179532cce7e2153103de759a20e76051d0199386cdf60f8d
   md5: 0a699aa68f2f3b73e1745da32c267ab5
@@ -11337,22 +11190,6 @@ packages:
   purls: []
   size: 18218
   timestamp: 1756549905587
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_6.conda
-  sha256: 4c8b60dbff320d806bac9428bc5d97836b0df7caa5dcb31c09588aa032d54745
-  md5: 0e809e282bcee4da3e2852a824728105
-  depends:
-  - libboost-devel 1.88.0 hfcd1e18_6
-  - libboost-python 1.88.0 py312hf890105_6
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - boost <0.0a0
-  - py-boost <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 18894
-  timestamp: 1763017877229
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-devel-1.88.0-py312h26dfbe5_7.conda
   sha256: bbf92788225d7aec6e13678cb1cb812b3336aaf4a812ab09739cb0495504b3bd
   md5: f541dd78a5952bff51acd5b7b9e53acf
@@ -11385,22 +11222,6 @@ packages:
   purls: []
   size: 18300
   timestamp: 1756550080131
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_6.conda
-  sha256: 9c0565ccf7c2f74e964fb015e5d624c4fd1aaa6647a67d1b3be35585b90d1448
-  md5: 988bff4752d6c4f9324ad8f4109cd38a
-  depends:
-  - libboost-devel 1.88.0 h37bb5a9_6
-  - libboost-python 1.88.0 py312he84d598_6
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - py-boost <0.0a0
-  - boost <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 19085
-  timestamp: 1763018373645
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-devel-1.88.0-py312h6ffa558_7.conda
   sha256: dde64fddab2d8dfb46bb847615c1e88d2892d80182da86afc9219e1ce512cbbe
   md5: 5e682f6d5a0c17abbbe28b38b320332f
@@ -12192,73 +12013,73 @@ packages:
   purls: []
   size: 423210
   timestamp: 1757945484108
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-  sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
-  md5: 6d0363467e6ed84f11435eb309f2ff06
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+  sha256: 43860222cf3abf04ded0cf24541a105aa388e0e1d4d6ca46258e186d4e87ae3e
+  md5: 3c281169ea25b987311400d7a7e28445
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.2.0=*_16
-  - libgomp 15.2.0 he0feb66_16
+  - libgcc-ng ==15.2.0=*_17
+  - libgomp 15.2.0 he0feb66_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 1042798
-  timestamp: 1765256792743
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-  sha256: 44bfc6fe16236babb271e0c693fe7fd978f336542e23c9c30e700483796ed30b
-  md5: cf9cd6739a3b694dcf551d898e112331
+  size: 1040478
+  timestamp: 1770252533873
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+  sha256: 3709e656917d282b5d3d78928a7a101bd638aaa9d17fb8689e6f95428d519056
+  md5: 0d842d2053b95a6dbb83554948e7cbfe
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 15.2.0 h8acb6b2_16
-  - libgcc-ng ==15.2.0=*_16
+  - libgomp 15.2.0 h8acb6b2_17
+  - libgcc-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 620637
-  timestamp: 1765256938043
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_116.conda
-  sha256: 48d7d8dded34100d9065d1c0df86a11ab2cd8ddfd1590512b304527ed25b6d93
-  md5: e67832fdbf2382757205bb4b38800643
+  size: 622154
+  timestamp: 1770252127670
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_117.conda
+  sha256: 10cb1284d303813a5e2432d437fe266f50792cf0b96cf172005b165fa597b34b
+  md5: c7d84def62dabe178304356d8b5d37e0
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 3094906
-  timestamp: 1765256682321
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_116.conda
-  sha256: 594e4f22a4b6aae1bca5e22ea3a075c070642ca4c27c53e0c0973926ca711e09
-  md5: 8ba6e9b5866b6a5429ca5d9fa12bc964
+  size: 3087343
+  timestamp: 1770252422540
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_117.conda
+  sha256: 91f02e978f226ca87ebd00a33a775373d99efc0eb7165cfc236c4c1dd5f28132
+  md5: 8d97f027c1de507a9e41719c91620a4b
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 2343262
-  timestamp: 1765256811670
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-  sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
-  md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
+  size: 2341423
+  timestamp: 1770252033781
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+  sha256: bdfe50501e4a2d904a5eae65a7ae26e2b7a29b473ab084ad55d96080b966502e
+  md5: 1478bfa85224a65ab096d69ffd2af1e5
   depends:
-  - libgcc 15.2.0 he0feb66_16
+  - libgcc 15.2.0 he0feb66_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27256
-  timestamp: 1765256804124
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-  sha256: 22d7e63a00c880bd14fbbc514ec6f553b9325d705f08582e9076c7e73c93a2e1
-  md5: 3e54a6d0f2ff0172903c0acfda9efc0e
+  size: 27541
+  timestamp: 1770252546553
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+  sha256: 308bd5fe9cd4b19b08c07437a626cf02a1d70a43216d68469d17003aece63202
+  md5: bcd31f4a57798bd158dfc0647fa77ca3
   depends:
-  - libgcc 15.2.0 h8acb6b2_16
+  - libgcc 15.2.0 h8acb6b2_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27356
-  timestamp: 1765256948637
+  size: 27555
+  timestamp: 1770252134574
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
   sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
   md5: 8504a291085c9fb809b66cabd5834307
@@ -12280,6 +12101,28 @@ packages:
   purls: []
   size: 652592
   timestamp: 1747060671875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h5fbf134_12.conda
+  sha256: 245be793e831170504f36213134f4c24eedaf39e634679809fd5391ad214480b
+  md5: 88c1c66987cd52a712eea89c27104be6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  purls: []
+  size: 177306
+  timestamp: 1766331805898
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   md5: 68fc66282364981589ef36868b1a7c78
@@ -12301,6 +12144,27 @@ packages:
   purls: []
   size: 177082
   timestamp: 1737548051015
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-h88aa843_12.conda
+  sha256: 8b7dfd29a8ce42d28c47a06dcaa7c21f6dad751b72d2352668d680b6ec951630
+  md5: b4c9083a19a45047173f380624c7e5f3
+  depends:
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  purls: []
+  size: 195554
+  timestamp: 1766331786625
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
   sha256: 7e199bb390f985b34aee38cdb1f0d166abc09ed44bd703a1b91a3c6cd9912d45
   md5: d256b0311b7a207a2c6b68d2b399f707
@@ -12367,53 +12231,53 @@ packages:
   purls: []
   size: 37460
   timestamp: 1751557569909
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
-  sha256: 8a7b01e1ee1c462ad243524d76099e7174ebdd94ff045fe3e9b1e58db196463b
-  md5: 40d9b534410403c821ff64f00d0adc22
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
+  sha256: 1604c083dd65bc91e68b6cfe32c8610395088cb96af1acaf71f0dcaf83ac58f7
+  md5: a6c682ac611cb1fa4d73478f9e6efb06
   depends:
-  - libgfortran5 15.2.0 h68bc16d_16
+  - libgfortran5 15.2.0 h68bc16d_17
   constrains:
-  - libgfortran-ng ==15.2.0=*_16
+  - libgfortran-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27215
-  timestamp: 1765256845586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_16.conda
-  sha256: 02fa489a333ee4bb5483ae6bf221386b67c25d318f2f856237821a7c9333d5be
-  md5: 776cca322459d09aad229a49761c0654
+  size: 27515
+  timestamp: 1770252591906
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_17.conda
+  sha256: 50c82232581a5105eb8648d1fae1677176e5bf06681120b08969e83136bcd8dc
+  md5: 7fa4f07979f7aff0938e5664f43f7053
   depends:
-  - libgfortran5 15.2.0 h1b7bec0_16
+  - libgfortran5 15.2.0 h1b7bec0_17
   constrains:
-  - libgfortran-ng ==15.2.0=*_16
+  - libgfortran-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27314
-  timestamp: 1765256989755
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_16.conda
-  sha256: dc13ce4ceecb5b3aaca4133731e459d1111961288a1e071cc18bd71d5a47e976
-  md5: e5eb2ddedabd0063e442f230755d2062
+  size: 27523
+  timestamp: 1770252166194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.2.0-h69a702a_17.conda
+  sha256: 60b78fd6dbb8259b4d1c8a8a363f22a86674509e7cf42497eeb5448b4d05d03d
+  md5: d7954bb54fc77e7952a78e5e0d134df5
   depends:
-  - libgfortran 15.2.0 h69a702a_16
+  - libgfortran 15.2.0 h69a702a_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27300
-  timestamp: 1765257039455
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_16.conda
-  sha256: c97f2dd9f426311591880986e4f9ec3b3207971fde20189f6d16d9d0fba3138b
-  md5: 3b55579065fac309af0129098fa1657b
+  size: 27558
+  timestamp: 1770252799999
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-15.2.0-he9431aa_17.conda
+  sha256: 8a23960d2f88950faf124bd003c9c74e623b239b60a9a4435037567f7fd8124a
+  md5: 35b0dce3fb093e09af32f7e4939769c4
   depends:
-  - libgfortran 15.2.0 he9431aa_16
+  - libgfortran 15.2.0 he9431aa_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27343
-  timestamp: 1765257260085
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
-  sha256: d0e974ebc937c67ae37f07a28edace978e01dc0f44ee02f29ab8a16004b8148b
-  md5: 39183d4e0c05609fd65f130633194e37
+  size: 27583
+  timestamp: 1770252353964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
+  sha256: b1c77b85da9a3e204de986f59e262268805c6a35dffdf3953f1b98407db2aef3
+  md5: 202fdf8cad9eea704c2b0d823d1732bf
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=15.2.0
@@ -12422,11 +12286,11 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 2480559
-  timestamp: 1765256819588
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_16.conda
-  sha256: bde541944566254147aab746e66014682e37a259c9a57a0516cf5d05ec343d14
-  md5: 87b4ffedaba8b4d675479313af74f612
+  size: 2480824
+  timestamp: 1770252563579
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_17.conda
+  sha256: c3482b88cd253f6b423e93ba51105aa6d0178582be70648d92564c5308a4d76b
+  md5: 577bd91c44237433e010e9b96aea7ee0
   depends:
   - libgcc >=15.2.0
   constrains:
@@ -12434,8 +12298,8 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 1485817
-  timestamp: 1765256963205
+  size: 1487504
+  timestamp: 1770252146167
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -12494,9 +12358,9 @@ packages:
   purls: []
   size: 3974801
   timestamp: 1763672326986
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
-  sha256: 82d6c2ee9f548c84220fb30fb1b231c64a53561d6e485447394f0a0eeeffe0e6
-  md5: 034bea55a4feef51c98e8449938e9cee
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_1.conda
+  sha256: cf44d4ae071b524b1e1bbd0eb9bc428715b41c735a6cdce97ec6f813160dcedc
+  md5: 5b5846bc2b23e07a1d61b89dcb67fcf0
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.5.2,<3.6.0a0
@@ -12505,11 +12369,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
   constrains:
-  - glib 2.86.3 *_0
+  - glib 2.86.3 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 3946542
-  timestamp: 1765221858705
+  size: 4368329
+  timestamp: 1770929706446
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.2-he84ff74_0.conda
   sha256: 69072fe6401f2a616966d8b41bf4c73e00e5412a3ffbf45c8b42e417df4a0bab
   md5: d184d68eaa57125062786e10440ff461
@@ -12525,9 +12389,9 @@ packages:
   purls: []
   size: 4043199
   timestamp: 1763672135379
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_0.conda
-  sha256: 35f4262131e4d42514787fdc3d45c836e060e18fcb2441abd9dd8ecd386214f4
-  md5: f226b9798c6c176d2a94eea1350b3b6b
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.86.3-hf53f6bf_1.conda
+  sha256: 02bef720754741a7b9bda5a724e928392fde21dfb0d2cdc1a6a377aa036c5caa
+  md5: 9590055a5bc67692dbc2f6176df96a38
   depends:
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
@@ -12535,11 +12399,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
   constrains:
-  - glib 2.86.3 *_0
+  - glib 2.86.3 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 4041779
-  timestamp: 1765221790843
+  size: 4473914
+  timestamp: 1770929652170
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
   md5: 8422fcc9e5e172c91e99aef703b3ce65
@@ -12623,24 +12487,24 @@ packages:
   purls: []
   size: 26362
   timestamp: 1731331008489
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
-  sha256: 5b3e5e4e9270ecfcd48f47e3a68f037f5ab0f529ccb223e8e5d5ac75a58fc687
-  md5: 26c46f90d0e727e95c6c9498a33a09f3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+  sha256: b961b5dd9761907a7179678b58a69bb4fc16b940eb477f635aea3aec0a3f17a6
+  md5: 51b78c6a757575c0d12f4401ffc67029
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 603284
-  timestamp: 1765256703881
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
-  sha256: 0a9d77c920db691eb42b78c734d70c5a1d00b3110c0867cfff18e9dd69bc3c29
-  md5: 4d2f224e8186e7881d53e3aead912f6c
+  size: 603334
+  timestamp: 1770252441199
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
+  sha256: ffa6169ef78e5333ecb08152141932c5f8ca4f4d3742b1a5eec67173e70b907a
+  md5: 0ad9074c91b35dbf8b58bc68a9f9bda0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 587924
-  timestamp: 1765256821307
+  size: 587183
+  timestamp: 1770252042141
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.58-h54a6638_0.conda
   sha256: 8c0786ab58d25fb0c947b29cbd7b155d5a79b46cc2d059f94d887fa61400b363
   md5: 791699a08705ad827006957002cd92aa
@@ -13049,35 +12913,35 @@ packages:
   purls: []
   size: 691818
   timestamp: 1762094728337
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
-  sha256: 1b9eda9cf595313cf093d40dfbe5aa1ff55c97a04cc024cf80a35dad527f7a54
-  md5: 6e9bf4ce797d0216bd2a58298b6290b5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+  sha256: 0c2399cef02953b719afe6591223fb11d287d5a108ef8bb9a02dd509a0f738d7
+  md5: 1df8c1b1d6665642107883685db6cf37
   depends:
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libhwy >=1.3.0,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1912600
-  timestamp: 1768821967254
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.1-h71be66a_8.conda
-  sha256: 185af4f1f843492dc243e4fd40751312e2ad5ffb1792eee21ce9177f38b63d86
-  md5: dce56413f74be74df9ff2feedd1ecc02
-  depends:
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
+  - libhwy >=1.3.0,<1.4.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1883476
+  timestamp: 1770801977654
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjxl-0.11.2-h71be66a_0.conda
+  sha256: 880d6a176e0fed5f3a8b1db034f6ee59dab1622d0ab03ea1298ddd9d42f6fa5d
+  md5: 0f640337bf465aa7b663a6ba399d4fc4
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libbrotlidec >=1.2.0,<1.3.0a0
   - libhwy >=1.3.0,<1.4.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1485547
-  timestamp: 1768821981402
+  size: 1489440
+  timestamp: 1770801995062
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
   build_number: 5
   sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
@@ -13533,59 +13397,6 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 32367046
   timestamp: 1751758392292
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.12.0-qt6_py312h52d6ec5_612.conda
-  sha256: 73b3c2f1bc8417d297bc71e895236c7a23ac6c3a6bffe617eada876b66fd3280
-  md5: 872b744a711e7948710f70a79926e207
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  - ffmpeg >=8.0.1,<9.0a0
-  - harfbuzz >=12.2.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - imath >=3.2.2,<3.2.3.0a0
-  - jasper >=4.2.8,<5.0a0
-  - libavif16 >=1.3.0,<2.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libjxl >=0.11,<0.12.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.23,<3
-  - openexr >=3.4.4,<3.5.0a0
-  - qt6-main >=6.10.1,<6.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 32672205
-  timestamp: 1766495315053
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312h52d6ec5_601.conda
   sha256: 28a7670a7078e5fcde9605baeae22a2a8aacbf2c6bf629ab7570652855756258
   md5: 96a02f37d7036eb8cd59cf82cfbb7770
@@ -13639,6 +13450,59 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 33346271
   timestamp: 1769911857943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.13.0-qt6_py312hbe9d83b_602.conda
+  sha256: fc0785b40b349a948d295fca142126c0c488b5c626cde8d1145d0c89ad9e76eb
+  md5: 5b5f31e829c0b4d4497fdab5c9de27f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=8.0.1,<9.0a0
+  - harfbuzz >=12.3.2
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - jasper >=4.2.8,<5.0a0
+  - libavif16 >=1.3.0,<2.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.4.4,<3.5.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 33415395
+  timestamp: 1770927388760
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py311h6b27ceb_600.conda
   sha256: dbd1d7474baec6d22e1bb92463562f7f6e31c5d5215d4285a5ca4db41a45a5ec
   md5: a8275aa67d33b80901c64b77cb03b412
@@ -13693,56 +13557,6 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 20733237
   timestamp: 1751758100288
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.12.0-qt6_py312h051a780_612.conda
-  sha256: 5c663900109033b4f39da6adbf0bd65054eeedff28079890644525952a71388f
-  md5: bd63fd7ffdf84b4a23c05032618ebe9d
-  depends:
-  - _openmp_mutex >=4.5
-  - ffmpeg >=8.0.1,<9.0a0
-  - harfbuzz >=12.2.0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - imath >=3.2.2,<3.2.3.0a0
-  - jasper >=4.2.8,<5.0a0
-  - libavif16 >=1.3.0,<2.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libjxl >=0.11,<0.12.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-arm-cpu-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
-  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.23,<3
-  - openexr >=3.4.4,<3.5.0a0
-  - qt6-main >=6.10.1,<6.11.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 21232907
-  timestamp: 1766496175059
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312h051a780_601.conda
   sha256: f622609d060185525024d8a492f0a7bb6aa6406cc7d289b04f948cceb04e60b3
   md5: 5020fdde038856180d9b797d02cce46f
@@ -13793,6 +13607,56 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 22787717
   timestamp: 1769912243224
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.13.0-qt6_py312hac3c9ff_602.conda
+  sha256: b461bf14d2a1ba07f8ecce7493191988381980747fcc32326918ede6a10ac1ac
+  md5: fdad84a36bce322f965d3347cebc3a26
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=8.0.1,<9.0a0
+  - harfbuzz >=12.3.2
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - imath >=3.2.2,<3.2.3.0a0
+  - jasper >=4.2.8,<5.0a0
+  - libavif16 >=1.3.0,<2.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-arm-cpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - openexr >=3.4.4,<3.5.0a0
+  - qt6-main >=6.10.2,<6.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 23034948
+  timestamp: 1770927789454
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
   sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
   md5: 7df50d44d4a14d6c31a2c54f2cd92157
@@ -13855,6 +13719,18 @@ packages:
   purls: []
   size: 6504144
   timestamp: 1769904250547
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_2.conda
+  sha256: 2a3082c408581fd7c8d65df7c9acf0c6f421a6d82c92ff122a79fcf4505f3338
+  md5: 1e19a58da158e3c711307429155c69a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 6508131
+  timestamp: 1770890698209
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.0.0-hd63d6c0_3.conda
   sha256: d4e774708a073ba4a240fd2bc0f524d8b6d9fe68a24074bc7affe70c7fd9d8b7
   md5: 97277bfdfcc0dd59c0a74869fb31269a
@@ -13877,6 +13753,17 @@ packages:
   purls: []
   size: 5665824
   timestamp: 1769898242484
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2025.4.1-h1915271_2.conda
+  sha256: ca66de8a41532c2aee68aa7f9ff3cf269f0bdd4bd7079e969e427828bfd709d2
+  md5: 3c4b05ef9e3289ff5abe268f31bfbd1a
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 5665408
+  timestamp: 1770884570912
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.0.0-hd63d6c0_3.conda
   sha256: 1097bf9bfff8a9dade6b2a033b107aafed75d0dd2b4430a1754d8b89cb12f47d
   md5: 387c0cad41f9e9cf330da02e9f7d4898
@@ -13901,6 +13788,18 @@ packages:
   purls: []
   size: 10070230
   timestamp: 1769898273278
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2025.4.1-h1915271_2.conda
+  sha256: 5e4b89c0aa4725aa323df7844fd5e0dd9f8b9dd599ca528c0385f5848a710c8c
+  md5: fff9e59b56bb915f4fc4cec409fac6ed
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 10058464
+  timestamp: 1770884605329
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.0.0-h4d9b6c2_3.conda
   sha256: b4c61b3e8fc4d7090a94e3fd3936faf347eea07cac993417153dd99bd293c08d
   md5: 2e349bafc75b212879bf70ef80e0d08c
@@ -13925,6 +13824,18 @@ packages:
   purls: []
   size: 114792
   timestamp: 1769904275716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_2.conda
+  sha256: 24f6d5021124329bd5c100e2824f67ca2e927ea7337d04d985ec3437057bfa4d
+  md5: 50c2599f30938cd26f6c2003032b211c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 114792
+  timestamp: 1770890724162
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.0.0-hf15766e_3.conda
   sha256: 829a98d1dd0859fec5536419c9d7b1b99a612a91c629f173f6e9f05003e85749
   md5: 70a507a1ce0a13f5562953631deec2fd
@@ -13947,6 +13858,17 @@ packages:
   purls: []
   size: 111764
   timestamp: 1769898305839
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2025.4.1-h3d5001d_2.conda
+  sha256: e1bb6bca1807c0bee29bc0ada64c6c1d1f2b7db61d06ae348997db8cc75f2f6a
+  md5: e2b63ce6bc27b8815184fbc7e3fac225
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 111986
+  timestamp: 1770884638275
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.0.0-h4d9b6c2_3.conda
   sha256: ae72903e0718897b85aae2110d9bb1bfa9490b0496522e3735b65c771e7da0ea
   md5: 74d074a3ac7af3378e16bfa6ff9cba30
@@ -13971,6 +13893,18 @@ packages:
   purls: []
   size: 250114
   timestamp: 1769904292210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_2.conda
+  sha256: 24aa3da807e6e9c079ad1a4dda167c4d24f2980d9f872544f5920a1bbdd32f7a
+  md5: 9992be1ddb9a2e878699170c06cc5bcb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 250313
+  timestamp: 1770890741123
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.0.0-hf15766e_3.conda
   sha256: af207ffa6f3a8a150620ca32c2996e941645689596ad2dc923115cef3ac1706d
   md5: 8399dc85b397fdb3770613c4b10f5a49
@@ -13993,6 +13927,17 @@ packages:
   purls: []
   size: 235829
   timestamp: 1769898319432
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2025.4.1-h3d5001d_2.conda
+  sha256: 0823660e3b66337022a0971052070afd05778890f2c8e1bf3e06309037f62501
+  md5: 8590b21846f798b9097ad362aaf01383
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 235721
+  timestamp: 1770884651838
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.0.0-h981d57b_3.conda
   sha256: b2c9ef97907f9c77817290bfb898897b476cc7ccf1737f0b1254437dda3d4903
   md5: 21f7997d68220d7356c1f80dc500bfad
@@ -14017,6 +13962,18 @@ packages:
   purls: []
   size: 212030
   timestamp: 1769904308850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_2.conda
+  sha256: 8f5fff1cee8127e15e278a241f19ccd8ffa36db4bf75b632f5d58c05cb1565ac
+  md5: ffc9462e82dc54f24d94399536774a6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 212579
+  timestamp: 1770890758143
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.0.0-ha8e9e04_3.conda
   sha256: 69c8e3a060a10900f6d35df32264f48560e153fe370c6a2ee7fcff1b969629bb
   md5: e12bff64bfd2ef9e282383afb3cccc13
@@ -14039,6 +13996,17 @@ packages:
   purls: []
   size: 204116
   timestamp: 1769898333070
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2025.4.1-he07c6df_2.conda
+  sha256: d54814fab18f61818abc087d854dbe5135ade77cc02796de9f04410a3f732c5b
+  md5: b2b6150fac2ad6f4edd1b8df46746ce5
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 204419
+  timestamp: 1770884665459
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.0.0-hdc3f47d_3.conda
   sha256: 9f6613906386a0c679c9a683ca97a5a2070111d9ada4f115c1806d921313e32d
   md5: 3385f38d15c7aebcc3b453e4d8dfb0fe
@@ -14065,6 +14033,19 @@ packages:
   purls: []
   size: 12956806
   timestamp: 1769904325853
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_2.conda
+  sha256: 324517ed5c5dde25d9def7d30e390ebbf0ade6be7e541ee535de2514c36822db
+  md5: dcff5decc0bcac07bb81276ed0104654
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 12980040
+  timestamp: 1770890775560
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.0.0-hdc3f47d_3.conda
   sha256: 8430f87a3cc65d3ef1ec8f9bfa990f6fb635601ad34ce08d70209099ff03f39c
   md5: f2d50e234edd843d9d695f7da34c7e96
@@ -14093,6 +14074,20 @@ packages:
   purls: []
   size: 11421657
   timestamp: 1769904366195
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_2.conda
+  sha256: d457fd2a6e4f6e2bc2457943c149f786e660bce40d6a9843a733b1e738a3a8dc
+  md5: c609d1b2a15535ff40702ee0c62f7793
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - ocl-icd >=2.3.3,<3.0a0
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 11430969
+  timestamp: 1770890817223
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.0.0-hdc3f47d_3.conda
   sha256: 37ec3e304bf14d2d7b7781c4b6a8b3a54deae90bc7275f6ae160589ef219bcef
   md5: f632cad865436394eebd41c3afa2cda3
@@ -14121,6 +14116,20 @@ packages:
   purls: []
   size: 1743490
   timestamp: 1769904403110
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_2.conda
+  sha256: 4577f42537f8ad768a5618b1e3484e95530372c01dc2b71b91fc2c7d28939815
+  md5: 6fabe9fecde73d1eb8b5fe865fc42819
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - level-zero >=1.28.0,<2.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 1743589
+  timestamp: 1770890855774
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.0.0-h981d57b_3.conda
   sha256: 268716b5c1858c1fddd51d63c7fcd7f3544ef04f221371ab6a2f9c579ca001e4
   md5: 94f25cc6fe70f507897abb8e61603023
@@ -14145,6 +14154,18 @@ packages:
   purls: []
   size: 200411
   timestamp: 1769904421156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_2.conda
+  sha256: d4d20bd0cff882edd7ccd5db951a6960df639e89bcc3c0671eb8fcde494e662e
+  md5: 7d28310dd0cd6e72251202de790388fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 200031
+  timestamp: 1770890874362
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.0.0-ha8e9e04_3.conda
   sha256: 3901f6922cfbac4de21622445d8a201862f46f502c95251bd2cba11eb67bf839
   md5: a3edb4a113c03ec3a3db3f89c7dabfb8
@@ -14167,6 +14188,17 @@ packages:
   purls: []
   size: 190629
   timestamp: 1769898346574
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2025.4.1-he07c6df_2.conda
+  sha256: 307d8c5d1a9bde07ad696df44240128fb4131fc2d11a20aa8109a787eb2c5c38
+  md5: 9fb10c7aa4422f9c36eb85547da15a4b
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 190899
+  timestamp: 1770884679080
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.0.0-h0e684df_3.conda
   sha256: 5ce66c01f6ea365a497f488e8eecea8930b6a016f9809db7f33b8a1ebbe5644e
   md5: 7cd3272c3171c1d43ed1c2b3d6795269
@@ -14195,6 +14227,20 @@ packages:
   purls: []
   size: 1902792
   timestamp: 1769904438153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h7a07914_2.conda
+  sha256: 2ce7decbbb252f52953eb69c85f7f1948d13121a50d748f20f9db1bdf896c092
+  md5: f7e5f4d50f1114476d948a4afe72e7aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 1920462
+  timestamp: 1770890891848
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.0.0-hd8f0270_3.conda
   sha256: 72097ef28507f41ff371cb10540261b7cbd433a9932a9c42d073f4d56335bfbe
   md5: cf46d328c1b254d16d18128999d31d61
@@ -14221,6 +14267,19 @@ packages:
   purls: []
   size: 1692258
   timestamp: 1769898360577
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2025.4.1-h558496d_2.conda
+  sha256: d9631851f26966283369ac7c0fbed6b4a5832a913fd423833065c4778ef98790
+  md5: 00e42251179551eeb1064a658fedc45c
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 1706648
+  timestamp: 1770884693186
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.0.0-h0e684df_3.conda
   sha256: 826507ac4ea2d496bdbec02dd9e3c8ed2eab253daa9d7f9119a8bc05c516d026
   md5: 5b66cbc9965b429922b8e69cd4e464d7
@@ -14249,6 +14308,20 @@ packages:
   purls: []
   size: 745483
   timestamp: 1769904456844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h7a07914_2.conda
+  sha256: 8d953ea646a9f88e27df2f4364d939f218659db211b8f02365554edfbf6f0c29
+  md5: 872ce0b26eba7c63342af17518921e64
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 746379
+  timestamp: 1770890911012
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.0.0-hd8f0270_3.conda
   sha256: b7666e63f7399e94599829b9b8901e1e6541d9d4d0c156359eb24846a434bcb7
   md5: 9d6043d6fae5342567173f949af80e4f
@@ -14275,6 +14348,19 @@ packages:
   purls: []
   size: 675934
   timestamp: 1769898376449
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2025.4.1-h558496d_2.conda
+  sha256: fdecd50a590b99384aa878c6f5f12f8b0b45c258637a24df8a3c2252130ef59a
+  md5: 3c0b6210a45260eb927a8ca1d3b9f32f
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 676062
+  timestamp: 1770884708960
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.0.0-h5888daf_3.conda
   sha256: fda07e70a23aac329be68ae488b790f548d687807f0e47bae7129df34f0adb5b
   md5: a6ece96eff7f60b2559ba699156b0edf
@@ -14297,6 +14383,17 @@ packages:
   purls: []
   size: 1266512
   timestamp: 1769904473901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_2.conda
+  sha256: d3278d4a121ae7255b898b4ad79a6a2761d3f21331a3022b72e53fcbe41d5631
+  md5: 6d76c8267adbec519a336e2ae591b5ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  purls: []
+  size: 1266211
+  timestamp: 1770890928572
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.0.0-h5ad3122_3.conda
   sha256: 174f630bdc3ffc6728fc83aefef15cf9a9a9fcd00712ce809df7a3b5c37dae99
   md5: d740a43f206611d7ab09488a6cb2f8eb
@@ -14317,6 +14414,16 @@ packages:
   purls: []
   size: 1142325
   timestamp: 1769898392266
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2025.4.1-hfae3067_2.conda
+  sha256: 00bc1b4c8cb3e02959c3e469b0f3cb3967d146e707e6ee7dc96f30bb9bc1f945
+  md5: d10e29f113f1bc3d6601dfd6ec1dc90d
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  purls: []
+  size: 1142046
+  timestamp: 1770884727169
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.0.0-h684f15b_3.conda
   sha256: e02990fccd4676e362a026acff3d706b5839ebf6ae681d56a2903f62a63e03ef
   md5: e1aeb108f4731db088782c8a20abf40a
@@ -14347,6 +14454,21 @@ packages:
   purls: []
   size: 1324086
   timestamp: 1769904491964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h78e8023_2.conda
+  sha256: 1bf285e6b5e9aee8ec31fbc3540a15079d3598dec757865a3625a4415495a736
+  md5: e1c042b51bc48fde21e33e4b063a6f70
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - snappy >=1.2.2,<1.3.0a0
+  purls: []
+  size: 1326875
+  timestamp: 1770890947226
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.0.0-h33e842c_3.conda
   sha256: 437fc934eaa6282258ac2dc3e58d276b208079ee2440264cd19b67a9b6ff6827
   md5: 9083c0e4a30698bdbab0598d964e4540
@@ -14361,6 +14483,20 @@ packages:
   purls: []
   size: 1204132
   timestamp: 1742043420133
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h2cb6e3c_2.conda
+  sha256: 61533da0af6be42a10b7875b0d3c739c7936b4d28335472c466bf276e3994163
+  md5: e220cb1e3a7766b7b54525be6a02e3d0
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - snappy >=1.2.2,<1.3.0a0
+  purls: []
+  size: 1231632
+  timestamp: 1770884742364
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h38473e3_1.conda
   sha256: 61b6cd52c7b36eefdcd61031fcc136dca2bf5da40eb016961675ab0513840718
   md5: d4db7b24db084ec72793dd3bfc93ac7d
@@ -14397,6 +14533,17 @@ packages:
   purls: []
   size: 496261
   timestamp: 1769904509651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_2.conda
+  sha256: acedf398736f215938b620d731375bf53e35651b198eef14ec38932b5712cccd
+  md5: 9e68b0b85a19341d4b5bff06196377a1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_2
+  - libstdcxx >=14
+  purls: []
+  size: 496037
+  timestamp: 1770890966852
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.0.0-h5ad3122_3.conda
   sha256: e1328d5e6ef41e112c1e79d06e2309b89da302806a5ec7b18cf7bfe47d321be6
   md5: bb1da88624792f47b7ac93ae0bb8206e
@@ -14417,6 +14564,16 @@ packages:
   purls: []
   size: 456871
   timestamp: 1769898421788
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_2.conda
+  sha256: e000cf544e1055ae4a62969bcfbb50b53b7f42aa6234864623c486f577c600d9
+  md5: 2e46e5e7ee8bf76777bf7c62e2c22a6d
+  depends:
+  - libgcc >=14
+  - libopenvino 2025.4.1 h1915271_2
+  - libstdcxx >=14
+  purls: []
+  size: 456898
+  timestamp: 1770884757014
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
   sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
   md5: 2446ac1fe030c2aa6141386c1f5a6aed
@@ -14529,27 +14686,27 @@ packages:
   purls: []
   size: 4235531
   timestamp: 1767877590823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
-  sha256: 5de60d34aac848a9991a09fcdea7c0e783d00024aefec279d55e87c0c44742cd
-  md5: d361fa2a59e53b61c2675bfa073e5b7e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
+  md5: 5f13ffc7d30ffec87864e678df9957b4
   depends:
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317435
-  timestamp: 1768285668880
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.54-h1abf092_0.conda
-  sha256: 190f6ee7265b752d139b54f988f9f765d93ed127a8372bf7c252f1cdca27fd4a
-  md5: 45b47396febdf400c55fe129cfc398aa
+  size: 317669
+  timestamp: 1770691470744
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
+  sha256: c7378c6b79de4d571d00ad1caf0a4c19d43c9c94077a761abb6ead44d891f907
+  md5: be4088903b94ea297975689b3c3aeb27
   depends:
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 339937
-  timestamp: 1768285692100
+  size: 340156
+  timestamp: 1770691477245
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
   sha256: 06a8ace6cc5ee47b85a5e64fad621e5912a12a0202398f54f302eb4e8b9db1fd
   md5: a4769024afeab4b32ac8167c2f92c7ac
@@ -14564,34 +14721,20 @@ packages:
   purls: []
   size: 2649881
   timestamp: 1763565297202
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.1-h5c52fec_2.conda
-  sha256: bbab2c3e6f650f2bd1bc84d88e6a20fefa6a401fa445bb4b97c509c1b3a89fa8
-  md5: a8ac9a6342569d1714ae1b53ae2fcadb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
+  sha256: 5f857281d53334f1a400afae7ae915161eb8f796ddadb11c082839a4c47de6da
+  md5: fa63c385ddb50957d93bdb394e355be8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
+  - icu >=78.2,<79.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=14
   - openldap >=2.6.10,<2.7.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2711480
-  timestamp: 1764345810429
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.1-hb80d175_3.conda
-  sha256: 21adefed86a36622dd500d7862cb980c5bdaab6ed3f4930a9b9afceabc7a6d58
-  md5: c39da2ad0e7dd600d1eb3146783b057d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.1,<79.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=14
-  - openldap >=2.6.10,<2.7.0a0
-  - openssl >=3.5.4,<4.0a0
-  license: PostgreSQL
-  purls: []
-  size: 2761692
-  timestamp: 1766448056465
+  size: 2809023
+  timestamp: 1770915404394
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.7-haf03d9f_1.conda
   sha256: bd9f9a792eb9843a583714849041bc1b53d3a30deb15b73e21f13b4f4bb8db6a
   md5: 16b3ba316edb147bf2063b8003ea8939
@@ -14605,32 +14748,19 @@ packages:
   purls: []
   size: 2774183
   timestamp: 1763565420622
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.1-haf03d9f_2.conda
-  sha256: 14f7609f8074bd689fafa981c3bbf07ee2a37f5d7f40e158d01a25fe280e2177
-  md5: 8b0d66c4db91b3ef64daad7f61a569d0
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.2-hf8816c8_0.conda
+  sha256: 529ac66cdfce1dc5ead63071f2e2dd69a3fa88b4a8dcf4595079997a3df5dd97
+  md5: c54b5b1eb1b2c0f41781293fd4b530b3
   depends:
-  - icu >=75.1,<76.0a0
+  - icu >=78.2,<79.0a0
   - krb5 >=1.21.3,<1.22.0a0
   - libgcc >=14
   - openldap >=2.6.10,<2.7.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2783759
-  timestamp: 1764345873700
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.1-hf8816c8_3.conda
-  sha256: 728673152498cd078e1818da74f69cabce940ac6a05c25e89f154583fb3339b1
-  md5: e0d7a6cbc0b8a6d05002cb9bd061a4af
-  depends:
-  - icu >=78.1,<79.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=14
-  - openldap >=2.6.10,<2.7.0a0
-  - openssl >=3.5.4,<4.0a0
-  license: PostgreSQL
-  purls: []
-  size: 2792562
-  timestamp: 1766448160775
+  size: 2785155
+  timestamp: 1770915428682
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h7460b1f_3.conda
   sha256: 14450a1cd316fe639dd0a5e040f6f31c374537141b7b931bf8afbfd5a04d9843
   md5: 63c1256f51815217d296afa24af6c754
@@ -14661,6 +14791,21 @@ packages:
   purls: []
   size: 4372578
   timestamp: 1766316228461
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+  sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
+  md5: 11ac478fa72cf12c214199b8a96523f4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3638698
+  timestamp: 1769749419271
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.29.3-h9267e96_3.conda
   sha256: 59627092f1bd23a82f6827b679125408b8bed2738b3e3af900e3fcf3a94ed96d
   md5: 30c909af87055ea5b257f29e4f7d9297
@@ -14689,6 +14834,20 @@ packages:
   purls: []
   size: 4218080
   timestamp: 1766315327959
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
+  sha256: f68780642c215b93f4991c43d88ab0af8a08e66826e68affc65b8905cc21d86b
+  md5: 7f4a589ae616399b7e375053e82a3b12
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.0,<20260108.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3465308
+  timestamp: 1769748410724
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
   sha256: daed72abc320ec9b33a9c7092a160f9683d04425fa194e789829d06528c4b266
   md5: 3459f613a2c36a161d0cee2f38bfd9d6
@@ -15100,82 +15259,82 @@ packages:
   purls: []
   size: 311396
   timestamp: 1745609845915
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-  sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
-  md5: 68f68355000ec3f1d6f26ea13e8f525f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+  sha256: 50c48cd3716a2e58e8e2e02edc78fef2d08fffe1e3b1ed40eb5f87e7e2d07889
+  md5: 24c2fe35fa45cd71214beba6f337c071
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_16
+  - libgcc 15.2.0 he0feb66_17
   constrains:
-  - libstdcxx-ng ==15.2.0=*_16
+  - libstdcxx-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 5856456
-  timestamp: 1765256838573
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-  sha256: 4db11a903707068ae37aa6909511c68e9af6a2e97890d1b73b0a8d87cb74aba9
-  md5: 52d9df8055af3f1665ba471cce77da48
+  size: 5852406
+  timestamp: 1770252584235
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+  sha256: fe425c07aa3116e7d5f537efe010d545bb43ac120cb565fbfb5ece8cb725aa80
+  md5: 500d275cb616d81b5d9828aedffc4bc3
   depends:
-  - libgcc 15.2.0 h8acb6b2_16
+  - libgcc 15.2.0 h8acb6b2_17
   constrains:
-  - libstdcxx-ng ==15.2.0=*_16
+  - libstdcxx-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 5541149
-  timestamp: 1765256980783
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_116.conda
-  sha256: cb331c51739cc68257c7d7eef0e29c355b46b2d72f630854506dbc99240057c1
-  md5: 2730e07e576ffbd7bf13f8de34835d41
+  size: 5542688
+  timestamp: 1770252159760
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_117.conda
+  sha256: fc9f068b67579c583a55446855fa61386051d0c809121e7ed05d484f389f5ede
+  md5: f03443e70a0184411736e67166282d8f
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 20763949
-  timestamp: 1765256724565
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_116.conda
-  sha256: 06be0d20cb3784e1d625f316f26962085dd14f74e166bd668ee9c089b5fa3efa
-  md5: 48cfd02ec4f1308109e5daaccb99aa30
+  size: 20748870
+  timestamp: 1770252462739
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_117.conda
+  sha256: c14d731f4673b25c6aafcb1137d5293ecc84a074e208f9016fd02e7f426fb928
+  md5: 0843c0da805052d6657a6db839b5ce00
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 17639950
-  timestamp: 1765256847600
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
-  sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
-  md5: 1b3152694d236cf233b76b8c56bf0eae
+  size: 17527790
+  timestamp: 1770252060613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+  sha256: ca3fb322dab3373946b1064da686ec076f5b1b9caf0a2823dad00d0b0f704928
+  md5: ea12f5a6bf12c88c06750d9803e1a570
   depends:
-  - libstdcxx 15.2.0 h934c35e_16
+  - libstdcxx 15.2.0 h934c35e_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27300
-  timestamp: 1765256885128
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
-  sha256: dd5c813ae5a4dac6fa946352674e0c21b1847994a717ef67bd6cc77bc15920be
-  md5: 20b7f96f58ccbe8931c3a20778fb3b32
+  size: 27573
+  timestamp: 1770252638797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+  sha256: 3842e84b5ad187cb30c7a1c8b5c0a33d70b7b3ce91b27dfcb2a6f2c2f055f07d
+  md5: beb8c015b02b7a1c2eea6d7a9847f8f5
   depends:
-  - libstdcxx 15.2.0 hef695bb_16
+  - libstdcxx 15.2.0 hef695bb_17
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 27376
-  timestamp: 1765257033344
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
-  sha256: b3a7f89462dc95c1bba9f663210d20ff3ac5f7db458684e0f3a7ae5784f8c132
-  md5: 70d1de6301b58ed99fea01490a9802a3
+  size: 27614
+  timestamp: 1770252201381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
+  sha256: f0356bb344a684e7616fc84675cfca6401140320594e8686be30e8ac7547aed2
+  md5: 1d4c18d75c51ed9d00092a891a547a7d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.77,<2.78.0a0
   - libgcc >=14
   license: LGPL-2.1-or-later
   purls: []
-  size: 491268
-  timestamp: 1765552759709
+  size: 491953
+  timestamp: 1770738638119
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.4-h3dc2cb9_0.conda
   sha256: 5a073ee10beb11a8616277b37f09971d14fe6b1311c1ab69620c030537f0eefd
   md5: cb9e2966356c3cd8b91fc3998cc4eaa0
@@ -15191,16 +15350,16 @@ packages:
   purls: []
   size: 488348
   timestamp: 1741612443852
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
-  sha256: 57fe7a9f0c289e4f2fdf5200271848adc9f102921056d5904173942628b472cd
-  md5: 254474a19793a5f06de7cf3e3e2359fb
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_4.conda
+  sha256: 95bb4c430e8ca666a4c67b7951f03fbee5a5258b1d29c2a26bf56c86fe32c010
+  md5: 96e731e9cf876fb2d8882093c0f24630
   depends:
   - libcap >=2.77,<2.78.0a0
   - libgcc >=14
   license: LGPL-2.1-or-later
   purls: []
-  size: 517687
-  timestamp: 1765552618501
+  size: 517911
+  timestamp: 1770738680829
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.4-h27834fc_0.conda
   sha256: f80282962e974af3629b9623ee908590210837eb93a0b63bb2058c10bfa51821
   md5: 1e88213b16672350abe3810b002a1b0d
@@ -15304,17 +15463,17 @@ packages:
   purls: []
   size: 488407
   timestamp: 1762022048105
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
-  sha256: 977e7e4955ea1581e441e429c2c1b498bc915767f1cac77a97b283c469d5298c
-  md5: 3934f4cf65a06100d526b33395fb9cd2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
+  sha256: ed4d2c01fbeb1330f112f7e399408634db277d3dfb2dec1d0395f56feaa24351
+  md5: 6c74fba677b61a0842cbf0f63eee683b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.77,<2.78.0a0
   - libgcc >=14
   license: LGPL-2.1-or-later
   purls: []
-  size: 145023
-  timestamp: 1765552781358
+  size: 144654
+  timestamp: 1770738650966
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.4-h9a4d06a_0.conda
   sha256: 65ebc2185cdc008f8da92864e8063e60293c59134b11b13e4bc44fd6f6e04eec
   md5: 8b87f46f586167c54b2d4c0fd4a72001
@@ -15326,16 +15485,16 @@ packages:
   purls: []
   size: 143836
   timestamp: 1741612453664
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
-  sha256: 39bdad22998d1ef5b366d9c557b5ca8a2ee2bea1f05eab9e1b20fbfef9d6d7a4
-  md5: 8da19c1b9138b2f0a57012c31e3ad81d
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_4.conda
+  sha256: 18098716de78ab49566c862a5bf1f89e0e064a4fc0f31ad08b60b7774cfdb60e
+  md5: a9bcd3f70036640538e8187e4c594cbf
   depends:
   - libcap >=2.77,<2.78.0a0
   - libgcc >=14
   license: LGPL-2.1-or-later
   purls: []
-  size: 156695
-  timestamp: 1765552629955
+  size: 157130
+  timestamp: 1770738690431
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.4-h1187dce_0.conda
   sha256: 1389af70858732b9bf6384c2af9b1da4b261bc8d889bb6a25d853a75cbb04073
   md5: 0a0bd551a68587c7dd852324da97b853
@@ -15827,22 +15986,6 @@ packages:
   purls: []
   size: 697033
   timestamp: 1761766011241
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
-  sha256: ec0735ae56c3549149eebd7dc22c0bed91fd50c02eaa77ff418613ddda190aa8
-  md5: e512be7dc1f84966d50959e900ca121f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libxml2-16 2.15.1 ha9997c6_0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 45283
-  timestamp: 1761015644057
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
   sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
   md5: 417955234eccd8f252b86a265ccdab7f
@@ -15873,21 +16016,6 @@ packages:
   purls: []
   size: 737147
   timestamp: 1761766137531
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h788dabe_0.conda
-  sha256: db0a568e0853ee38b7a4db1cb4ee76e57fe7c32ccb1d5b75f6618a1041d3c6e4
-  md5: a0e7779b7625b88e37df9bd73f0638dc
-  depends:
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libxml2-16 2.15.1 h8591a01_0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 47192
-  timestamp: 1761015739999
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.1-h825857f_1.conda
   sha256: 9fe997c3e5a8207161d093a5d73f586ae46dc319cb054220086395e150dd1469
   md5: eb4665cdf78fd02d4abc4edf8c15b7b9
@@ -15903,23 +16031,6 @@ packages:
   purls: []
   size: 47725
   timestamp: 1766327143205
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
-  sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
-  md5: e7733bc6785ec009e47a224a71917e84
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.1
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 556302
-  timestamp: 1761015637262
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
   sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
   md5: 3fdd8d99683da9fe279c2f4cecd1e048
@@ -15953,22 +16064,6 @@ packages:
   purls: []
   size: 599721
   timestamp: 1766327134458
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.1-h8591a01_0.conda
-  sha256: 7a13450bce2eeba8f8fb691868b79bf0891377b707493a527bd930d64d9b98af
-  md5: e7177c6fbbf815da7b215b4cc3e70208
-  depends:
-  - icu >=75.1,<76.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.1
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 597078
-  timestamp: 1761015734476
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
   sha256: 0694760a3e62bdc659d90a14ae9c6e132b525a7900e59785b18a08bb52a5d7e5
   md5: 87e6096ec6d542d1c1f8b33245fe8300
@@ -17165,31 +17260,29 @@ packages:
   purls: []
   size: 392636
   timestamp: 1758489353577
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
-  sha256: 5f8e3ad6e707c3ffee81c3c2cbc1ac8f66eb10bbe0fe2edbe1cdad0972e006c8
-  md5: 65900b71509b2fd6c0a34a5dc1bd893a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.1-h8d634f6_0.conda
+  sha256: 5c87322edbbf19aa3ba053cdf75926fc01a1e7322cd950f443b3c07b704aed8a
+  md5: cc109dc1a4bedbd4f66c15502cb5df5b
   depends:
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libtiff >=4.7.1,<4.8.0a0
   license: BSD-2-Clause
-  license_family: BSD
   purls: []
-  size: 279868
-  timestamp: 1766578366964
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.0-h55827e0_0.conda
-  sha256: a3466093a27b20cce488f8adeacca1b31178956a59713bbaaced77f91b164dd1
-  md5: 9bbfd5f7bacb0ff01df9a3f09d52756d
+  size: 279779
+  timestamp: 1771181562551
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.1-h55827e0_0.conda
+  sha256: 2b34fd0cb3af698bf4e2eb4dd7e498ee87eefb3e03419162b217b9383c04047a
+  md5: 2e78f5dec9beccee3ba113292a1cfd1a
   depends:
   - libstdcxx >=14
   - libgcc >=14
   - libtiff >=4.7.1,<4.8.0a0
   license: BSD-2-Clause
-  license_family: BSD
   purls: []
-  size: 228517
-  timestamp: 1766578419889
+  size: 228526
+  timestamp: 1771181567062
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
   sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
   md5: 2e5bf4f1da39c0b32778561c3c4e5878
@@ -17267,9 +17360,9 @@ packages:
   purls: []
   size: 375893
   timestamp: 1760695582335
-- conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.1-h3435931_0.conda
-  sha256: 80193ee986b5a20b11d0a3f12c971d349cd6f46078247558904431f32213f02c
-  md5: 5abdbe4b5b16545d68431330e827a9d1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
+  sha256: f63962d24d81d4fafa15112c03cd5db1fddadd520fdb2ad7ec71a1689e8e694f
+  md5: 312989f1b7318c3763fffdc78df8474e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.5.2,<3.6.0a0
@@ -17278,11 +17371,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 3928152
-  timestamp: 1768944544987
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.1-h376a255_0.conda
-  sha256: 57c22390ce982b664f307a25afc34c99aef4e5b39b30d4a18aea3782e4111aff
-  md5: 4a2589bea4042a26ddbd894eace2060d
+  size: 3831848
+  timestamp: 1770417713801
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
+  sha256: b531aecc01aabb9a1f24d3586d96d07ca15d934465c1342c6a5e095e08d930a2
+  md5: 850c48e406ab29922a7fb8f61286abac
   depends:
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
@@ -17290,8 +17383,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 5176363
-  timestamp: 1768947686740
+  size: 5180065
+  timestamp: 1770420952184
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
   sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
   md5: b76541e68fea4d511b1ac46a28dcd2c6
@@ -17440,29 +17533,29 @@ packages:
   - pkg:pypi/pillow?source=hash-mapping
   size: 1044595
   timestamp: 1764033139051
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py312h50c33e8_0.conda
-  sha256: dc15482aadc863e2b65757b13a248971e832036bf5ccd2be48d02dfe4c1cf5e0
-  md5: 923b06ad75b7acc888fa20a22dc397cd
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
+  sha256: 782b6b578a0e61f6ef5cca5be993d902db775a2eb3d0328a3c4ff515858e7f2c
+  md5: c5eff3ada1a829f0bdb780dc4b62bbae
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
-  - tk >=8.6.13,<8.7.0a0
+  - lcms2 >=2.18,<3.0a0
   - python_abi 3.12.* *_cp312
-  - libxcb >=1.17.0,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
   - libtiff >=4.7.1,<4.8.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - zlib-ng >=2.3.2,<2.4.0a0
-  - lcms2 >=2.17,<3.0a0
   - openjpeg >=2.5.4,<3.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 1029473
-  timestamp: 1767353193448
+  - pkg:pypi/pillow?source=compressed-mapping
+  size: 1029755
+  timestamp: 1770794002406
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.0.0-py311hc62970c_1.conda
   sha256: 842883ec66d314a76b8c8bee47606ca552a8faf5794424dd659eb9a0c31a65de
   md5: 5d5a4f490c34d21fd1485112ceec9b14
@@ -17486,29 +17579,29 @@ packages:
   - pkg:pypi/pillow?source=hash-mapping
   size: 1024450
   timestamp: 1764033144336
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.0-py312h3b21937_0.conda
-  sha256: abdb88d8c85c02ed0b1d7967d309ba38b2a4390a94b65859eeeb2d77d507feb2
-  md5: e54f3db6483774a598e48aefac808b38
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
+  sha256: 72a6e7f18ca62f212c7b98c230d4798514764b2e9ee5b1ec10c467381b2df3c2
+  md5: df2579ed3703c56e70087d06f5f956df
   depends:
   - python
   - libgcc >=14
   - python 3.12.* *_cpython
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libxcb >=1.17.0,<2.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
-  - tk >=8.6.13,<8.7.0a0
-  - zlib-ng >=2.3.2,<2.4.0a0
-  - lcms2 >=2.17,<3.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libtiff >=4.7.1,<4.8.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - lcms2 >=2.18,<3.0a0
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 1010269
-  timestamp: 1767353151891
+  size: 1010426
+  timestamp: 1770794010333
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.7.0-py311hd79ae85_0.conda
   sha256: 7f3b0183e68c6db6a6cb0d03d41f73474521034bebd87a52b5cce48584cc3390
   md5: a696dd449736ea221cd96bbce03e9176
@@ -17701,7 +17794,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/psutil?source=compressed-mapping
+  - pkg:pypi/psutil?source=hash-mapping
   size: 231786
   timestamp: 1769678156460
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
@@ -17729,7 +17822,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/psutil?source=compressed-mapping
+  - pkg:pypi/psutil?source=hash-mapping
   size: 236635
   timestamp: 1769678160506
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py312hd41f8a7_0.conda
@@ -17878,20 +17971,20 @@ packages:
   purls: []
   size: 1153661
   timestamp: 1751758451269
-- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.12.0-qt6_py312h598be00_612.conda
-  sha256: 625f42acd5e3b4591c69be2e718ecebc3bd2ed4a00bea7ebd472b607e0197cfb
-  md5: 9fefe5550f3e8d5555efe24dfc94805c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h3a6da57_602.conda
+  sha256: 365d039f9ba7b74ab2004eede592d51a934db9e080c29751241562fa8707ea85
+  md5: 88fa01cb5370ea4ab56abc3d3df5bbd9
   depends:
-  - libopencv 4.12.0 qt6_py312h52d6ec5_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libopencv 4.13.0 qt6_py312hbe9d83b_602
+  - libprotobuf >=6.33.5,<6.33.6.0a0
   - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1154634
-  timestamp: 1766495407579
+  size: 1154078
+  timestamp: 1770927479102
 - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.13.0-qt6_py312h598be00_601.conda
   sha256: 256f704b939f4a6d7e765245ada425cf0f0e646654c39af2d7130d3b02461cb9
   md5: cee60bb8e5e5e0ed978b0f0b99f140f4
@@ -17920,20 +18013,6 @@ packages:
   purls: []
   size: 1153848
   timestamp: 1751758156649
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.12.0-qt6_py312h1743b20_612.conda
-  sha256: 942366d9d2ebd50b332f76456f44936a1e660254f62dff3601c98f752b0431d9
-  md5: 577b5cb5f79a0448b49e4e74689de614
-  depends:
-  - libopencv 4.12.0 qt6_py312h051a780_612
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 1154560
-  timestamp: 1766496246197
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h1743b20_601.conda
   sha256: cbda7a23f6b1d6c8f26bd28dc7d5c5ef5d45d70eb794995961507e77ead11010
   md5: e966f8ac43ec250ece096d4764d2dcce
@@ -17948,6 +18027,20 @@ packages:
   purls: []
   size: 1154757
   timestamp: 1769912289231
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.13.0-qt6_py312h9d755fc_602.conda
+  sha256: e0df5c60f932e608879e2bc9c83492683e9729bdf7d5af5d59cc9a8ee36f82b2
+  md5: d7b29579bf1dc66ecdbd7b2fc122e729
+  depends:
+  - libopencv 4.13.0 qt6_py312hac3c9ff_602
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1154173
+  timestamp: 1770927844243
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
   sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
   md5: 70ece62498c769280f791e836ac53fff
@@ -18065,32 +18158,6 @@ packages:
   - pkg:pypi/pyparsing?source=compressed-mapping
   size: 110893
   timestamp: 1769003998136
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.1-py312h9da60e5_0.conda
-  sha256: dccbc2674aaae31711933942fd16d87b127e6335556d5701cb760f27986f0375
-  md5: dda0a61b6186fc914cf6c1581f64229d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libclang13 >=21.1.7
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - libstdcxx >=14
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libxslt >=1.1.43,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt6-main 6.10.1.*
-  - qt6-main >=6.10.1,<6.11.0a0
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls:
-  - pkg:pypi/pyside6?source=hash-mapping
-  - pkg:pypi/shiboken6?source=hash-mapping
-  size: 11606305
-  timestamp: 1765811838817
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py312h9da60e5_0.conda
   sha256: 5e00f3e0a273e18b4ec0ae7f4fff507333a354dd5ecc31dd9f3b02ab1ee77163
   md5: 52412f1ae11e89b721784f2118188902
@@ -18141,31 +18208,6 @@ packages:
   - pkg:pypi/shiboken6?source=hash-mapping
   size: 10150360
   timestamp: 1756675160062
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.1-py312h4810df5_0.conda
-  sha256: cff2b6998a1de0a4b1eab5b8650e7c4ff53411f801450f7befa1e805aded96b6
-  md5: c75a1e6df539da34554cf0761d455221
-  depends:
-  - libclang13 >=21.1.7
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - libstdcxx >=14
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libxslt >=1.1.43,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - qt6-main 6.10.1.*
-  - qt6-main >=6.10.1,<6.11.0a0
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls:
-  - pkg:pypi/pyside6?source=hash-mapping
-  - pkg:pypi/shiboken6?source=hash-mapping
-  size: 7310180
-  timestamp: 1765812001685
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.2-py312h4810df5_0.conda
   sha256: 35c1a5e03c69929e0f456691afbcbe560463833cf0daed4276b7c97357b88e70
   md5: cdd1b930b3106c0fcc76b5535e080655
@@ -18542,7 +18584,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 201473
   timestamp: 1770223445971
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
@@ -18663,46 +18705,46 @@ packages:
   purls: []
   size: 52149940
   timestamp: 1756072007197
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3c3fd16_6.conda
-  sha256: 986dff37c0d4792f8e03f7313ffad28698fe80e9697f87cf54b895a456bd2e8a
-  md5: 5aab84b9d164509b5bbe3af660518606
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hc240232_7.conda
+  sha256: 401cc7f9ff78ee12097fcda8c09dcf269847a8a55b17b7c0a973f322c7bd5fbc
+  md5: fa3bbe293d907990f3ca5b8b9d4b10f0
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.14,<1.3.0a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
   - dbus >=1.16.2,<2.0a0
   - fontconfig >=2.15.0,<3.0a0
   - fonts-conda-ecosystem
-  - gst-plugins-base >=1.24.11,<1.25.0a0
-  - gstreamer >=1.24.11,<1.25.0a0
-  - harfbuzz >=12.1.0
-  - icu >=75.1,<76.0a0
+  - gst-plugins-base >=1.26.10,<1.27.0a0
+  - gstreamer >=1.26.10,<1.27.0a0
+  - harfbuzz >=12.3.2
+  - icu >=78.2,<79.0a0
   - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp21.1 >=21.1.3,<21.2.0a0
-  - libclang13 >=21.1.3
+  - libclang-cpp21.1 >=21.1.8,<21.2.0a0
+  - libclang13 >=21.1.8
   - libcups >=2.3.3,<2.4.0a0
   - libdrm >=2.4.125,<2.5.0a0
   - libegl >=1.7.0,<2.0a0
   - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.7.1,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
   - libgcc >=13
   - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.0,<3.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - libllvm21 >=21.1.3,<21.2.0a0
-  - libpng >=1.6.50,<1.7.0a0
-  - libpq >=18.0,<19.0a0
-  - libsqlite >=3.50.4,<4.0a0
+  - libglib >=2.86.3,<3.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libllvm21 >=21.1.8,<21.2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libpq >=18.1,<19.0a0
+  - libsqlite >=3.51.2,<4.0a0
   - libstdcxx >=13
   - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.12.0,<2.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
   - libxml2
   - libxml2-16 >=2.14.6
   - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.37,<5.0a0
-  - nss >=3.117,<4.0a0
-  - openssl >=3.5.4,<4.0a0
+  - nspr >=4.38,<5.0a0
+  - nss >=3.118,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - pulseaudio-client >=17.0,<17.1.0a0
   - xcb-util >=0.4.1,<0.5.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
@@ -18713,55 +18755,55 @@ packages:
   - xorg-libsm >=1.2.6,<2.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
   - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
   - qt 5.15.15
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 52624585
-  timestamp: 1760351016368
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
-  sha256: a91610b6df6a4a3aadfe94356a217714841829ce71b965798ae219f5687ccf46
-  md5: 27c3b4684b1fab3d79c9eb2d0268b449
+  size: 52414725
+  timestamp: 1770722572283
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
+  sha256: 279ed48d551966178cfde61d84c1b6ea9f2c0ad68620eb61f8ab8dff62a813d4
+  md5: 9a6791966bf4abb19bb1153758c97154
   depends:
-  - alsa-lib >=1.2.14,<1.3.0a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
   - dbus >=1.16.2,<2.0a0
   - fontconfig >=2.15.0,<3.0a0
   - fonts-conda-ecosystem
-  - gst-plugins-base >=1.24.11,<1.25.0a0
-  - gstreamer >=1.24.11,<1.25.0a0
-  - harfbuzz >=12.1.0
-  - icu >=75.1,<76.0a0
+  - gst-plugins-base >=1.26.10,<1.27.0a0
+  - gstreamer >=1.26.10,<1.27.0a0
+  - harfbuzz >=12.3.2
+  - icu >=78.2,<79.0a0
   - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp21.1 >=21.1.2,<21.2.0a0
-  - libclang13 >=21.1.2
+  - libclang-cpp21.1 >=21.1.8,<21.2.0a0
+  - libclang13 >=21.1.8
   - libcups >=2.3.3,<2.4.0a0
   - libdrm >=2.4.125,<2.5.0a0
   - libegl >=1.7.0,<2.0a0
   - libevent >=2.1.12,<2.1.13.0a0
-  - libexpat >=2.7.1,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
   - libgcc >=13
   - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.0,<3.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - libllvm21 >=21.1.2,<21.2.0a0
-  - libpng >=1.6.50,<1.7.0a0
-  - libpq >=18.0,<19.0a0
-  - libsqlite >=3.50.4,<4.0a0
+  - libglib >=2.86.3,<3.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libllvm21 >=21.1.8,<21.2.0a0
+  - libpng >=1.6.54,<1.7.0a0
+  - libpq >=18.1,<19.0a0
+  - libsqlite >=3.51.2,<4.0a0
   - libstdcxx >=13
   - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.12.0,<2.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
   - libxml2
   - libxml2-16 >=2.14.6
   - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.37,<5.0a0
-  - nss >=3.117,<4.0a0
-  - openssl >=3.5.4,<4.0a0
+  - nspr >=4.38,<5.0a0
+  - nss >=3.118,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - pulseaudio-client >=17.0,<17.1.0a0
   - xcb-util >=0.4.1,<0.5.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
@@ -18772,16 +18814,16 @@ packages:
   - xorg-libsm >=1.2.6,<2.0a0
   - xorg-libx11 >=1.8.12,<2.0a0
   - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
   - qt 5.15.15
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 52013627
-  timestamp: 1760203845477
+  size: 51877158
+  timestamp: 1769998016372
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hbe73643_5.conda
   sha256: 88fa7acea70be2846842a3d8fc48a81b3d4ce2d90d7f2b1112227416a0135924
   md5: 04bd1a8591a1e75d294ef39ee9b8d146
@@ -18840,70 +18882,6 @@ packages:
   purls: []
   size: 51916609
   timestamp: 1756053434448
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.1-h6f76662_3.conda
-  sha256: 8269ca1fc02dbd419f77ed30b6ec205897efd12813607ecb0630f075f8c5f01f
-  md5: f134a496ef494f2b6c5a26e5d739acc6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - dbus >=1.16.2,<2.0a0
-  - double-conversion >=3.4.0,<3.5.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - harfbuzz >=12.2.0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp21.1 >=21.1.7,<21.2.0a0
-  - libclang13 >=21.1.7
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.3,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libllvm21 >=21.1.7,<21.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libpq >=18.1,<19.0a0
-  - libsqlite >=3.51.1,<4.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - wayland >=1.24.0,<2.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-cursor >=0.1.6,<0.2.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxcomposite >=0.4.6,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrandr >=1.5.4,<2.0a0
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - qt 6.10.1
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 56636216
-  timestamp: 1766349442902
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
   sha256: 82393e8fc34c07cbd7fbba5ef7ce672165ff657492ad1790bb5fad63d607cccd
   md5: 9861c7820fdb45bc50a2ea60f4ff7952
@@ -19030,69 +19008,6 @@ packages:
   purls: []
   size: 52405921
   timestamp: 1758011263853
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.1-h9c50542_3.conda
-  sha256: 413f58648f0cfb7c93eac52e7aa4247ef1fa8babd6e1336a825986b59bf3beef
-  md5: 35cdd1d3eeb2a53672f0005564c10c9d
-  depends:
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - dbus >=1.16.2,<2.0a0
-  - double-conversion >=3.4.0,<3.5.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - harfbuzz >=12.2.0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp21.1 >=21.1.7,<21.2.0a0
-  - libclang13 >=21.1.7
-  - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.3,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libllvm21 >=21.1.7,<21.2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libpq >=18.1,<19.0a0
-  - libsqlite >=3.51.1,<4.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libvulkan-loader >=1.4.328.1,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - wayland >=1.24.0,<2.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xcb-util-cursor >=0.1.6,<0.2.0a0
-  - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.1,<0.5.0a0
-  - xcb-util-renderutil >=0.3.10,<0.4.0a0
-  - xcb-util-wm >=0.4.2,<0.5.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxcomposite >=0.4.6,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrandr >=1.5.4,<2.0a0
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - qt 6.10.1
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 59404266
-  timestamp: 1766346978669
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-h5343e53_4.conda
   sha256: bdbe77528cc62c84414b954a377663322a467934df0348cc00647af9b6ddcc4c
   md5: d21d5b2950f78f8f187aec04869bc9b3
@@ -29254,24 +29169,24 @@ packages:
   license: BSD-3-Clause
   size: 22778
   timestamp: 1753308529103
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np2py312h2ed9cc7_14.conda
-  sha256: aaff59a0a1bdfd645b71cfd59b1e5bd97e9c7faf67b9697ef192183df161606d
-  md5: 807d804e6e35e3709f5b0cb131e372d4
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-msgs-2.0.2-np2py312h2ed9cc7_16.conda
+  sha256: 24c3be282ad6e801ccd25d93f14ab2584a756174c8d5b1f97d4e66acbdfa677e
+  md5: ee033082fda524a2116438ce5335d8f4
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 89731
-  timestamp: 1768976569146
+  size: 90133
+  timestamp: 1771184649784
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-msgs-2.0.2-np2py312h61f2ce4_14.conda
   sha256: 58b85db016f341da013e3719f75e2c67564a6ea025ff86914652d2b215405b92
   md5: 8b51761c3058a7fc747f1f5e3f7badbc
@@ -29289,9 +29204,9 @@ packages:
   license: BSD-3-Clause
   size: 93941
   timestamp: 1768945572058
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 2a34a4a42b9160a497443e2a8217a9a4f0af892b2863e2d1037f4169771522dc
-  md5: fa7ae9f5392ed0088a313676794647c8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ackermann-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 148b3a42e3f423c55507c1c042b3550c347e60c535fda2a7996e60f9be198545
+  md5: 28f1023702bc12c02178af5242e94bb2
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -29304,17 +29219,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-srvs
   - ros-jazzy-steering-controllers-library
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 107328
-  timestamp: 1768982016668
+  size: 107200
+  timestamp: 1771190428063
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ackermann-steering-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: bb6e3e53801a495c1cab0e29ed75b47abfca59422cb1b32830fc60bef88d5a0e
   md5: f9c6650e2e3d6ddc77da9357cca1cac4
@@ -29339,9 +29254,9 @@ packages:
   license: Apache-2.0
   size: 104342
   timestamp: 1768950009924
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: df3a7c99d1444ff2c0d73c512b1c75f4ba8e181fd275fa96f9e98dacda20fa92
-  md5: d1505737d684a86fc85f8eeb63972d07
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-action-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: de90c354f2833719b868748f8683cce0788fcb33fc950c65d98fbc33653466d0
+  md5: ee92167b7ec28fdbc23388c7a8c74936
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -29349,17 +29264,16 @@ packages:
   - ros-jazzy-rosidl-core-runtime
   - ros-jazzy-service-msgs
   - ros-jazzy-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 152330
-  timestamp: 1768976295979
+  size: 152219
+  timestamp: 1771184279030
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-action-msgs-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 20ed3f836533209da76473c4af876480ababc41762f79d82a8dd5291a96ea338
   md5: a85acf6a01b2e230070ce42d66a0e780
@@ -29379,26 +29293,26 @@ packages:
   license: Apache-2.0
   size: 157590
   timestamp: 1768945263400
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 780d2d4208a70c28c606b6f1b7c7014fc7b95dc6ab68085efdedf94bb130ab71
-  md5: 8b1d6999c5a0cf9cecb18d467abb7a95
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-actionlib-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 4cfbbd610ecf55c5f6b22c9972a9271a33d0b385caee9e747a3721b5d6d70d69
+  md5: cf00ccaa7ddf4586dee2363a736bab77
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 111418
-  timestamp: 1768976645128
+  size: 112790
+  timestamp: 1771184720660
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-actionlib-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 4b7e415fb88557a1b8b32393a1f81b4348956a2c7404ae5d3cab334be52fa7bc
   md5: 522bebf7c062fd4adb5e639359fb687e
@@ -29418,9 +29332,9 @@ packages:
   license: Apache-2.0
   size: 115258
   timestamp: 1768945649833
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: e97556a20d17266177ab054f45bdfd9b6c9e024307a2ac61392a7a8bc288b952
-  md5: 32532d9fbb36fa7ce303d677026a9243
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-admittance-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 8ffd5ecd3ffbdef53181cc2f342bb4791dc959456d7e1f0314184348c3eb7978
+  md5: 4c5d20f2c6053e5858894a490458e5a6
   depends:
   - python
   - ros-jazzy-angles
@@ -29443,16 +29357,19 @@ packages:
   - ros-jazzy-tf2-kdl
   - ros-jazzy-tf2-ros
   - ros-jazzy-trajectory-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - tinyxml2
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 424598
-  timestamp: 1768981559624
+  size: 425869
+  timestamp: 1771189941612
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-admittance-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: ac572560b147f31a895bd7bdde7735f11e78a42828ba75b3c7856449561ba3a7
   md5: b784166b0d1d86a4255b62a03f0b5aef
@@ -29488,9 +29405,9 @@ packages:
   license: Apache-2.0
   size: 410930
   timestamp: 1768949619965
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 0483bf4dbda7d507bf3684f7cf3c82ffe0b62a2d2beb3fa35b8ee60946411b69
-  md5: 61722fcf171b18e7747e078f4aabfd23
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 86d39bcd77b513620b09c20f7312dc70fbc9330d68e4c2faf6e4063f2cb4ff91
+  md5: 33ef0274dc2e7f9a5df9071a4e415dd8
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -29508,17 +29425,18 @@ packages:
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-cmake-version
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - cmake
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23313
-  timestamp: 1768974327623
+  size: 23070
+  timestamp: 1771181803403
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 1690c793fce33b8d3351de9d28472d09be1f6962e59a79eb81a83c2703db4436
   md5: e5f88f2234095d5196cdf030fb211dd1
@@ -29550,26 +29468,26 @@ packages:
   license: Apache-2.0
   size: 23305
   timestamp: 1768943252296
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: b6bf021026abb899f4d5e5d8469c485ff37ecf0b6ff9c16d2d7ddeb4d815d6de
-  md5: 33178ee4503fb01faaa9e08785bf803d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-auto-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: ca62d269434b7a45cc5f77d4c43c20c4528d7c4d682512aaeef0a6b054247083
+  md5: 33d729a5e385fa4beadc4b8c739ca142
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ament-cmake-gmock
   - ros-jazzy-ament-cmake-gtest
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 27448
-  timestamp: 1768974379286
+  size: 27193
+  timestamp: 1771181891347
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-auto-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 29e2f6d8e4b1f861643060ca254ba239adfae17640dde2ebcf6266a1867e4dfc
   md5: 540baa295c75d95f1acca1774a2974d1
@@ -29588,25 +29506,25 @@ packages:
   license: Apache-2.0
   size: 27397
   timestamp: 1768943333700
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: e5e04b78e1d12eeb55b66824cd752c66094c9e5716a68642f9c09c18b112da1f
-  md5: 6fca677b0d5e63f107b33ad284bba68b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-copyright-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 8e675aa31012e495edc5d384fc60706808d3c61ed3ed38d96bc3e46601e036a3
+  md5: c93e829e07be2b722ee1ac9de30e1b44
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-copyright
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22772
-  timestamp: 1768974507285
+  size: 22507
+  timestamp: 1771182141337
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-copyright-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 0f4ffd9a0f6597c7ef34c2d9a293a8a9cd981fe6e89b96223c62ca63f2be763d
   md5: cc46fdb19a3cc4d4811dce66b267df48
@@ -29624,24 +29542,25 @@ packages:
   license: Apache-2.0
   size: 22770
   timestamp: 1768943455725
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 07fcb434cde42ce56a1f8d9000ed4644739440b13cb40ad5f64d4152294f370a
-  md5: caba5f805c0d02b1c2c1cd5127a5409f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-core-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 1ba0ba9e288f0631ccfdece200cdf8784e38834b5074529ca8f330613b58875d
+  md5: e60e1669ce01c53eb9ebfabb0264ed84
   depends:
   - catkin_pkg
   - python
   - ros-jazzy-ament-package
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - cmake
-  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 44941
-  timestamp: 1768973804943
+  size: 44761
+  timestamp: 1771181255713
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-core-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 22d8e2cfb74d38b8df4d663e1b504327856482e7e2be4d81c74d04cc7a339aa0
   md5: c6c7d7b2069b60665c4a73407faf72d7
@@ -29659,26 +29578,25 @@ packages:
   license: Apache-2.0
   size: 44948
   timestamp: 1768942649156
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 61f32281b0c6555512eba814391ec8ad906d8b3877a0e3679f7473bcd5f9251a
-  md5: 93150956627cda97aa49c5e22d5007c4
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cppcheck-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: f2145fea7ff195212971388295cdd8b4cbb706da3c580e95b5f3b06cc2055e02
+  md5: 03ace4f94dc129213d05e768553967ca
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-cppcheck
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24402
-  timestamp: 1768974657890
+  size: 24257
+  timestamp: 1771182320712
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-cppcheck-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 7025e32c99000cb6ef4ae82541c200e1b1965142a755800efd8bd45464ba5850
   md5: acf57e9ff858ffa1d5216c6d666973fc
@@ -29698,24 +29616,25 @@ packages:
   license: Apache-2.0
   size: 24395
   timestamp: 1768943627739
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: d925d3bd2e1735630f2cadcafe326b5da9169df3b84f627bea8c84cf733684ac
-  md5: c8b2fe40893b13b45a448624384d20b6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-cpplint-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: f297fde71fad587e24b9ac919fd3078727826b3b81807f728b1a01d1642dc523
+  md5: 31af3ac064c79441b3867deb76bb63a7
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-cpplint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23397
-  timestamp: 1768974681917
+  size: 23122
+  timestamp: 1771182344919
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-cpplint-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 1dc211449e0afc7bd8ede6b1852144edadb47613724a0cf8b54ae3b8fae524f3
   md5: 5a8953bfcf76b8da4f218c754a058ccb
@@ -29733,23 +29652,23 @@ packages:
   license: Apache-2.0
   size: 23420
   timestamp: 1768943650331
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: c37fdb7f20845eb52ceec3620816cd612df528c16cb0473e84453e531659fd25
-  md5: 4f5e14b421cd29eacb0e9178cee0e2c6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-definitions-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: b82ea4e717ed6ef6832a5f3d5bb3a68142ca3f3ccba8800ccbdc43d07ab395a0
+  md5: 376993cd9c67f43f31841d8fe0b31362
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22111
-  timestamp: 1768973898519
+  size: 21818
+  timestamp: 1771181332401
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-definitions-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 97e65269df115550ce46b1889d998f2b13f3f3fdad8f6691edc56f73d73d4a97
   md5: c05d6c854a2211211d24f99da91e647c
@@ -29766,25 +29685,24 @@ packages:
   license: Apache-2.0
   size: 22114
   timestamp: 1768942761646
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 6cfd134559e7c9d9931bf0261dd1d694c8beee75d785fc887ca18308d220860c
-  md5: b6738bdd18b92f77fec8b1ffc59c1778
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-dependencies-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 36cad6c469dac9a21ce7e4e34bdb075237795557e46d393fde35e03034b21179
+  md5: 71f8e260476f9a5eecc63392efdc6574
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-libraries
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 23036
-  timestamp: 1768974002217
+  size: 22743
+  timestamp: 1771181411253
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-dependencies-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 9b14bb063bb94293dd18c572c1217033e995e8ebf0003b1c5529af0a3ebde94f
   md5: c9774f9c8ebf442de42af7e1059d668e
@@ -29802,24 +29720,24 @@ packages:
   license: Apache-2.0
   size: 23023
   timestamp: 1768942872798
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: b163259291e71f3ef04fc586533cf238799d1e6f37637913182cd5617365f066
-  md5: 32a2ea42771a88d81c7f28e1dfaaf0c6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-include-directories-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: c34bf13189a6d435389848abdea1bad609ac5c50582b45bca320377b60dcfc2a
+  md5: d251ba259cf76ee66428163db85b0090
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22539
-  timestamp: 1768973895208
+  size: 22235
+  timestamp: 1771181329077
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-include-directories-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 77676cea1b828a0471f8f79549a781ad16ab9010488fc19b7f8f512ab44c22fa
   md5: f07db81c3f1c8a14389fa13e608429ba
@@ -29837,25 +29755,24 @@ packages:
   license: Apache-2.0
   size: 22540
   timestamp: 1768942750283
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 668a1e12b2b3aef58f3a76898a5a2dcedeb57b8804d98592648b16f7d4882e8e
-  md5: 6546163a1ec767fab158b1fe06eea916
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-interfaces-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: ed423bb95b8d6b842e3a2b487c85df9d2bfa0aa8a7df90624eac90f156e69189
+  md5: bc1a9ab5102fd0b1a4b8096d78b73f7c
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-export-libraries
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22732
-  timestamp: 1768973980127
+  size: 22429
+  timestamp: 1771181386686
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-interfaces-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 2f03e3dc4780ff54a270756503be0baba315511ff7c9b8fce5d52cfbb48b886b
   md5: 4252f365dde33340edb2116d2dfaeade
@@ -29873,23 +29790,23 @@ packages:
   license: Apache-2.0
   size: 22724
   timestamp: 1768942848671
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 09f0a7910a43d95e06f8793bc18d3408ac802c044b2b152c5cca5f3d4df8790f
-  md5: 2252fdd73a7bc0e17da5466ec5e7519b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-libraries-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 5ca32137c7be5d4a76ff6e6505188daf5040b8dbc611105e88b09c0125e2db1d
+  md5: 5ac6ac6a008c9bfb44d0555ab072d331
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 24052
-  timestamp: 1768973874336
+  size: 23757
+  timestamp: 1771181309504
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-libraries-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 06f9d0e6ada672528304b8bb6d3c3919863ed710aa80b05c5ef124661b154837
   md5: c2413fbff9b70538fc54d715c328113b
@@ -29906,24 +29823,24 @@ packages:
   license: Apache-2.0
   size: 24059
   timestamp: 1768942716131
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: ddbe0b429365f8156fe688c951a24525fcebe69747f36aa42deb89a2d2733de1
-  md5: a5ce8d4392f00f4e3ad12ff825116238
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-link-flags-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: fdd708708a25b21104e51e265ccd66b4e4931883167b051ff2f4b7d7851f3b65
+  md5: d97a0b372aa2997f921ca1a876ad4bac
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 22071
-  timestamp: 1768973891967
+  size: 21792
+  timestamp: 1771181324714
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-link-flags-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 51a1b7c60f10caff14390ff5572c5f894b56f3e465011072ca02e07c969e9a3a
   md5: 3b7de47af2c8b207776358957bd4efb3
@@ -29940,24 +29857,25 @@ packages:
   license: Apache-2.0
   size: 22081
   timestamp: 1768942744881
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: d158f7e1a3c844cb7b5ce4e0aa290221391a4f674027354f9a06c91606ceef5b
-  md5: bb50cff564c681b4ddf38936d3db5f10
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-export-targets-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 5cba268bd5b08fbaa50aa8103bf704bb35f13876c676582fd558269396a8bff4
+  md5: 078cfcd9d509d7bbd35178917baa72a2
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-export-libraries
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 22844
-  timestamp: 1768974009783
+  size: 22622
+  timestamp: 1771181418314
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-export-targets-2.5.4-np2py312h61f2ce4_14.conda
   sha256: b1c5ecbf15a66c1180069abf739a25c5666a44a9d76fdd4960bd631e5db15e25
   md5: 4a21db05d7e5c75d9e929b5646b4da07
@@ -29975,25 +29893,24 @@ packages:
   license: Apache-2.0
   size: 22897
   timestamp: 1768942880811
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: d111df8b9015895e396b440b8fa6014b4a0c440fd735df031b6e61eef5c56dd8
-  md5: a8056d911d1c1ecab61e798e1be9396f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-flake8-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 5f999261dc92f6e63ad979a9c0cc71c04fd6060efb971c673e3e1d67eb783c0a
+  md5: 126a2d9bc4d876421b92d71e77ed90ab
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-flake8
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 24451
-  timestamp: 1768974678382
+  size: 24151
+  timestamp: 1771182341328
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-flake8-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 273748d85522fc3f566b191ad5ad81c734c543c0504010aac40d0e13f6603480
   md5: f5e8e2ece60fa32ccf2b0bba564259f8
@@ -30011,23 +29928,24 @@ packages:
   license: Apache-2.0
   size: 24422
   timestamp: 1768943646674
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 172606d033950edc96bbfd9a56a3192059ac209945c772922b5aecf0c1ab1ce4
-  md5: b8239858edebc212393b8857ff35e8cd
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gen-version-h-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: ec2e006a239e2927f2b069803f9d1c4d7c004217c3f367ac03bff3c16d2c696c
+  md5: 916563f96a9aed361bb1dd858d978847
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 24822
-  timestamp: 1768974213242
+  size: 24576
+  timestamp: 1771181697722
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-gen-version-h-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 0fda5991216e06b9cbec06d689eea8ec55954f5eb95f097ee2e78d103e7fb803
   md5: 5148afa9481aea0d37c466048b21c638
@@ -30045,9 +29963,9 @@ packages:
   license: Apache-2.0
   size: 24883
   timestamp: 1768943137597
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 871e41eecd15c52e6e832f34619dd69efc8a74a9273cb7400c0d5dae76e6cb22
-  md5: f2d7e8f8c44b480cbad46eadac138aa0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gmock-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 905b4b0e5787272ab6e06e0a2d582ceded2d12aeb9400d71cf98364f2670c0ec
+  md5: 38972b1e51236e9784816ab5953fc0a7
   depends:
   - gmock
   - python
@@ -30055,17 +29973,17 @@ packages:
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-gmock-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25011
-  timestamp: 1768974220078
+  size: 24710
+  timestamp: 1771181705174
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-gmock-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 9efc6fcccaa1bcbb8b96ac46800ae94d7b250c08d22a0e8e9eec29f2331d19bd
   md5: e72d9cf2c286eb9b9f9b7d74e7637a8e
@@ -30086,26 +30004,27 @@ packages:
   license: Apache-2.0
   size: 24902
   timestamp: 1768943146001
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 3ffcfd7d2698b4fd07d338a506d1989268acb33597981a60296094111e8922ed
-  md5: fb1de1fa0649477e15dd6938c604ffcf
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-gtest-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: c2b72b949bb845d3fda7ed758b796b0421de40bbf1530e0a9711264fb556ba30
+  md5: 046b23f0dc0804facbdcfe95516727cb
   depends:
   - gtest
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-gtest-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - gtest >=1.17.0,<1.17.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - gtest >=1.17.0,<1.17.1.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24765
-  timestamp: 1768974098821
+  size: 24419
+  timestamp: 1771181561627
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-gtest-2.5.4-np2py312h61f2ce4_14.conda
   sha256: da3ab6d115e37edcebdac899f9213c7d3c3db39b418113b5eabeef267e07349c
   md5: 319e20e1cfead9730fec3a90d8a171a6
@@ -30126,24 +30045,24 @@ packages:
   license: Apache-2.0
   size: 24727
   timestamp: 1768942965772
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 79f0867a76db6cf0ecd3f84e3b55b3ebd76a7e5f5c9f09bc36b687cc0fbfeebf
-  md5: 24e25685a96f7c6e0403b0263430f7b2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-include-directories-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 16fb4e2ecb7e4a7e1495e3ec5c64d308928613aeec8481c457b8bf1c8fa7a5c8
+  md5: d06262b7f5c5b40f4f04123407fe7762
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22003
-  timestamp: 1768973898638
+  size: 21708
+  timestamp: 1771181334793
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-include-directories-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 498d2ef5a9e4cab150f37859648a7943b04db7a66c9c43a49ae2326ae5164521
   md5: 4be12bad88a68cae7b5043a0d7134ce9
@@ -30161,24 +30080,24 @@ packages:
   license: Apache-2.0
   size: 22008
   timestamp: 1768942746594
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 10f4db6478ebfbd1b7b7f040d3ef3d5a23ebb4dfce810c4325f3fa3e0ec9b15e
-  md5: 100398d5b43e180b756d1bd667494799
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-libraries-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: d5498d0511cab612a8af2175f81ba5cfac9da3c26dd244b8149c1cf618a8dc3a
+  md5: daabfb3606035ada39a52c0dc99f7cd8
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 21680
-  timestamp: 1768973895746
+  size: 21419
+  timestamp: 1771181332169
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-libraries-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 04c9f76f55484d5cf8be04d27743bad7d37a6c8d7a4492f7657fcb73c237bf5a
   md5: 13c06751cfd8d435ea3fb8d36dad0e13
@@ -30196,25 +30115,25 @@ packages:
   license: Apache-2.0
   size: 21715
   timestamp: 1768942743229
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 59eaf2799416c2e4813890449353c0dd5347fd60718af91e171152e8dfeada5d
-  md5: 1310ed2b9b36a3ebc534c5a287029793
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-lint-cmake-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 38131b38825f4f26e50ef43235166f7d6473524918e5ee6261633778c8eb238a
+  md5: 0d90634d373f3bd132a1c385de7da092
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-lint-cmake
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22470
-  timestamp: 1768974379705
+  size: 22154
+  timestamp: 1771181891344
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-lint-cmake-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 62b2814c47c6b1dbbcb6910dd6d409af2bdb98cd45529618b5bf6def4e1b7275
   md5: 593cb3326be4a9b3e14954ea04e98450
@@ -30232,24 +30151,25 @@ packages:
   license: Apache-2.0
   size: 22462
   timestamp: 1768943332067
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 9155ded7e163a741eee5e9257190391aa678b6a3674e79a16cee4dd434f4b013
-  md5: 8e2be3c3247dcb234d0a6d6779dea2fa
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pep257-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 965adca8cd3e8d4714c5bb2752b8b5226b22d20906f51269e5fc67d3c9f72ecc
+  md5: 77d76c0acb16b504574410c75dab42c1
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-pep257
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23126
-  timestamp: 1768974674965
+  size: 22893
+  timestamp: 1771182337202
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-pep257-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 3c8ed82251680f48c816274e2f3a0a667de41e000ffdb29ca9789fad7e3e95a9
   md5: 00d14709cf99e44bd3ce55394ae340fa
@@ -30267,26 +30187,26 @@ packages:
   license: Apache-2.0
   size: 23146
   timestamp: 1768943640898
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 419bb650491a1c1531e40980d0d4a860b91ce71b414f501f4e94ed659cbd9734
-  md5: ac9303daf5026ea167e7e9c4f0ab1bae
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-pytest-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: beac02970847d953e590e083c1f1e2bf8ec3bb7c1de45177d9c5bc081e68c007
+  md5: 3795059e2f7dff3c6aee1973b6e07951
   depends:
   - pytest
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 24849
-  timestamp: 1768974083180
+  size: 24586
+  timestamp: 1771181548902
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-pytest-2.5.4-np2py312h61f2ce4_14.conda
   sha256: cef15ec8f3000dd8f5630d239e6c7372bcac5060f5daf68cf2e395e184dc312c
   md5: 4a791acf06c9d4aaca0bae27aa9c4f70
@@ -30306,23 +30226,23 @@ packages:
   license: Apache-2.0
   size: 24854
   timestamp: 1768942948495
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: c2b04144eafb6e5b5a499818f763d023f7e56bd6452f30c66f812cd6e9189743
-  md5: 17ad11b28c28cc34b00b82734a7fddee
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-python-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 881eeafbc1ecbac47dce8b30b768c18ee62c32fbbb97dd79d6e168e387a542f0
+  md5: fdb0995e81002318c9be7989c0dc2a0a
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 24222
-  timestamp: 1768973887099
+  size: 23934
+  timestamp: 1771181322985
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-python-2.5.4-np2py312h61f2ce4_14.conda
   sha256: ceb948c0e5c881d54a3defb5985c9282e0b11e1c5206d5403275e307647005a0
   md5: 867bdcbae1aa09a54d971edc2b2ea3af
@@ -30340,9 +30260,9 @@ packages:
   license: Apache-2.0
   size: 24242
   timestamp: 1768942731958
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np2py312h2ed9cc7_14.conda
-  sha256: 94ac539e1592e3bd408c072966126a681bf3b8e50d714bdd1034e8caa8084a4d
-  md5: 97961fc35f3e355fd5dc9e345e25d1c0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-ros-0.12.0-np2py312h2ed9cc7_16.conda
+  sha256: 508b31b85cd537181c002a3f0dc001550acc3a2b0a1326ed3da3fb2c61986e83
+  md5: f139b903271f9d78a1ca60214cf44386
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -30351,17 +30271,16 @@ packages:
   - ros-jazzy-ament-cmake-pytest
   - ros-jazzy-domain-coordinator
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 31382
-  timestamp: 1768975009128
+  size: 31233
+  timestamp: 1771182716767
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-ros-0.12.0-np2py312h61f2ce4_14.conda
   sha256: 1326aef83078055b63380c20867cfbc4980d743549e13df6eaa55b65e7b3fe9d
   md5: ee2a6abac7910314fc9c6afdd05bd939
@@ -30383,26 +30302,25 @@ packages:
   license: Apache-2.0
   size: 31315
   timestamp: 1768943980257
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: a1ff5c48f1b5f2a0959a2c2f1ec83fe47c46dc009f272f8b5c0c4d02bedd47a8
-  md5: b75991741593b5ce011b29678c8071d6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-target-dependencies-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 7dc01391724bcc023383e2e5468de0abd2de1187e8a3ed1acc8a2dab9a791605
+  md5: ff8a05f8637cb7b482d6b2a8c27a683e
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-include-directories
   - ros-jazzy-ament-cmake-libraries
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23731
-  timestamp: 1768974006080
+  size: 23408
+  timestamp: 1771181414771
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-target-dependencies-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 0b820ea0c3f422ed6ca298af77eb87eb7b9fb90563e33f9c827969dff79da737
   md5: 63e903082b80ac4712189c0fecaf43c4
@@ -30422,24 +30340,23 @@ packages:
   license: Apache-2.0
   size: 23703
   timestamp: 1768942877247
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: 4080080ee8041c8e79168d9d4f70a340ef34ab7e426648d9da200f225be0f663
-  md5: cec3ecc93585d253286748ba4ac7c9b8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-test-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 6749aaaec1993cef9d6117378882d8e09702400798acfadffad335df91d9db57
+  md5: e7ff75d814e988154478a6c606a21322
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36159
-  timestamp: 1768973994025
+  size: 35846
+  timestamp: 1771181403664
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-test-2.5.4-np2py312h61f2ce4_14.conda
   sha256: c5e384a08da23c4988735e68aa13566b4af1c2d639ef48f175a61c6198ab239e
   md5: f20600be16821541796c168ef8d89c9a
@@ -30457,25 +30374,25 @@ packages:
   license: Apache-2.0
   size: 36124
   timestamp: 1768942863941
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 989916930b82b9511a796c5edae1c7644bf7b751ba3a69cb5434784422f0dcce
-  md5: 48ac82ecea8eaa3db530b85a510c4a75
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-uncrustify-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 5f58eedd32903e127b5187181a3668e35ec2de61c8a75cbf7fa6f04810ea8ee7
+  md5: 356a912921695707ee2c121f6023590b
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-uncrustify
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23714
-  timestamp: 1768974671543
+  size: 23449
+  timestamp: 1771182333518
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-uncrustify-0.17.3-np2py312h61f2ce4_14.conda
   sha256: db0750480b22e7ab8dd8db608d7513df45882c6552e6b09214cf40c79254643c
   md5: 7f235b43cad9497d9ed2ee9b14c02296
@@ -30493,24 +30410,24 @@ packages:
   license: Apache-2.0
   size: 23777
   timestamp: 1768943637023
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.4-np2py312h2ed9cc7_14.conda
-  sha256: fd62143bac65a77e58d5d4a81d25335db8cc060150b9dbabea28549d957b2298
-  md5: 52b93d3de8bde7b875db54db2057ade5
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-version-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 9aeb19fd76b6d50fa3ff5e58ea324121bed1db3182f34cdd8670471db6174e85
+  md5: b61d109c80c6a8bfd441b1f1327a8ed2
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 21853
-  timestamp: 1768973887986
+  size: 21567
+  timestamp: 1771181321533
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-version-2.5.4-np2py312h61f2ce4_14.conda
   sha256: 134eac02ecd311d76ebfbe2ac8965936d1ca479e5c596754e6d00665498a0a57
   md5: b57e1dec8633f6072feb86e17bc44272
@@ -30528,24 +30445,24 @@ packages:
   license: Apache-2.0
   size: 21898
   timestamp: 1768942738395
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: ec922395c78e8501719eab800358727f50bb06f150952ad7bd1fdeed88476221
-  md5: 6aa4b183d08d2faf9e4177742b4bfb76
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cmake-xmllint-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: f73da6db6edb1edd7916a84ae7063f9de460f16568376fe581ea6790d1156565
+  md5: e2d53e79f8fcd67f99151ebaf6d49015
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ament-xmllint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23151
-  timestamp: 1768974656681
+  size: 22902
+  timestamp: 1771182320353
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cmake-xmllint-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 97ba5ace199ee07bc390235e9f75048e31bf08a11135322060af8bfd501ba133
   md5: 880880ce7b17e0c42627625698623ae9
@@ -30564,25 +30481,25 @@ packages:
   license: Apache-2.0
   size: 23179
   timestamp: 1768943624375
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: c570b0af4d9a050af2a8c50674c585bdaaba431a1044ed5603271041763d04aa
-  md5: 10e8f53dd90ac657537a20f5c8f047c7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-copyright-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: faf9ddcf5679a1b6323a2e8899b151f2744dfb44ba7bda4a9d35aefbfa0ad6d3
+  md5: 077ac848073066f4c7b3bac2159e413e
   depends:
   - importlib-metadata
   - python
   - ros-jazzy-ament-lint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 66626
-  timestamp: 1768974198181
+  size: 66279
+  timestamp: 1771181679310
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-copyright-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 6569aa2f37ef88d47acff3df47462813b45d3ce8e5af67b64cbb04c863b296a9
   md5: 5782e4a80dbd121a5986d010399207f0
@@ -30601,24 +30518,23 @@ packages:
   license: Apache-2.0
   size: 66553
   timestamp: 1768943115693
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 9d22d33d0f6685da9324e8440f13813fe3a9b5a1d408599e1bafa189c433a3a7
-  md5: 04dde38951a5581722b524e78d2f519a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cppcheck-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: d2fe3caaf0ae8dd5184b96ace64d758ec1e42749126313d91fe095cb455754ad
+  md5: 625aafaeb233d73406b2c17ba97dabf1
   depends:
   - cppcheck
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 29962
-  timestamp: 1768974343747
+  size: 29689
+  timestamp: 1771181818342
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cppcheck-0.17.3-np2py312h61f2ce4_14.conda
   sha256: f5fe22505a45bdfd12122668bb677bb8156e536738be17c6a7ca22d90e7314b2
   md5: fc60006a83bac6fe18118555814ec8ae
@@ -30635,23 +30551,23 @@ packages:
   license: Apache-2.0
   size: 29997
   timestamp: 1768943271136
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 617083ee655a503b50af3e4969b1642996af5c23367dec4a81124774d6adb6cd
-  md5: 3d04592013e3421c450e5c54c7f6545f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-cpplint-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: b7508e6ab00cf00d99df73e5b2abb61b18673b0eb76e3b03ad43b7c495de59fc
+  md5: fe1fc4b9936f6f9d83f703e97ec624f3
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 168773
-  timestamp: 1768974339137
+  size: 168484
+  timestamp: 1771181814294
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-cpplint-0.17.3-np2py312h61f2ce4_14.conda
   sha256: debc55681d87af1cbbf8d991a52c809c7a3c2c0e9df06769dca81e8b22227a34
   md5: ab28cc6b78acc6416632d5fc62d8b91d
@@ -30667,9 +30583,9 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 168774
   timestamp: 1768943265983
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: abc5c3c8da0c45022f0dbd8ad258a8bb9dd779dcbc0791f44e53ece45632452c
-  md5: 4ca32a573ccfb7d26e50a7859ff11ac0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-flake8-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 91194f30828f9559bc35d23a420d5b9cb615b36996bf2fb6038af642fb2b8baf
+  md5: 0a1429892e507e1d549097af25867eae
   depends:
   - flake8
   - flake8-builtins
@@ -30680,17 +30596,17 @@ packages:
   - python
   - ros-jazzy-ament-lint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 28405
-  timestamp: 1768973981180
+  size: 28257
+  timestamp: 1771181387505
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-flake8-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 45547afaa57c5323c06da8befc8d76460ba98041b112ef041a1845ae727bbd24
   md5: d93f08b02159e3afcdb40a6ef7701445
@@ -30713,22 +30629,22 @@ packages:
   license: Apache-2.0
   size: 28399
   timestamp: 1768942847806
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.1-np2py312h2ed9cc7_14.conda
-  sha256: 5098ee870238bf1dae3245e0beb3f3b91d2fc0d0ee41b99c0c7f0f88a28d2ec9
-  md5: 6f91d8e4237b0d64f263133e633c167b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-cpp-1.8.2-np2py312h2ed9cc7_16.conda
+  sha256: ec80fadfbfeb4946bbb8792639e5ef6718bbf6b3a609117ec12db928f64fa873
+  md5: 2c504b5b62ce7a44710809f596646bdd
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 47033
-  timestamp: 1768975298861
+  size: 47149
+  timestamp: 1771182993545
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-index-cpp-1.8.1-np2py312h61f2ce4_14.conda
   sha256: c8c5077c3b6d5eb78e52bfaa741bc4b430d6874d1f7db7a21a7a349b6db3e52c
   md5: 541793fca2117ef8e0b1a186d925e963
@@ -30744,23 +30660,22 @@ packages:
   license: Apache-2.0
   size: 46371
   timestamp: 1768944179297
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.1-np2py312h2ed9cc7_14.conda
-  sha256: e8226eb54557eadd191638a9bde1dd2c3cd45c6a45f85893b8d453b54afbf49a
-  md5: aef7d4e7d566506e1d2fd7cec44badcd
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-index-python-1.8.2-np2py312h2ed9cc7_16.conda
+  sha256: 8828e2524959e7ac7d0c14ed5680ddbd9d3c443e4887073a039896868dd5eba3
+  md5: 225907bbfbe65586fe04e393aff5fcb0
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 29732
-  timestamp: 1768974311071
+  size: 29450
+  timestamp: 1771181790321
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-index-python-1.8.1-np2py312h61f2ce4_14.conda
   sha256: ab70979fc7792ca88377b8595945ef344b1a364774ca07e5b8134861d705cbd6
   md5: 5673e044f1ddd27777ae1b1a05b84ed4
@@ -30776,22 +30691,23 @@ packages:
   license: Apache-2.0
   size: 29705
   timestamp: 1768943243163
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 838cf72a27a506f3c22a60b2fe3b1e81fc4f65b6d36530b1886c24fd52eabf69
-  md5: 4671d659d6c4424ab8428a06df1553b2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 9c9921280460a4588576db5f41780145b45bcc3bd9c58a97e4227d6f64f672da
+  md5: 2c6988301fbd9c9644ba8d3b8f230a00
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 18330
-  timestamp: 1768973871545
+  size: 18119
+  timestamp: 1771181309383
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-lint-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 016107f32518f8086e5d93f6036377bc4d4ef71517f3293c2bcadf015227ed49
   md5: 0f9c204f161e5dbc65aaf037f9866823
@@ -30808,25 +30724,24 @@ packages:
   license: Apache-2.0
   size: 18346
   timestamp: 1768942716129
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 1be1c17902578bd7f7cd0d01070b1e26f519d3eb3cdb5c11c2db8483f4ae5559
-  md5: 9c903c772cf822fbf4daaf77fcc67139
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-auto-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 62df0b8d79cfde4aa3819e6485a8ff66ef9b7532641ef19cb62da823f48f1c8a
+  md5: 592fec905a659f865141da0324861b64
   depends:
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22080
-  timestamp: 1768974114189
+  size: 21756
+  timestamp: 1771181576142
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-lint-auto-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 1b858aa92189f94dbae2679b505a57478c28eff219d230ed1fc9706414542ce7
   md5: 95eb6a288acaee514af4149ab61f932f
@@ -30844,23 +30759,23 @@ packages:
   license: Apache-2.0
   size: 22100
   timestamp: 1768942983693
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: d7b5cdc8912e3fbc004031b6c5a61c3a48fdf48c694bbc5032891254e51fd130
-  md5: 730bba0b74c52705a0e36b466fbebf7c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-cmake-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 24b3bc9f3cd4f40b90aa8af6ffd5aec0f450c048a48d8d9c46b46108be34b018
+  md5: e68923b1ccb75083471ac05e5338499e
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 39548
-  timestamp: 1768974311366
+  size: 39291
+  timestamp: 1771181787564
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-lint-cmake-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 259ca385b8a265b29a14b14b49ccce37be106e6212797c794e94f42d0df82d97
   md5: 553ea90b179b5cdfe3728eb31cf4dee6
@@ -30876,9 +30791,9 @@ packages:
   license: Apache-2.0
   size: 39537
   timestamp: 1768943235497
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 696d4804513bdf5102e259aefbea8d000d6dea9ff8bf62780d02e259f4dad813
-  md5: 22ae156bc07365cbd4bd1f1a0075c8f1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-lint-common-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: d9846e59b65f6d7193e9935177f394e3cb973b94c10ee918f6f4e905b6ed8860
+  md5: a6a63c5752969bb71cc29c02cc282158
   depends:
   - python
   - ros-jazzy-ament-cmake-copyright
@@ -30891,17 +30806,17 @@ packages:
   - ros-jazzy-ament-cmake-uncrustify
   - ros-jazzy-ament-cmake-xmllint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22345
-  timestamp: 1768974718131
+  size: 22090
+  timestamp: 1771182370900
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-lint-common-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 3dc1521d3b6f17f0c15605d397c4fb0dc361307a40b756bcd205ba412943bab7
   md5: 3c25c4ae2b94eeb64cbe90f7502d3b80
@@ -30926,25 +30841,24 @@ packages:
   license: Apache-2.0
   size: 22400
   timestamp: 1768943699454
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.4-np2py312h2ed9cc7_14.conda
-  sha256: de7fd8bb838ebde86b4bb5ae8b44aa3a4f86d8d92194832d307603f9c4116b55
-  md5: a1594609fe03afc07aa6287044fb6c4d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-package-0.16.5-np2py312h2ed9cc7_16.conda
+  sha256: f7b3ed112e5bff5daea156f3ddd43e0cadf362fc3bd8207e61f3a4463c5f695a
+  md5: 7b2db4c20e603d93ce0deb174615747f
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - setuptools
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 43044
-  timestamp: 1768973793208
+  size: 42829
+  timestamp: 1771181243480
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-package-0.16.4-np2py312h61f2ce4_14.conda
   sha256: efc7c2fb5b4ab18602ded959384fb64d15f93a5125b76e8d206ccb37ec68cd27
   md5: 347dff8c350538686ab6edec19a9d13f
@@ -30963,24 +30877,25 @@ packages:
   license: Apache-2.0
   size: 43053
   timestamp: 1768942636046
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 43ae962ff83a00169ce6e6b44b781cb370e02f1d7a7afcfdd51732cc1601be78
-  md5: 81d2813f6c6197a7ffc10fd43959c9a7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-pep257-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: f686a1a88e09faf361a9e86bc68457be89f2c202a99ec19f2e6eada4c7fc5b48
+  md5: 8e5c384575817db3626195e197bbaf74
   depends:
   - pydocstyle
   - python
   - ros-jazzy-ament-lint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0 OR MIT
-  size: 27110
-  timestamp: 1768974083190
+  size: 26846
+  timestamp: 1771181547421
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-pep257-0.17.3-np2py312h61f2ce4_14.conda
   sha256: 549b700e3256da1ce48ab6385ebc997b6941ec09f3b7bf22fb4503ba6467e830
   md5: cff18ee98193fbf40a0d67cdeff145e4
@@ -30998,24 +30913,24 @@ packages:
   license: Apache-2.0 OR MIT
   size: 27114
   timestamp: 1768942948011
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: f66d63e0afcabd2c6da0043826a1c9a1471f0b4f24c3a2f929ca47c67cd6c002
-  md5: db6a33415c8419fe5eb148cc7905fcf9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-uncrustify-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: a624b528369b4b880d766056a9c64f89898f3c8cd431bae0d9dd3d46bf0dcab1
+  md5: fb695cebcae62df34f633236646805f8
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-uncrustify-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 68218
-  timestamp: 1768974524311
+  size: 67950
+  timestamp: 1771182167081
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-uncrustify-0.17.3-np2py312h61f2ce4_14.conda
   sha256: a4dddfe8e5a84767c2e132b799e53a31eaf6f83c1a24a9993dbb90b1a10c3a9f
   md5: cf3054fd99e0c1b575c24a63692ae489
@@ -31033,24 +30948,25 @@ packages:
   license: Apache-2.0
   size: 68209
   timestamp: 1768943470817
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.3-np2py312h2ed9cc7_14.conda
-  sha256: 03d8a3d591763b4891a2685a7d21e4542643e3ee187238d412b050baa7ecc855
-  md5: 91a8abf2641d3a9da33416d4fc5d9c6b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ament-xmllint-0.17.4-np2py312h2ed9cc7_16.conda
+  sha256: 9ef057476f48279fc65c9159ce95def9bb2fc86039d6341497dbb8b3b96ccc1c
+  md5: 2c1a35db5520efda8e4c037f050035f3
   depends:
   - libxml2
   - python
   - ros-jazzy-ament-lint
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 28165
-  timestamp: 1768974334577
+  size: 27931
+  timestamp: 1771181810113
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ament-xmllint-0.17.3-np2py312h61f2ce4_14.conda
   sha256: fbd19194c1ac9654545ef085a1b5a6d91c6b7693eade6408b3de3457d66bd71c
   md5: 7eba5c4b3abc861ba15e8546f38542e0
@@ -31069,24 +30985,24 @@ packages:
   license: Apache-2.0
   size: 28207
   timestamp: 1768943260467
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np2py312h2ed9cc7_14.conda
-  sha256: 81a8ce0be90cf0b02e9c839e18900cef4f766d6f54d438c0bb2436e096e3db27
-  md5: e5c40bf5d8541e978807646ed1a8664c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-angles-1.16.1-np2py312h2ed9cc7_16.conda
+  sha256: 374294029f87c32d80262985252830a74afff776c95aa24143449d5d950da44e
+  md5: 541fd6cdf5a8f20a38f76eb7bcc3c973
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 34340
-  timestamp: 1768974403396
+  size: 34097
+  timestamp: 1771181983126
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-angles-1.16.1-np2py312h61f2ce4_14.conda
   sha256: 1c2490aa8aa19160a798a9d315219d8664ba04f5696ff16e071f2cb684cbeadc
   md5: 8223b84bbffb4af16f3cb68a0013be6b
@@ -31104,24 +31020,25 @@ packages:
   license: BSD-3-Clause
   size: 34329
   timestamp: 1768943372845
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np2py312h2ed9cc7_14.conda
-  sha256: 4590ddafd1abd29acfe182d5b1dd7a44d82d26e3732ca8578de884d5bb7001d9
-  md5: aae5689fc10cebfb5adbf74d8e332679
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-backward-ros-1.0.8-np2py312h2ed9cc7_16.conda
+  sha256: 5e957849d0fd89f6b28f591c17d97c4499fec88a812f87f1e00c8e6626b9b3af
+  md5: ccc88a81056a4fe9b2a32441b012806f
   depends:
   - elfutils
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - elfutils >=0.194,<0.195.0a0
   license: MIT
-  size: 333672
-  timestamp: 1768974040190
+  size: 333457
+  timestamp: 1771181446318
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-backward-ros-1.0.8-np2py312h61f2ce4_14.conda
   sha256: 01c21e3178b46256eb0444306332275b8bd755e3f2bd5889a1472c9f8e2a0d92
   md5: b8ff83b4e232688970aa11b96be05fdd
@@ -31140,9 +31057,9 @@ packages:
   license: MIT
   size: 323488
   timestamp: 1768942896418
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 106c1710b781d9544cbbb73b88be8a1f4548b1320a64223f5aafef95e153a066
-  md5: cda0f87e6d37747db51e7dd676b32878
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-bicycle-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 948dfdaa3625e1e69ecb6498d58b74787e945ae673f6722dd44f0daf451888b2
+  md5: b9670d4427e4d94dcd2858d161938295
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -31155,17 +31072,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-srvs
   - ros-jazzy-steering-controllers-library
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 104559
-  timestamp: 1768981999
+  size: 104476
+  timestamp: 1771190410029
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-bicycle-steering-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 2d763a82cd286b4a10c2b4d4b453bdc528e4fd03f3d41fe38cbfec999fa0e47f
   md5: 25aa8d8769d8640852d07a20e84ea9fb
@@ -31190,23 +31106,23 @@ packages:
   license: Apache-2.0
   size: 102541
   timestamp: 1768949991682
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: a59309c935653a53b41aa55a47be10e87eeb06e69a17e804e72a79aec001e2dd
-  md5: 381e6b2ad2c4e6d0ff23fe35b9ee3916
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-builtin-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: 5672127981c75e6cbe983c1384c1147dee84683293a37a020bd21daa4729077f
+  md5: 2d4d4c88a61f47c9fb61d69920e97e17
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 80018
-  timestamp: 1768976227318
+  size: 80256
+  timestamp: 1771184213652
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-builtin-interfaces-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 33f7cd1c160e459264c9429cb5176e4fd4d8e127806e6b0fbf9cfa1d19799d91
   md5: 4faf1d5da1cf17c69042c8155697e9a2
@@ -31224,9 +31140,9 @@ packages:
   license: Apache-2.0
   size: 83813
   timestamp: 1768945187535
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: d0b32e458cfe1d49f85dfbff118937121fb1b3623564b3e8c102542183face71
-  md5: 6bf05c8fa099b1eac452fa63c50c30a1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-chained-filter-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: c3f2cdf825733cf35e534235671f03a5b65475e29cd9606e509503267ce10c01
+  md5: 5e5559ce3348b5f6c91b8d1315642954
   depends:
   - python
   - ros-jazzy-controller-interface
@@ -31236,16 +31152,16 @@ packages:
   - ros-jazzy-rclcpp
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 213653
-  timestamp: 1768981539272
+  size: 213584
+  timestamp: 1771189919532
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-chained-filter-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 792e386f59b966343ea25e46e81979c9f0d203fc19d4adb3b9f9d0eea34ac633
   md5: 2dba057efa3f61aa45ec70781c046d9b
@@ -31267,27 +31183,27 @@ packages:
   license: Apache-2.0
   size: 210780
   timestamp: 1768949597619
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np2py312h2ed9cc7_14.conda
-  sha256: c69d53568d70b5a8c1c58082d894fa73ec09c0da1559416806ccb5687832b53d
-  md5: b1c2db69a8940aff64c88d471490fef6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-class-loader-2.7.0-np2py312h2ed9cc7_16.conda
+  sha256: 792afcd8efbfc2680a46ceab8aba840bce0c9b1ebfef9f5fd36dae7e8b93a5ba
+  md5: d111fd3e4046be445700d14a5d7ce6af
   depends:
   - console_bridge
   - python
   - ros-jazzy-console-bridge-vendor
   - ros-jazzy-rcpputils
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   - console_bridge >=1.0.2,<1.1.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 74325
-  timestamp: 1768975645437
+  size: 74148
+  timestamp: 1771183342204
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-class-loader-2.7.0-np2py312h61f2ce4_14.conda
   sha256: b102c5c719093a5c41ac91bb01d50a71dd354d51edbd486896b14f45d8ed2007
   md5: 3f1ab57be7da377fb32af269dd5f8eef
@@ -31307,9 +31223,9 @@ packages:
   license: BSD-3-Clause
   size: 80382
   timestamp: 1768944616929
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: e188c2566ea6f265a348a5aba11c3589c0f91371f2d51936baa40ab20f2c957b
-  md5: 694bb527dec6886bb6474d5eb02c89a3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-common-interfaces-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 89ac5cebea77e81d3100cf0b9dbacb351f1a191c545d372c3586667619af1372
+  md5: ed08c45e744d7c47ff831b95c86ee694
   depends:
   - python
   - ros-jazzy-actionlib-msgs
@@ -31325,16 +31241,16 @@ packages:
   - ros-jazzy-stereo-msgs
   - ros-jazzy-trajectory-msgs
   - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26797
-  timestamp: 1768978054215
+  size: 26694
+  timestamp: 1771185871645
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-common-interfaces-5.3.6-np2py312h61f2ce4_14.conda
   sha256: f7eb63ecdf497b4a57999bfbf595b6eee42a068ea5e2fdc16afb6f3cab423330
   md5: 48605a15537c65f141753389f1da96ab
@@ -31363,24 +31279,25 @@ packages:
   license: Apache-2.0
   size: 26819
   timestamp: 1768946552096
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: d35e8b9bfa6b4f49a9938661edd52938084ccbacb161e742d966a3aadb9f2350
-  md5: a8ada4e5ee4ba505c3f1d9e0d5848cd4
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-composition-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: c248737721418ae05ffa513a8c67b6ac5587f489e88b2268b52485f729afe888
+  md5: 5217bad84d9164773070778ed6902aa1
   depends:
   - python
   - ros-jazzy-rcl-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 224475
-  timestamp: 1768976648065
+  size: 226936
+  timestamp: 1771184715615
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-composition-interfaces-2.0.3-np2py312h61f2ce4_14.conda
   sha256: fc1dbabf0a76502ff804b36a07d6207dca3ff4526c5cf7f3b522de49962c3f5f
   md5: 2111f28c0c2930f22d7a4de8c280f22a
@@ -31399,25 +31316,25 @@ packages:
   license: Apache-2.0
   size: 230165
   timestamp: 1768945633483
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np2py312h2ed9cc7_14.conda
-  sha256: 59b7544f6a9fb313972ce6997012393adfdcbfa7a9b76c3f37cc600c699ec6a8
-  md5: e1f8e37aed54c54de40a3e86fcf9ec3b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-console-bridge-vendor-1.7.1-np2py312h2ed9cc7_16.conda
+  sha256: fab27a4fe6fb2b3d04d0d0a691c845df0a65955a638f5b08dda44fd2d3711724
+  md5: b7d17d8e3b9894e3b55ab2936ca550d8
   depends:
   - console_bridge
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - console_bridge >=1.0.2,<1.1.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - console_bridge >=1.0.2,<1.1.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27841
-  timestamp: 1768975369434
+  size: 27713
+  timestamp: 1771183055984
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-console-bridge-vendor-1.7.1-np2py312h61f2ce4_14.conda
   sha256: 5cca6a0af81f4672c60676735629297d0efa7c4d8c95eaa2898bfdbacbe4eebf
   md5: 95b42473fce26393c6492592bcfcce67
@@ -31436,9 +31353,9 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 27839
   timestamp: 1768944252470
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.7.0-np2py312h2ed9cc7_14.conda
-  sha256: 8d9ee6303c6928ccfb694bc7a9ff2cf95113c1692e47992ec72b105321af5c38
-  md5: 738a5dea4c085788c6eff5533afab510
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-msgs-5.8.0-np2py312h2ed9cc7_16.conda
+  sha256: 9716c84d0a0001935c83d890fa3a7c69f4ae1a7ec60a841f2dfcd9e1058fd05c
+  md5: cc81c992bb12ebbccd2d48d4eb8453f7
   depends:
   - python
   - ros-jazzy-action-msgs
@@ -31449,17 +31366,17 @@ packages:
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
   - ros-jazzy-trajectory-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 1247494
-  timestamp: 1768977058569
+  size: 1285912
+  timestamp: 1771185148025
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-msgs-5.7.0-np2py312h61f2ce4_14.conda
   sha256: 298fd756e54a8e537a52f5e1becb4457ceaba0e25ed6de70c1eee8982aa95b13
   md5: d90e53137a517d2f4b59d38a847dd875
@@ -31482,9 +31399,9 @@ packages:
   license: BSD-3-Clause
   size: 1255828
   timestamp: 1768945999887
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.9.0-np2py312h2c89a96_14.conda
-  sha256: 0865259a42210585d5941ebb96ef065cab13c9c2c90e4f0494dbcb221ce79b42
-  md5: 7393fb8df7eee399b7f54efc1a3e8c4c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-control-toolbox-4.9.0-np2py312h2c89a96_16.conda
+  sha256: 8b44ec05cc2f1f1c4bfd148d0c3e4f424bea20ccce6f11239fe528717330870b
+  md5: bbabe0a904cece0c4926fbaaa789d267
   depends:
   - eigen
   - fmt
@@ -31502,18 +31419,17 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-geometry-msgs
   - ros-jazzy-tf2-ros
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 287335
-  timestamp: 1768979862046
+  size: 287269
+  timestamp: 1771188260733
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-control-toolbox-4.9.0-np2py312h8b5252a_14.conda
   sha256: 258d6fad89ade6175b51bbd4e4d47c96254ee02e08a1ad8414e706be03855e7a
   md5: d8118f1c5dcfb11e01d09219770403d8
@@ -31544,26 +31460,27 @@ packages:
   license: Apache-2.0
   size: 283520
   timestamp: 1768948249131
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.42.1-np2py312h2c89a96_14.conda
-  sha256: a5e26b139a03b43173e21b1c4f401175c9e0bbb9e80f243941c4bf16027c7807
-  md5: 770287760deb713a05a593f4e9c83f0b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-interface-4.43.0-np2py312h2c89a96_16.conda
+  sha256: 747d3568462163d3131b691435373a1e4d7d33fae468e1bd54fc6aff29b81b68
+  md5: 4243b1f7f6bf7c4b48174b8a4c69c466
   depends:
   - python
   - ros-jazzy-hardware-interface
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - fmt >=12.1.0,<12.2.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 132923
-  timestamp: 1768980292302
+  size: 132805
+  timestamp: 1771188688159
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-interface-4.42.1-np2py312h8b5252a_14.conda
   sha256: 8049c4a8a42de0c1b067f16ab839a0fc9119341c0f35ec1deaa9fb766a2f850e
   md5: dc82acfa2a270ec08f379c781fe91381
@@ -31583,9 +31500,9 @@ packages:
   license: Apache-2.0
   size: 131059
   timestamp: 1768948622571
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.42.1-np2py312h2c89a96_14.conda
-  sha256: 67d6c6b324a398eb3588acd4bf989c1b4cbb2c98fd138fd5f17b090dc83b5b51
-  md5: dc7bc399756809c06bfffafdfe909671
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-4.43.0-np2py312h2c89a96_16.conda
+  sha256: bf8a14c02db911c6a5fd8050434b4dccc82a2e7e834f9f9288b92bc01e9738ea
+  md5: f91008be527f60bc01db6f52c338f5f2
   depends:
   - fmt
   - python
@@ -31610,18 +31527,17 @@ packages:
   - ros-jazzy-ros2param
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 678446
-  timestamp: 1768981045873
+  size: 680466
+  timestamp: 1771189455291
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-4.42.1-np2py312h8b5252a_14.conda
   sha256: 1c9a544471b45b62094e18c42058124e692ea5cf679b7de54d5656a0b489a63a
   md5: 6453431d8a09d43422ac02e61b29b0b7
@@ -31659,9 +31575,9 @@ packages:
   license: Apache-2.0
   size: 643686
   timestamp: 1768949184505
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.42.1-np2py312h2ed9cc7_14.conda
-  sha256: 1cb85a7b16bdac2f78cb90610d33e37cc1cb6edd63bbcf442ec802116158cfdd
-  md5: efd5a293e53147bf2e450cabb3be3cb7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-controller-manager-msgs-4.43.0-np2py312h2ed9cc7_16.conda
+  sha256: a4203f0abd9e90df5f5e651da9bbd91b9710f2603afa414b5699ccc4a76a4e94
+  md5: 16785badf6582555d4d90dee7fc93004
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -31669,17 +31585,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 573340
-  timestamp: 1768976602383
+  size: 577778
+  timestamp: 1771184677904
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-controller-manager-msgs-4.42.1-np2py312h61f2ce4_14.conda
   sha256: 670e223be7365e192d928df71a0d86be51ba43779a30da77fb5b93e3e11a7aaa
   md5: 476dfeffbd1ab0ccb2b0ce4928ffb1d3
@@ -31700,9 +31616,9 @@ packages:
   license: BSD-3-Clause
   size: 581666
   timestamp: 1768945618228
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np2py312h2ed9cc7_14.conda
-  sha256: 6bb21234dd801560eec120dc5dd0bf93e741fb1aab5c6396813981abab99acee
-  md5: 81dbc2a5e9cd0aba5c633e8e5efb7192
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-cyclonedds-0.10.5-np2py312h2ed9cc7_16.conda
+  sha256: f904ba801dccf0eb3c8982a0fbfb93496e05038e44d763f70fea04c1d6aaa2d7
+  md5: ef094c4926971c6c8e85726ba729609b
   depends:
   - openssl
   - python
@@ -31710,18 +31626,17 @@ packages:
   - ros-jazzy-iceoryx-hoofs
   - ros-jazzy-iceoryx-posh
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - openssl >=3.6.1,<4.0a0
   - numpy >=1.23,<3
-  - openssl >=3.6.0,<4.0a0
+  - python_abi 3.12.* *_cp312
   license: EPL-2.0 OR BSD-3-Clause
-  size: 1198707
-  timestamp: 1768974223640
+  size: 1198542
+  timestamp: 1771181714190
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-cyclonedds-0.10.5-np2py312h61f2ce4_14.conda
   sha256: f4a36c6446bfa6889e148525c5332795e3029dd43343ba446cd5706ce87b6afa
   md5: c467352279a1feee346d5ee15f369c21
@@ -31743,9 +31658,9 @@ packages:
   license: EPL-2.0 OR BSD-3-Clause
   size: 1262104
   timestamp: 1768943150778
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 14a64e7d671c810ae93d18bf6d2984b9c77de73671712d94ae1f3cc52ac8dd13
-  md5: 3d95a06eaf205864d759bf39dec65202
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: ff79863af33907de4a925e567f334eed9a20a1c0bde054c7b19f905205b9557e
+  md5: ad1edf0acbc17428cb55e73fba724329
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -31753,17 +31668,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 209501
-  timestamp: 1768976788907
+  size: 210738
+  timestamp: 1771184841289
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diagnostic-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 9828c9ab1b444cf82812275f2355ee052e0cfd711c471e809a12bfefce22f7f8
   md5: a77da34e6ac42229ab1de5d3d364938b
@@ -31784,9 +31698,9 @@ packages:
   license: Apache-2.0
   size: 213780
   timestamp: 1768945753807
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np2py312h2ed9cc7_14.conda
-  sha256: 76a47616bf3e7d7fac445364b2fd48efb97071b0551d510239eed3370d5e73c8
-  md5: 924ecddde0d222aed4503e6091480b0a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diagnostic-updater-4.2.6-np2py312h2ed9cc7_16.conda
+  sha256: 0b89f8316b443865bd3f577647c896763f96d283f6dd82118bebc67353611444
+  md5: 7f8b10265d995d1223241706dff0c3f7
   depends:
   - python
   - ros-jazzy-diagnostic-msgs
@@ -31794,16 +31708,17 @@ packages:
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 188194
-  timestamp: 1768979136785
+  size: 188133
+  timestamp: 1771187497112
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diagnostic-updater-4.2.6-np2py312h61f2ce4_14.conda
   sha256: 62a45163646fa71822998a4c445897f9d349130dd0f7002fb38b475d1fcd26f8
   md5: c3de6c0ea519a4aa7535f69b176680f8
@@ -31823,9 +31738,9 @@ packages:
   license: BSD-3-Clause
   size: 190393
   timestamp: 1768947592331
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: d151e59dcf250b876ab9cc970226f3fed97da597ecea06b496f5e3f3dbc77eca
-  md5: c9e81f85cf428b5030f9b7c4f0d14d2a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-diff-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: b3c3d3094473deb160b7bc49ad88d0fb72b3c5d0c125c9f6b2ce28c4022886b0
+  md5: 55d40a456a82ac32f7f2616ab8b81991
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -31842,17 +31757,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tf2
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 332320
-  timestamp: 1768981483225
+  size: 332216
+  timestamp: 1771189860929
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-diff-drive-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 24f6d5159e552712c16f3efbaa34dac8a94f9751c7b196cefddcd9cf8c8be4ac
   md5: 4b3b42953539bbe3e14522afc9c7133a
@@ -31882,22 +31797,23 @@ packages:
   license: Apache-2.0
   size: 315250
   timestamp: 1768949540070
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np2py312h2ed9cc7_14.conda
-  sha256: 9f4c63a2cbc6496f20eea8e39da663afb36ee3dbffcc70063f244a63ae4de30f
-  md5: a9b2ab72cfe9abb2b34520bd890e21b1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-domain-coordinator-0.12.0-np2py312h2ed9cc7_16.conda
+  sha256: 2da3e6fc7097d5e78a387b7a57fbdafac91e6ca41b945c96d2d6bd505eaa455c
+  md5: 830ed7e0d4d893f3bfc4be929ea78daf
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 21162
-  timestamp: 1768974323947
+  size: 20964
+  timestamp: 1771181802706
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-domain-coordinator-0.12.0-np2py312h61f2ce4_14.conda
   sha256: 0e35facc93ef65c17c74cdb4176a6ca9c9b34a7cdcc3a1bc0799a3f92af9046f
   md5: 3fc6badb65f17e35db7a8ed87a99d789
@@ -31914,9 +31830,9 @@ packages:
   license: Apache-2.0
   size: 21209
   timestamp: 1768943256007
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 9d98491705201348e100433b149200be73c60495c972df482d51ab13490fefcd
-  md5: aea54b11ec2ac4e31e29e5e29e175c8c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-effort-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 1a0f5402a5821ff35c2402ddf0c7d6ee96d9782aacda4d2dba74ab8f0c9bacc4
+  md5: 9a2c3daeb7dce255987b00aaeb4c42ba
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -31924,16 +31840,17 @@ packages:
   - ros-jazzy-pluginlib
   - ros-jazzy-rclcpp
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 78166
-  timestamp: 1768981959297
+  size: 78102
+  timestamp: 1771190361491
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-effort-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: abd27b92175af09d731b09070cdaf2644b9786a12cc653b760193d7da1935f8e
   md5: d818f870e2077daf5aa7bb1b92399855
@@ -31954,23 +31871,23 @@ packages:
   license: Apache-2.0
   size: 79184
   timestamp: 1768949950667
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np2py312h2ed9cc7_14.conda
-  sha256: 726a961f0c0bd4054f1f55a96f15551b841670605bdf2da96863faaf393dcab6
-  md5: 3c03cec7abb43f8d59cfb66da82ebe63
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-eigen3-cmake-module-0.3.0-np2py312h2ed9cc7_16.conda
+  sha256: 6f36940abf7af67db58a77955e517151e546f6c7166d3a20156d91918402631c
+  md5: 2b72648095541498b81b703ac3f6b2fc
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23600
-  timestamp: 1768974679364
+  size: 23396
+  timestamp: 1771182341186
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-eigen3-cmake-module-0.3.0-np2py312h61f2ce4_14.conda
   sha256: ba9ae186500db66ee7f142e6eaa03a9bfe2cb0c64ae783c1cb00c82b3df07bbd
   md5: d1ae92d33a7e47d8e0388becadba7a7d
@@ -31986,23 +31903,23 @@ packages:
   license: Apache-2.0
   size: 23587
   timestamp: 1768943654348
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.5-np2py312h2ed9cc7_14.conda
-  sha256: 3ac561ca2fe4b128f27aca8aa16ea67937c82bce7adf874ad7cd2730e1119a1d
-  md5: a50c063080d7508d868127bc8d9f0060
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastcdr-2.2.7-np2py312h2ed9cc7_16.conda
+  sha256: 00bae805c124d2ea45a007f4b87ad2feded86cc5049d962bd9c087f8479ff560
+  md5: ebb20af11a33dec16e9eb5e3127eb9ce
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 88720
-  timestamp: 1768974411517
+  size: 89449
+  timestamp: 1771181956820
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastcdr-2.2.5-np2py312h61f2ce4_14.conda
   sha256: dd3a81fa8fb9304b856f5a6072f865f7f4723af3a5a44545977542581439c0e0
   md5: e8d618c20c667198c721222478834fdb
@@ -32019,29 +31936,28 @@ packages:
   license: Apache-2.0
   size: 85812
   timestamp: 1768943363998
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np2py312h2ed9cc7_14.conda
-  sha256: fcba94d0c98353bffe9bfb22c440e6edde1b64df147eb6d750990b380c31721e
-  md5: 6c9772f854b8fb47ecea078d08334053
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-2.14.5-np2py312h2ed9cc7_16.conda
+  sha256: 64f610adb96897a555d57184d76b2b8c355f1fcad7094076660965144a5d84e9
+  md5: 09f8c0ae8c24c065aee272a37e39bc1c
   depends:
   - openssl
   - python
   - ros-jazzy-fastcdr
   - ros-jazzy-foonathan-memory-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - tinyxml2
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - openssl >=3.6.0,<4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   - tinyxml2 >=11.0.0,<11.1.0a0
+  - openssl >=3.6.1,<4.0a0
   license: Apache-2.0
-  size: 4288878
-  timestamp: 1768974993912
+  size: 4292124
+  timestamp: 1771182693606
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastrtps-2.14.5-np2py312h61f2ce4_14.conda
   sha256: 7a537e1e2631360684e062ece43abd18fc531729de6ded5b4b0b28faaa58e76c
   md5: 3ee82764a9a4fd9e0874d2d1bf661e32
@@ -32063,23 +31979,23 @@ packages:
   license: Apache-2.0
   size: 4101030
   timestamp: 1768943952657
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.3-np2py312h2ed9cc7_14.conda
-  sha256: a8fdcb0309f4fe1df42c06bd498ad9701749204af2b147ae8371f5a424611a6d
-  md5: 110199549e41801294b59bc4e6c843b7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-fastrtps-cmake-module-3.6.3-np2py312h2ed9cc7_16.conda
+  sha256: 9c4554ba16e1467cb0dd687f05fede37f759aa78aba61e05a451a6cfe0c10dbc
+  md5: 3db3bb419552524c7fb412d212d23336
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 27574
-  timestamp: 1768974982016
+  size: 27404
+  timestamp: 1771182666787
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-fastrtps-cmake-module-3.6.3-np2py312h61f2ce4_14.conda
   sha256: 1621742d2dcbab99c80f2709b37237ff0c56d7d14ef009644beb10d6789a2abb
   md5: 01a175ec84e92d1f1a3c35792dbfa69c
@@ -32096,27 +32012,26 @@ packages:
   license: Apache-2.0
   size: 27561
   timestamp: 1768943940401
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np2py312h2ed9cc7_14.conda
-  sha256: c734bdabd11ba89ae84c54eb64b1701973599f85f65340e145c3770c65182320
-  md5: 1e2a0760541c563c8809274955d79510
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-filters-2.2.2-np2py312h2ed9cc7_16.conda
+  sha256: 33dd4f500fee240813476fc8b095792f1f0d4ea60db0a1e639473d9632ce527e
+  md5: e69f37fcf496e4e41393847d288bb387
   depends:
   - libboost-devel
   - python
   - ros-jazzy-pluginlib
   - ros-jazzy-rclcpp
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - libboost >=1.88.0,<1.89.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 132635
-  timestamp: 1768978487324
+  size: 132521
+  timestamp: 1771186788448
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-filters-2.2.2-np2py312h61f2ce4_14.conda
   sha256: 6f4b3985e6eaff336bf9ac25161929636320d8994811b01e0b1a3b00dcf0c6cd
   md5: bced279e3207893d62ac08b32f983e9b
@@ -32136,26 +32051,25 @@ packages:
   license: BSD-3-Clause
   size: 133295
   timestamp: 1768947015830
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_14.conda
-  sha256: 91978bdc4e8c592845c953806b8461279b323fe7a2453e37b42d449d436fc371
-  md5: b440b4ea79648b6fdc2e07b608e166c2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_16.conda
+  sha256: 3911d88e0513ab963d112dc5e485df39377d2a6cae6edcffade564f3e431153a
+  md5: 34ca2e37e06f5a14918db1fa447cb0e4
   depends:
   - foonathan-memory
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - cmake
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - foonathan-memory >=0.7.3,<0.7.4.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR Zlib
-  size: 19613
-  timestamp: 1768974732543
+  size: 19369
+  timestamp: 1771182385330
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-foonathan-memory-vendor-1.3.1-np2py312h61f2ce4_14.conda
   sha256: 04f8817c1feca013833f2325f87ec015c362e4e6d81dae6c5e965564179ab50a
   md5: e5ceaf9f8073b7d5dea92b57b6efa6d5
@@ -32174,9 +32088,9 @@ packages:
   license: Apache-2.0 OR Zlib
   size: 19602
   timestamp: 1768943715608
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: a04c87050cccc9f935139f335a9875de84a5f57dca9ee19c3574a1489e61250f
-  md5: fa709f0935b02365d601b97cd36e2887
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-force-torque-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 03554b976d788b5f421617ac0205452ee429437a01109437cd8ff7d6ebd2377e
+  md5: 99bc154b6e1ddce4ed72257db2520c9e
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -32193,17 +32107,17 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-geometry-msgs
   - ros-jazzy-tf2-ros
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 412582
-  timestamp: 1768981583667
+  size: 412521
+  timestamp: 1771189962949
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-force-torque-sensor-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 537910c52d1c08340e65b45c02bbc78bafcbaf54f4fb3a7bfc2111fed2d7abff
   md5: 33f74be2a43bd036b43be218d16c4dc6
@@ -32232,9 +32146,9 @@ packages:
   license: Apache-2.0
   size: 404488
   timestamp: 1768949651361
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: a394322527e80c1d6266993f2312589ca9f8be7af27db40da663ae319292d208
-  md5: 395c0914c5c40ee9867ad95310f3efb1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-forward-command-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: ad9888b7f79fe8195c029df455ebec6e59d138d358f0ebb1cfb18f2e76680bb8
+  md5: 6af44ef6c59fb7a6092ebb5225b4d61e
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -32247,16 +32161,16 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 228543
-  timestamp: 1768981484466
+  size: 228449
+  timestamp: 1771189860237
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-forward-command-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 79dfe6fcfcd8b429f60f9778b20f7301710a7fc034f44b7a4d2b357ecd1437bc
   md5: f57efcfbf80aed10df86854d988ad8e7
@@ -32282,9 +32196,9 @@ packages:
   license: Apache-2.0
   size: 224000
   timestamp: 1768949540981
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.6.0-np2py312h2c89a96_14.conda
-  sha256: 91b4bdafd465406661df766011a9aa05ce3e47d0777e53bdb20e0b132d77d6bd
-  md5: e8575d2b74bf64fa845cc4aaa84c76f2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-0.6.0-np2py312h2c89a96_16.conda
+  sha256: 4e82c67dfe0c3220baa1d365551328bd1a2eb927ff91b3a91dfb8faa05f9644d
+  md5: 3ebd4b1efd2fc4afa9da618c44053046
   depends:
   - fmt
   - python
@@ -32297,18 +32211,17 @@ packages:
   - ros-jazzy-rsl
   - ros-jazzy-tcb-span
   - ros-jazzy-tl-expected
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - fmt >=12.1.0,<12.2.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 50797
-  timestamp: 1768979117675
+  size: 50635
+  timestamp: 1771187478256
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-0.6.0-np2py312h8b5252a_14.conda
   sha256: e464c1f1e8b47ff91daffa0ec6db7077512473813df4c7d170324d7ea09cefc0
   md5: a76e17471cd7334339e7f665bf84e917
@@ -32334,26 +32247,26 @@ packages:
   license: BSD-3-Clause
   size: 50508
   timestamp: 1768947566011
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_14.conda
-  sha256: 0bcb2ebbbd0897091ed73e9b6c0bfc0ee00233b57a3ae4ba1fbd6a1d051482f6
-  md5: 939f375eadc655ebc9807ce58a89ac73
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_16.conda
+  sha256: 59e25a883b8c5db03f354b386df1250f96eae7a25d7e5925c2242581f9486c3a
+  md5: 8a5d76ae1a5fb0a72ca30abb87d341e5
   depends:
   - jinja2
   - python
   - pyyaml
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - typeguard
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 71201
-  timestamp: 1768974327951
+  size: 70919
+  timestamp: 1771181807472
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-generate-parameter-library-py-0.6.0-np2py312h61f2ce4_14.conda
   sha256: 68bb1c5a9f85161b6f3b87c91fb735007e45e28ab9b3e7763f393dd4a6994f95
   md5: 3fc2a1af34450b0f72a1c7d73e0dfd25
@@ -32372,24 +32285,25 @@ packages:
   license: BSD-3-Clause
   size: 71218
   timestamp: 1768943262465
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 45d223f66db6e9084a0d8a15106c3b4b5ad272bfd30b41888cb3924e91202099
-  md5: 30a1ecf3d7eca9afe781cedb010ef31b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-geometry-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 1559505477be3967aca3415283ab6cafe9895c77cc60362c61b8521456230e9d
+  md5: d00c744931ffffb875e4e7a807a38221
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 378328
-  timestamp: 1768976665376
+  size: 379806
+  timestamp: 1771184731586
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-geometry-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 6c78861421048d4b555e9c2994ba58c7e6c7cedf640b6e409892ad7015be0c62
   md5: c55d881bcea7bf4ea219556a64e4c78c
@@ -32407,23 +32321,24 @@ packages:
   license: Apache-2.0
   size: 387385
   timestamp: 1768945647999
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np2py312h2ed9cc7_14.conda
-  sha256: ae4d290f1f62038dea2d8067f47132491fefda516adac12f96a95ecebe9e4eb0
-  md5: a1906688ae2da9d0244b93387662bd83
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gmock-vendor-1.14.9000-np2py312h2ed9cc7_16.conda
+  sha256: f377eb20739a8926edcd0883f0ad184319cdf4d4a180b0e9d3999554b1cf8796
+  md5: 5d0667f83f166be64e8292b1c5555246
   depends:
   - python
   - ros-jazzy-gtest-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 122498
-  timestamp: 1768973994404
+  size: 122360
+  timestamp: 1771181399689
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gmock-vendor-1.14.9000-np2py312h61f2ce4_14.conda
   sha256: 674c746e885014389072b5558d4c24dd1a8ce6913ee3f9f7ddc8a057349b15e4
   md5: 17185335808c4cef783438eae9a4df3c
@@ -32440,9 +32355,9 @@ packages:
   license: BSD-3-Clause
   size: 122496
   timestamp: 1768942861398
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 52330067c079a2360261cc6a5d145bc23c229c2a1df5f02bd11a8e430a08b052
-  md5: 61d3100086102343b597317aa9827d89
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gpio-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: a08a86a2a06fb652489a0af8799e12ed8220a575e8eddbaae015647464f62315
+  md5: 9e864b85961111fb48ae40737bc53b1d
   depends:
   - python
   - ros-jazzy-control-msgs
@@ -32453,17 +32368,16 @@ packages:
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 248326
-  timestamp: 1768981560352
+  size: 248246
+  timestamp: 1771189937102
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gpio-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 6e2994f23972c01092c21dbfba5e21388348f8ac25d5d455b3dad675bcbacb5a
   md5: 592ed85d7ca5d7a89f785fd68bb92295
@@ -32487,9 +32401,9 @@ packages:
   license: Apache-2.0
   size: 244893
   timestamp: 1768949623527
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: bd627f8404a68e1ca99f285ca39b0b02350f94e9e5f59249d5a926d3c7c3e68e
-  md5: ff42ec1be67712e6b869a66f06588363
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gps-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 16416d8752b74f557baeaaa23254fd3d9fe1238a88a6da945d879ca2e41703f5
+  md5: 85fe72ab2bbd9959fa337753d79aad80
   depends:
   - python
   - ros-jazzy-controller-interface
@@ -32501,17 +32415,16 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 153937
-  timestamp: 1768981543791
+  size: 153887
+  timestamp: 1771189919527
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gps-sensor-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 7eda062aa4a72275b0b6fe5b5b1585541851835be7454b0ca866bbbf9f27679e
   md5: 73d9d176012ab19cf1fcd1251ac4feff
@@ -32535,9 +32448,9 @@ packages:
   license: Apache-2.0
   size: 154038
   timestamp: 1768949604239
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 3d746249edda1441147043bf9fd83681441209067ba2b0dc636943198258642d
-  md5: 77da34416ff26a7dadf4d54990db0920
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gripper-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 4b9faea1d6a7a0d886359ff88001b7508c19b58020f1fce372e419a3a3c6bc8a
+  md5: eebfd108b5d5cdefaa5a9786592fb631
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -32551,16 +32464,17 @@ packages:
   - ros-jazzy-rclcpp-action
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 157725
-  timestamp: 1768981531638
+  size: 157687
+  timestamp: 1771189900576
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gripper-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 7b3c7bcae37283b7aa93e5a4950a282b3e35efe7b1d3ed9c1eca50848b29910f
   md5: b1a3bdf749846d37db1a55bba56f7f29
@@ -32586,23 +32500,23 @@ packages:
   license: Apache-2.0
   size: 154275
   timestamp: 1768949587896
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np2py312h2ed9cc7_14.conda
-  sha256: 2f85954cfa7f6412fa66bd8b8eeef7a26153773155c30ff5281f9db20f7009b5
-  md5: 6d62ac403f26154961e0efcf164bf02a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gtest-vendor-1.14.9000-np2py312h2ed9cc7_16.conda
+  sha256: 57f55e3a7b15e8a6856f05e50a56e62419c10a2c81a53b22819d70a5e77cd4b0
+  md5: b6c347396b35923caa768b0be2e055a8
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 208884
-  timestamp: 1768973893170
+  size: 208727
+  timestamp: 1771181329475
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gtest-vendor-1.14.9000-np2py312h61f2ce4_14.conda
   sha256: a8031b2b5c0dbdf6585b79d02b4ec5b09f3ae1934552c38f7d0f090dc995bb95
   md5: 0f0f53b4f6026f02f06fe9528131a58e
@@ -32619,25 +32533,24 @@ packages:
   license: BSD-3-Clause
   size: 208851
   timestamp: 1768942740388
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np2py312h2ed9cc7_14.conda
-  sha256: 9909360d63cfb933fdceb72c791e3f405835e007f0d1a8607caa225491b42ca1
-  md5: a0257594d1efe75f1508dfce9bd48469
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-cmake-vendor-0.0.10-np2py312h2ed9cc7_16.conda
+  sha256: 9c995ccb801c0e32d462b2f8b81e9da4f4610fb343b1c45a2c888901011c4e4e
+  md5: 4c086d2da8ce7b827b101f69b95fb55d
   depends:
   - gz-cmake3
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libgz-cmake3 >=3.5.5,<4.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24763
-  timestamp: 1768974736897
+  size: 24488
+  timestamp: 1771182389447
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-cmake-vendor-0.0.10-np2py312h61f2ce4_14.conda
   sha256: 40661a47f7a6957af5f55b12dbaf13849826379e14759eeec603301e9245a588
   md5: 28d7ff015ee6209edded55b4db106dec
@@ -32655,9 +32568,9 @@ packages:
   license: Apache-2.0
   size: 24751
   timestamp: 1768943720998
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np2py312h2ed9cc7_14.conda
-  sha256: d6329fb58bddb759b5ec3511680a77d5ff5285d0f3e5897862c7ce17351e2831
-  md5: 79ceaf5f8294f02e113a059b7d5aeb6b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-math-vendor-0.0.8-np2py312h2ed9cc7_16.conda
+  sha256: b461d930a0cac35c7e27aee841057191f053048efcc4eed49df579700760de63
+  md5: e7c2dd364818a68801c40c9692c722e8
   depends:
   - eigen
   - gz-math7
@@ -32665,18 +32578,18 @@ packages:
   - ros-jazzy-gz-cmake-vendor
   - ros-jazzy-gz-utils-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libgz-math7 >=7.5.2,<8.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 28108
-  timestamp: 1768975346422
+  size: 27853
+  timestamp: 1771183038936
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-math-vendor-0.0.8-np2py312h61f2ce4_14.conda
   sha256: c42d3f7b6fd479d27b3e8f78b75b0ddef99cd5cf3ee8bd34d205e56d4b3b3a9d
   md5: 14e8f5306ae47df66c268df2c03acc26
@@ -32698,27 +32611,26 @@ packages:
   license: Apache-2.0
   size: 28105
   timestamp: 1768944230440
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np2py312h2ed9cc7_14.conda
-  sha256: 1ebd18f38805c14b213a05390b20e672dbe74ce20abb276cb11bf6f7974d7cc3
-  md5: 8e01c8bb9cf44ec7584491663fe3b305
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-tools-vendor-0.0.7-np2py312h2ed9cc7_16.conda
+  sha256: aac51328c3e7141b69b4f4f891334bb3f2bdfb21fc5d72a2b24443f1a5ca5ee2
+  md5: fee5e91446ba3153765bdfbf782c1042
   depends:
   - gz-tools2
   - python
   - ros-jazzy-gz-cmake-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - ruby
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libgz-tools >=2.0.3,<3.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 27642
-  timestamp: 1768975014217
+  size: 27486
+  timestamp: 1771182689407
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-tools-vendor-0.0.7-np2py312h61f2ce4_14.conda
   sha256: d605b3c3f1822c3a2fe3492e9d388fef7bb45eb8181ed6c757086f77bb7dfe20
   md5: c8a0fec7b9bf85a6e90dcf97a889e32e
@@ -32738,26 +32650,26 @@ packages:
   license: Apache-2.0
   size: 27547
   timestamp: 1768943969240
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np2py312h2ed9cc7_14.conda
-  sha256: cb8d7c9417b0faecaa7c2b0cca8e68c8d6f87b9045ffebb235e9173503c3e3ab
-  md5: 4f317c6a5dcf52c866d3826214c5f6f5
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-gz-utils-vendor-0.0.5-np2py312h2ed9cc7_16.conda
+  sha256: 9794dc197d5973441986cdefe674b62242d8c4f2f161d9cda55013b053f1d628
+  md5: f973fb5235f6a4a7f30bd743c2caa88b
   depends:
   - gz-utils2
   - python
   - ros-jazzy-gz-cmake-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - libgz-utils2 >=2.2.1,<3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26181
-  timestamp: 1768975009289
+  size: 25878
+  timestamp: 1771182684931
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-gz-utils-vendor-0.0.5-np2py312h61f2ce4_14.conda
   sha256: b89af33ebf90fec4f43de4988f73e6102cb0d727b9e289690a3ff4beda954dc6
   md5: 6369aa0a73b30107c2e32304638258be
@@ -32776,9 +32688,9 @@ packages:
   license: Apache-2.0
   size: 26158
   timestamp: 1768943957739
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.42.1-np2py312h2c89a96_14.conda
-  sha256: 5783bad224f2b24bf4bf28b6ddb0918b0bd21b7c043fe2b780b3f9759d8da6e0
-  md5: 10fdb5b32bea8ee01f2d2c1e8ce6a615
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-hardware-interface-4.43.0-np2py312h2c89a96_16.conda
+  sha256: 67628453d17ffbc2abedcb6a17aa8bca12f79e15a38146dc16c564d3ed81b997
+  md5: 0ce2cc7a2341251ef19d2393bf642ee6
   depends:
   - fmt
   - python
@@ -32796,18 +32708,17 @@ packages:
   - ros-jazzy-sdformat-urdf
   - ros-jazzy-tinyxml2-vendor
   - ros-jazzy-urdf
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 465316
-  timestamp: 1768979791649
+  size: 467293
+  timestamp: 1771188188235
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-hardware-interface-4.42.1-np2py312h8b5252a_14.conda
   sha256: 0f4cf413f8c4b666f07c1601c57a47f81d94bd8177e0c5abd0c152ffe223a603
   md5: 5f4de4e26c3f5bde4e706fca31327a39
@@ -32839,23 +32750,23 @@ packages:
   license: Apache-2.0
   size: 447542
   timestamp: 1768948173088
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np2py312h2ed9cc7_14.conda
-  sha256: 8f010888b7ea6b9875445af532fab0859673107a70fb7f5c3a4767d95c312015
-  md5: aa351521475dbea357447318c72eecfe
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-binding-c-2.0.6-np2py312h2ed9cc7_16.conda
+  sha256: 7c6f6ffabad4da18868b1aa94aa4a9d7f346ab9d6272f447c715041f1aa915cb
+  md5: d076d8b4df63ced919bebe8dd7010d7a
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 93049
-  timestamp: 1768974102613
+  size: 92888
+  timestamp: 1771181569856
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-binding-c-2.0.6-np2py312h61f2ce4_14.conda
   sha256: 508f097e3fae6220c3c625636eef39a450d9f9df31eeecb49c3aaf43cc18a6d0
   md5: 2690ce999a2653ed8aa3af9ffab721c7
@@ -32871,25 +32782,24 @@ packages:
   license: Apache-2.0
   size: 90888
   timestamp: 1768942992068
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np2py312h2ed9cc7_14.conda
-  sha256: a3ecb7c3bad08d61cac049f17fa08f539ad7313efc308445ef18256bdf59f999
-  md5: f58696012dc006e97b4b83ee20f563ef
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-hoofs-2.0.6-np2py312h2ed9cc7_16.conda
+  sha256: c6e2f5e887a9643a573ea5aca74af866fe5eac37f6427eccc6f86ab34dd414f1
+  md5: 04c92c52df04345c2eec47a663d74b89
   depends:
   - libacl
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - libacl >=2.3.2,<2.4.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 263886
-  timestamp: 1768973871610
+  size: 263723
+  timestamp: 1771181309002
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-hoofs-2.0.6-np2py312h61f2ce4_14.conda
   sha256: 4763ebb412d79e88be8de15c0b534440bbfc4f3adebbcdfc4ef74f15975e98a9
   md5: d0371701279b5e1634e0e3ffaa602f15
@@ -32907,24 +32817,23 @@ packages:
   license: Apache-2.0
   size: 264150
   timestamp: 1768942717260
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np2py312h2ed9cc7_14.conda
-  sha256: ac7b6b1e2bf01d21fc28719ef509f8535fc078ac439738dc832ee7789f2e60ac
-  md5: ceab222eb87fcd6896336b24914cab84
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-iceoryx-posh-2.0.6-np2py312h2ed9cc7_16.conda
+  sha256: a2cee0b8aec0271458d797c1074e535af136d7dc8c0649ee26b7fec77165c021
+  md5: 1e8219076c2ef4b36316b8196e6ce8f7
   depends:
   - python
   - ros-jazzy-iceoryx-hoofs
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 573882
-  timestamp: 1768973997324
+  size: 573789
+  timestamp: 1771181402685
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-iceoryx-posh-2.0.6-np2py312h61f2ce4_14.conda
   sha256: 84a235029ea5284ebaff5f852d9240163a3077adcb39920dfbfce69a10df671c
   md5: 1199dbc2573373ee29c9e770a1e678c9
@@ -32941,9 +32850,9 @@ packages:
   license: Apache-2.0
   size: 577354
   timestamp: 1768942864767
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np2py312h2ed9cc7_14.conda
-  sha256: b1160bba9c4a83d5ebc3d22a678e4784cda0959b60aa06604a66080ac60712dd
-  md5: c037c91a9d24569547f4e8a21e7bc6b2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-image-transport-5.1.7-np2py312h2ed9cc7_16.conda
+  sha256: c76c8b623bf1517e4fed60528951258b562e486337d5a479ce5604bd2058cffe
+  md5: 0c892918b81b51262afb4f295571835f
   depends:
   - python
   - ros-jazzy-message-filters
@@ -32952,16 +32861,17 @@ packages:
   - ros-jazzy-rclcpp-components
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 579122
-  timestamp: 1768979167412
+  size: 578963
+  timestamp: 1771187526810
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-image-transport-5.1.7-np2py312h61f2ce4_14.conda
   sha256: 7fb3fb6b500acf23c455932acdf606b14fd0fce1ad54799d484a52d273dce891
   md5: 883d501df4c4e3085c764c14e3ba2d26
@@ -32982,9 +32892,9 @@ packages:
   license: BSD-3-Clause
   size: 584007
   timestamp: 1768947612609
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: c6b6c8a23c342e356895f7817e9336516210014e9e7acee1f9ff1c1660735857
-  md5: d99bb2a49acdfd88e34e67d2a96bc477
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-imu-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: f7251aca2d5abb316ee6866372d4a59ab1a948d95b60e28e6efdb756e1c09f8b
+  md5: 32601838f9bcc39d6bb44e898122e187
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -32997,17 +32907,16 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 153565
-  timestamp: 1768981526793
+  size: 153342
+  timestamp: 1771189902
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-imu-sensor-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 85359d779903a9ad7fdf4e9fb87d7c9c82b9fdffe486ad94cffa22551a1d1dab
   md5: aed834b87c9ba5a4eba57134573185dc
@@ -33033,9 +32942,9 @@ packages:
   license: Apache-2.0
   size: 154086
   timestamp: 1768949585088
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.5-np2py312h2ed9cc7_14.conda
-  sha256: c7241cabc60b41053ca2c05e2e313e13410f4905f2d54c51f9f801a103ba3a94
-  md5: 31acd36893365f55707a8cd92a6ab901
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-interactive-markers-2.5.5-np2py312h2ed9cc7_16.conda
+  sha256: 6e58c60773f12249b309d171004d89c20b5f8a864513c48eb5428435436832d6
+  md5: 251ca30d463c8e0807df55fd5c8d6576
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -33049,16 +32958,17 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-geometry-msgs
   - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 306955
-  timestamp: 1768979892451
+  size: 306774
+  timestamp: 1771188291811
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-interactive-markers-2.5.5-np2py312h61f2ce4_14.conda
   sha256: 11be2acf5ec4e53e3c842e88802eb8552eab3673d8562a40c25e8f7221972f14
   md5: c06a6d2591bc3234323c5b6c6c85391d
@@ -33084,9 +32994,9 @@ packages:
   license: BSD-3-Clause
   size: 306452
   timestamp: 1768948265070
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.42.1-np2py312h2c89a96_14.conda
-  sha256: 8929b7e40d95b22065dae305d86d6512783075a8a857ca4140fc0db3ca8c8227
-  md5: 92457abb473f1acd7ad16d8ffc272d61
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-limits-4.43.0-np2py312h2c89a96_16.conda
+  sha256: 951b2c36f64f2a8045ab513ae69dbd2d4ca4771d4c146447c1dc6c0ea0ab6cbe
+  md5: ec9c694d8933b28a83d29c2a01b1f8c9
   depends:
   - fmt
   - python
@@ -33098,18 +33008,18 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-trajectory-msgs
   - ros-jazzy-urdf
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 140585
-  timestamp: 1768979350126
+  size: 140743
+  timestamp: 1771187726577
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-limits-4.42.1-np2py312h8b5252a_14.conda
   sha256: 44043385407a5a010561f347644cc89f34f6b2c9511b0681c32841791dabfa7f
   md5: 70b845bd7a7b657d82d37caa843cda17
@@ -33134,9 +33044,9 @@ packages:
   license: Apache-2.0
   size: 140723
   timestamp: 1768947777964
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 4be7a9a2dae98637172077259c77f56fb26f0719eef94a38d8e5bee4349b17f0
-  md5: ba421c69e1621f0ce932c8164dd25db6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-state-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 9c79ef4954949577124c61b5620dcb67e3b799e4ab3e6c9ae21021bad6ae5847
+  md5: 34b1718db7732a5b76b14402c8df8059
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -33151,17 +33061,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
   - ros-jazzy-urdf
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 188961
-  timestamp: 1768981483140
+  size: 188848
+  timestamp: 1771189859122
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-state-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 35f70954ffb5b20b524a9bd15706208ba666739095e8fe4c73dc66f51de64b6e
   md5: 4f0d0e73e27a399dab9db6c98ad78bd3
@@ -33188,9 +33098,9 @@ packages:
   license: Apache-2.0
   size: 186469
   timestamp: 1768949541921
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: e4ca716af07c67b9b00acc72dccc2a94d06331b7a33c1e291d899349696abd53
-  md5: 2cc32360706fa22f0aa4d70359683bac
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-joint-trajectory-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 045a68bc6961d94aed376f49b93dc717694ab8c067d2009206f7bcdb1b676516
+  md5: 7fcb98378f3213f0cdb208c511e711b0
   depends:
   - python
   - ros-jazzy-angles
@@ -33210,16 +33120,17 @@ packages:
   - ros-jazzy-tl-expected
   - ros-jazzy-trajectory-msgs
   - ros-jazzy-urdf
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 405164
-  timestamp: 1768981619485
+  size: 405031
+  timestamp: 1771189999980
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-joint-trajectory-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 6eebadaaeda0763ecf9abf0de65dbd2699f92b0154f151fa54aada638a0ade80
   md5: c09eb0d57bf24ba85e299cac958a3590
@@ -33251,9 +33162,9 @@ packages:
   license: Apache-2.0
   size: 392478
   timestamp: 1768949690516
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np2py312h2ed9cc7_14.conda
-  sha256: cb216c6777e04ae1993b9e65e4169c0e3071a69d08ca655b4e10d30937ed31d0
-  md5: cdcf417482aa5451d665eeed7ea2bb73
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kdl-parser-2.11.0-np2py312h2ed9cc7_16.conda
+  sha256: 6b4ea316ea6565879785a968b58a4d12f3dacca9c69d88046cbd8ccb19d930b2
+  md5: 4ce3fea980db4f8dc1db2c0189fa66fb
   depends:
   - python
   - ros-jazzy-orocos-kdl-vendor
@@ -33261,16 +33172,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-urdf
   - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 47346
-  timestamp: 1768976075902
+  size: 47248
+  timestamp: 1771183956036
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kdl-parser-2.11.0-np2py312h61f2ce4_14.conda
   sha256: 6db4fa369a94436c5d5cef0d4d2fafcc57e863585644c83acb6ca05f4183d024
   md5: 3df5cfa4240556c98d765896b6c9e669
@@ -33291,26 +33203,26 @@ packages:
   license: BSD-3-Clause
   size: 48411
   timestamp: 1768945046723
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.7.0-np2py312h2ed9cc7_14.conda
-  sha256: e87bcb94cbd53d995aab5cd03a5db211c81f7e0b5b44680565691568d04e57d0
-  md5: d5f07a47b83ee3fc0c51ed614ade033b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-kinematics-interface-1.7.0-np2py312h2ed9cc7_16.conda
+  sha256: f92fffc0dffdf191e441a94c423384213ee805b43d6f35bb790d6e00db1ab04f
+  md5: 491325bcf991d920bcd1edd8f507c4d9
   depends:
   - eigen
   - python
   - ros-jazzy-backward-ros
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 50857
-  timestamp: 1768978708514
+  size: 50751
+  timestamp: 1771187093399
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-kinematics-interface-1.7.0-np2py312h61f2ce4_14.conda
   sha256: 31142b22f914ab5e8d1589177ba978f14e6fd03ecee4734626578ae35d539b57
   md5: fb0d0412e9866ae6f97c7475f865992f
@@ -33329,9 +33241,9 @@ packages:
   license: Apache-2.0
   size: 51815
   timestamp: 1768947234759
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.2-np2py312h2ed9cc7_14.conda
-  sha256: b64921a1723e46872f881bd3675a1031742b261e30a774aeff995fb83fce4d63
-  md5: 3ee05aecb92144881b48053608362125
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-laser-geometry-2.7.2-np2py312h2ed9cc7_16.conda
+  sha256: 7bcb9aa1c6813f892b76cb697bf5713cfb8d792e2cfcd53276d5a1b3a7dc820f
+  md5: c4121fea810c7df08db4d85d792b08e9
   depends:
   - eigen
   - numpy
@@ -33343,17 +33255,16 @@ packages:
   - ros-jazzy-sensor-msgs
   - ros-jazzy-sensor-msgs-py
   - ros-jazzy-tf2
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 61545
-  timestamp: 1768978489268
+  size: 61406
+  timestamp: 1771186796429
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-laser-geometry-2.7.2-np2py312h61f2ce4_14.conda
   sha256: 9080fe021fa99edf52f762bc3b7a1d952d9044a117e7947f7f02426651e39956
   md5: 597d2f1f975ce1ee12b4a6f8f4305ed0
@@ -33377,9 +33288,9 @@ packages:
   license: BSD-3-Clause
   size: 61041
   timestamp: 1768947033866
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.9-np2py312h2ed9cc7_14.conda
-  sha256: a7b7ca6d7c915792b84a2dd6e40e2f8ca9b7d2b440a15c83b30d46f40ed18641
-  md5: eece9b9118bda0c5bae30681a3267ef5
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-3.4.10-np2py312h2ed9cc7_16.conda
+  sha256: 0edbe6d59136807c7beddcc67ab69fddc9ef6774eff97d8db15496414d2b5b2a
+  md5: 3bda048d15d8490da63e887b9e7daf22
   depends:
   - importlib-metadata
   - lark-parser
@@ -33388,17 +33299,16 @@ packages:
   - ros-jazzy-ament-index-python
   - ros-jazzy-osrf-pycommon
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 235443
-  timestamp: 1768974397719
+  size: 234601
+  timestamp: 1771181921660
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-3.4.9-np2py312h61f2ce4_14.conda
   sha256: dd903f667bc6d89c69c648d6aeb09b8b480e5cb2091bba1c444b4a836ccfa8a5
   md5: b6e964e4dafa277db02c5ee9e23d526b
@@ -33419,9 +33329,9 @@ packages:
   license: Apache-2.0
   size: 235364
   timestamp: 1768943350591
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.10-np2py312h2ed9cc7_14.conda
-  sha256: c160af2015648c7d6b4811e71503fd3464138fe322f4f917f625f34d0dcd62d8
-  md5: 194c6e171fa85836d6f461afae155c46
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-ros-0.26.11-np2py312h2ed9cc7_16.conda
+  sha256: a120b42ce3a34c3f4a14fb402313b45a9f747bda265b3991a70d2350b7ef434c
+  md5: 4359b2fd50c2f22c746d161ac4ea5007
   depends:
   - importlib-metadata
   - python
@@ -33433,17 +33343,17 @@ packages:
   - ros-jazzy-osrf-pycommon
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 128002
-  timestamp: 1768978481518
+  size: 127888
+  timestamp: 1771186785677
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-ros-0.26.10-np2py312h61f2ce4_14.conda
   sha256: a8214e39c85f2b83b7a2f602bdd513f269e143c90a4ef39c3e65abd6d69a468b
   md5: 0b9974489866fc54ba097d3fecdb2fd1
@@ -33468,9 +33378,9 @@ packages:
   license: Apache-2.0
   size: 127843
   timestamp: 1768947019206
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.9-np2py312h2ed9cc7_14.conda
-  sha256: 49949bf40443150f07f34fd0762a86acd2e2870ee4a8cffcdae28a5551c2bd88
-  md5: e025ba63f56fc312b2e6470867a64d4f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-3.4.10-np2py312h2ed9cc7_16.conda
+  sha256: fd6188fa0d4fda4c25d2ec8e7bdf4185c7c22dfb66637e8429020d407580ae50
+  md5: ffeb754d7964328e8578756fe64e80ce
   depends:
   - pytest
   - python
@@ -33480,17 +33390,17 @@ packages:
   - ros-jazzy-launch-yaml
   - ros-jazzy-osrf-pycommon
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 115977
-  timestamp: 1768974672239
+  size: 115800
+  timestamp: 1771182334915
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-testing-3.4.9-np2py312h61f2ce4_14.conda
   sha256: 75f0f161242e7dd254beaaa295ab553d4f3a4aa9d2feab42819eccb901fd55cc
   md5: 13caf5cded6bb30dcda8fdc1200a037d
@@ -33512,26 +33422,26 @@ packages:
   license: Apache-2.0
   size: 115977
   timestamp: 1768943643603
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.9-np2py312h2ed9cc7_14.conda
-  sha256: f967b76acff72df08cf6028a7e6794a73f8f74cee238ff2e1d2391003d8bdaf2
-  md5: 80dbdaf04ea1a78698258e2a6bab433e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ament-cmake-3.4.10-np2py312h2ed9cc7_16.conda
+  sha256: 612ddbe73de617752798bcc4272d01cca18ba2d9290a1d8044a62930f4f7ad87
+  md5: 05748e9aec44d3bc408680b344610ae2
   depends:
   - python
   - ros-jazzy-ament-cmake-test
   - ros-jazzy-launch-testing
   - ros-jazzy-python-cmake-module
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27342
-  timestamp: 1768975330125
+  size: 27056
+  timestamp: 1771183023714
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-testing-ament-cmake-3.4.9-np2py312h61f2ce4_14.conda
   sha256: be9a10812728e7dc71d6039f42a7e25e6a4967d23a954980a92f7b1280fe3743
   md5: dccef7271dfa87bb496dfa231c8b2e17
@@ -33550,9 +33460,9 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 27319
   timestamp: 1768944216101
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.10-np2py312h2ed9cc7_14.conda
-  sha256: b538c003f443fb610a36c1e8ecde0405d1a04f10f4ce3b727726ad71bcbd13cd
-  md5: 51cabc505aafe4e61c1e533d5da2bf08
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-testing-ros-0.26.11-np2py312h2ed9cc7_16.conda
+  sha256: 82f03eb399704182fdf1cbb0b592279512fd3a1757ee7c93260180bf8f6e0f79
+  md5: 3ac8271804e83cf4da79708d521a0c60
   depends:
   - python
   - ros-jazzy-ament-index-python
@@ -33560,16 +33470,16 @@ packages:
   - ros-jazzy-launch-testing
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 52124
-  timestamp: 1768978670276
+  size: 55262
+  timestamp: 1771187052672
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-testing-ros-0.26.10-np2py312h61f2ce4_14.conda
   sha256: 6d43ec81622e0c4b6fbe312bb36a7260ecf0797287b82904acb25bb163db534b
   md5: 859173c0661dae6fa696444efb954e4b
@@ -33589,24 +33499,23 @@ packages:
   license: Apache-2.0
   size: 51936
   timestamp: 1768947195359
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.9-np2py312h2ed9cc7_14.conda
-  sha256: 41671c6138e27d3dfa04c59b952ec0f084b01f813da674be77166e3e30a9af7a
-  md5: f70b975a10ced6a1031ede610f3e2ad6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-xml-3.4.10-np2py312h2ed9cc7_16.conda
+  sha256: 73ec8e744ba82530880c90b742c224c70b78be855033ffa2e8396eaf0b6e0712
+  md5: 3e667315e75eda67956c164c2b26ba73
   depends:
   - python
   - ros-jazzy-launch
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26211
-  timestamp: 1768974536054
+  size: 25911
+  timestamp: 1771182181875
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-xml-3.4.9-np2py312h61f2ce4_14.conda
   sha256: 54b0260cc4b7e7a2fb74055783e8bdb276b1f94a926b481f7049107ea6bf674b
   md5: e9d064feb5dd82669bb22f4fca045022
@@ -33623,24 +33532,24 @@ packages:
   license: Apache-2.0
   size: 26166
   timestamp: 1768943482467
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.9-np2py312h2ed9cc7_14.conda
-  sha256: 3f1a44cdfabb9114f6cb554e97218d59d5e586d3eb4688bfebd860aeaa3f45a6
-  md5: 51a9ae73837b23e9ed3cb22733f3e09e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-launch-yaml-3.4.10-np2py312h2ed9cc7_16.conda
+  sha256: 10c3ae995906701b9b3bdf2001428cfd2798fa5d399809c5f8a84fc70f4f9d16
+  md5: b9d7ec1c27bb257de60c6f27587a4a9c
   depends:
   - python
   - ros-jazzy-launch
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 26763
-  timestamp: 1768974530568
+  size: 26520
+  timestamp: 1771182172937
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-launch-yaml-3.4.9-np2py312h61f2ce4_14.conda
   sha256: 354fcfdf4338be4c1c0257597c1fd38ff6f100d6d437843466007e74d4e9c7bc
   md5: 3431ac897fa0777ad375f7d7e4c0c8b4
@@ -33658,25 +33567,25 @@ packages:
   license: Apache-2.0
   size: 26752
   timestamp: 1768943476336
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np2py312h2ed9cc7_14.conda
-  sha256: 83d8b640abc07769de68c488ae41fd6abb0bf95d4da0d86710e6bfe0098c9e69
-  md5: 02eb1bc519dd239ee17bd704e3443243
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libcurl-vendor-3.4.4-np2py312h2ed9cc7_16.conda
+  sha256: 7d92890b37ecde8820c8c155bb196d3a595be3be8d65dbca456aa0cbf18fce44
+  md5: e14a567dcd399256b5d599970706752f
   depends:
   - libcurl
   - pkg-config
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - libcurl >=8.18.0,<9.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR MIT
-  size: 24022
-  timestamp: 1768974398717
+  size: 23738
+  timestamp: 1771181913671
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libcurl-vendor-3.4.4-np2py312h61f2ce4_14.conda
   sha256: 261d74b8aa7cf9ee97427470f86a4dc6f6c8ca1f04268335fca00712021e236c
   md5: 8df330b82b81b6513a85fdaa3b15a959
@@ -33696,9 +33605,9 @@ packages:
   license: Apache-2.0 OR MIT
   size: 24064
   timestamp: 1768943365365
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np2py312h2ed9cc7_14.conda
-  sha256: d62517ec97ae1f6092dd2c9671fb679af5559002ee0478c1b584a64ac9f6d4a0
-  md5: ef16f94cbbc4a58ef8531b326bf69a69
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libstatistics-collector-1.7.4-np2py312h2ed9cc7_16.conda
+  sha256: 28a886f44f45738c282a8e50a6a632046685c4c965baef5cafbe1fac236c3497
+  md5: e25b9890f9952d051d6710459b6637ba
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -33707,16 +33616,17 @@ packages:
   - ros-jazzy-rmw
   - ros-jazzy-ros-workspace
   - ros-jazzy-statistics-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 58653
-  timestamp: 1768978155993
+  size: 58541
+  timestamp: 1771186026943
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libstatistics-collector-1.7.4-np2py312h61f2ce4_14.conda
   sha256: 82b53c050a82de8e312e684c58090798462226a6633cdc954869ca3712edf13d
   md5: 091b7785c0ad4274620e2259fc387af9
@@ -33738,28 +33648,28 @@ packages:
   license: Apache-2.0
   size: 58036
   timestamp: 1768946658363
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np2py312h2ed9cc7_14.conda
-  sha256: 7d78f69d773ce404c673608accad28589976a7f641c74cc7f0cb4a494a501e60
-  md5: 275fd48396be8b164dcd049157bd6e03
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-libyaml-vendor-1.6.3-np2py312h2ed9cc7_16.conda
+  sha256: bf60ead7eabb0c00debfe62499ebf432609a0af495c32dc78092820a58000f66
+  md5: b2b5db515d9cd6bbbe383c0806e75ef4
   depends:
   - pkg-config
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - yaml
   - yaml-cpp
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
   - numpy >=1.23,<3
+  - yaml >=0.2.5,<0.3.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0 OR MIT
-  size: 29785
-  timestamp: 1768975364622
+  size: 29646
+  timestamp: 1771183051186
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-libyaml-vendor-1.6.3-np2py312h61f2ce4_14.conda
   sha256: 719e35c5975680c84fd2baaa5ab2f0b376548b9836cd900a1f3e1747b5c5df4a
   md5: 1afe2bfacdb4a62d7a371f10eb2e3f83
@@ -33781,23 +33691,24 @@ packages:
   license: Apache-2.0 OR MIT
   size: 29800
   timestamp: 1768944246613
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: d9260b8b62217c2115b3c2d182b82c3e60eede9e27f2d0149a7a647547ea450c
-  md5: 24696c77b54e41934b37fbb9b74193c1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-lifecycle-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: eb1ff42c4abe09c590cb85a487125dcb87e1c49c09fbc3091944061abc72a85f
+  md5: e48564c20cc670532a5c9e0cfa7df1eb
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 268422
-  timestamp: 1768976385186
+  size: 269381
+  timestamp: 1771184398235
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-lifecycle-msgs-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 19db5891b5fac367ce11fd89ba9c0b671fe091163b39ca4fd0efb026c14eecc7
   md5: 1285e34928098d691b521b8c6735a4e7
@@ -33814,9 +33725,9 @@ packages:
   license: Apache-2.0
   size: 276654
   timestamp: 1768945384
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np2py312h2ed9cc7_14.conda
-  sha256: c3928bd8e8506e259d8d5a46b71be8b2a403a8e550fede229b486feba53f8f0c
-  md5: dd224650948f01fc110335a46f3f8bc2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-map-msgs-2.4.1-np2py312h2ed9cc7_16.conda
+  sha256: b97d6d46b4ee637848f93b29ec693412cb244280c24f0778ad46db0b46bd8f39
+  md5: 368a94e5ae187bf9900341cb75abb88a
   depends:
   - python
   - ros-jazzy-nav-msgs
@@ -33824,17 +33735,17 @@ packages:
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 346433
-  timestamp: 1768977054937
+  size: 347447
+  timestamp: 1771185144723
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-map-msgs-2.4.1-np2py312h61f2ce4_14.conda
   sha256: 1ae2ae5121ae8799f6a53cb8bff8d85fda611c9b914c5ef9bd37eccc349ab274
   md5: 4a7cb75a844116f843fcefef6dfbab01
@@ -33854,9 +33765,9 @@ packages:
   license: BSD-3-Clause
   size: 354735
   timestamp: 1768945992841
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 0180377a7c686c1506949cc1f384f03d718a305f7acaed5bcad667348839f659
-  md5: 7444f99fea649e41c368bffc1bfac405
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-mecanum-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 60429e5865da4b8d46f2bf118eaf889a897eae9cca77b4a8044cbc82de256e1b
+  md5: 71a25b5c737cff03e0913bf0d8bde2ff
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -33875,17 +33786,17 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-geometry-msgs
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 299386
-  timestamp: 1768981588748
+  size: 299333
+  timestamp: 1771189969221
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-mecanum-drive-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 57ce59d8f9f0b3651ae604c3c2988018af95e6bcf2a6de24ee56fa6bf66bc9c8
   md5: 73244b3dd25a03d6945806171401a751
@@ -33917,9 +33828,9 @@ packages:
   license: Apache-2.0
   size: 290544
   timestamp: 1768949656210
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.9-np2py312h2ed9cc7_14.conda
-  sha256: 163f1ac45d52683833d38d0313a38f7e331a58330923250a4f020edd809126df
-  md5: 6027ba4d12cd1d9b6c50ea8298b506d8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-message-filters-4.11.10-np2py312h2ed9cc7_16.conda
+  sha256: bce9599721b256b2e32311c089075a893bc07b5b0f8c8361e4a2ecf6e518cb81
+  md5: c63cdd3251dbe7bc35f4e68ad2106583
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -33928,17 +33839,17 @@ packages:
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 82853
-  timestamp: 1768978685416
+  size: 83465
+  timestamp: 1771187068208
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-message-filters-4.11.9-np2py312h61f2ce4_14.conda
   sha256: ef386df1a6e9e1b24bfe0e05af7ccd8ba5a6505a4a84ef23287ae1ed1ec67bf9
   md5: 74e81939d5c02a025a6e7d1e7badc775
@@ -33960,9 +33871,9 @@ packages:
   license: BSD-3-Clause
   size: 83126
   timestamp: 1768947219947
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 22dfe512aae9adb3d125f324a0fa5c31a74d8518a728c714778fbc1c9e0faa1a
-  md5: f7f9f73ec85a7d89b47d6eb13415c486
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-nav-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: fead9138b90a64ce092b0a27a1ce6391199312ccb1483df73fe541bedb203503
+  md5: d1d350c81efeef8c306e48ac25b99327
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -33970,17 +33881,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 315493
-  timestamp: 1768976736613
+  size: 316823
+  timestamp: 1771184803763
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-nav-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 8693395c40543e8e4b0d324f54a86565fc19592602e833230104bb818d9089fc
   md5: 8f68dcdadeb78e789735127ebf81ce6f
@@ -34001,9 +33911,9 @@ packages:
   license: Apache-2.0
   size: 323835
   timestamp: 1768945723141
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 762424257a2548066c8683d3e711cbc5066376e25f0ba46f6442d5e6274b127e
-  md5: 98935c41113c91d2a56dea7a2c7a91bb
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-omni-wheel-drive-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: f7753ed227fe6328d72ad8444de3611ca9414154ff5af95676bb4358c68d7286
+  md5: 64cd50c6d396e751a05d7dd14d944be3
   depends:
   - eigen
   - python
@@ -34019,16 +33929,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tf2
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 397018
-  timestamp: 1768981557469
+  size: 396926
+  timestamp: 1771189933833
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-omni-wheel-drive-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: e4f667c5b87153822481f1aabb2c3d61ae7a8d7a0b64a5b264aadd4979284deb
   md5: 6542cbb9ab833d7b1f8d7bc7f64ca100
@@ -34057,27 +33968,27 @@ packages:
   license: Apache-2.0
   size: 382285
   timestamp: 1768949620764
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_14.conda
-  sha256: 6f5f48757332fd68c511fbe26e0e135de9fc3386a376f689f1426a0cc72ba7c5
-  md5: c4f6a3580fb31dce3c1dfff78ef3b268
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_16.conda
+  sha256: 3b99fadc8db8d08761ccaf4c271a4e229a99f27a998692d5d880b697949a950f
+  md5: e8296194669cf5cc38c6300fa32c90d3
   depends:
   - eigen
   - orocos-kdl
   - python
   - ros-jazzy-eigen3-cmake-module
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - orocos-kdl >=1.5.3,<1.6.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - orocos-kdl >=1.5.3,<1.6.0a0
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 28189
-  timestamp: 1768975024091
+  size: 28032
+  timestamp: 1771182699155
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-orocos-kdl-vendor-0.5.1-np2py312h61f2ce4_14.conda
   sha256: 390ddadabf95fb20e0b0d44f476f859a9267e4e5ede69ffc367d79fc1243883a
   md5: 04ffc42b51b3a4e42c300a8120486966
@@ -34097,24 +34008,23 @@ packages:
   license: Apache-2.0 OR LGPL-2.1-or-later
   size: 28195
   timestamp: 1768943993043
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np2py312h2ed9cc7_14.conda
-  sha256: 1f901727bc29bc4dc8525d5f026147addcf3292856236d7aee5906a75801daa5
-  md5: 6c1b85c9a373e69eca4501b6c7426b18
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-osrf-pycommon-2.1.7-np2py312h2ed9cc7_16.conda
+  sha256: 7a302c443a84452d053627ed95649d835ef609bb216fbd33e8b401a13d679b42
+  md5: e4aab42fa3680bc35d5e14d06435666f
   depends:
   - importlib-metadata
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 64649
-  timestamp: 1768973918027
+  size: 64494
+  timestamp: 1771181321947
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-osrf-pycommon-2.1.7-np2py312h61f2ce4_14.conda
   sha256: afc268bd72969cb4429cb0a144dc0c7a88f41565409d551c3be84b51c42165b6
   md5: 66591403c17ab7b26617f3e426b2edfb
@@ -34131,9 +34041,9 @@ packages:
   license: Apache-2.0
   size: 64590
   timestamp: 1768942731998
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np2py312h2ed9cc7_14.conda
-  sha256: f5b4efd6ceb6d967e7a187a2f0df6ce77b2073f334cc9dd49ed85f61074d1f81
-  md5: 0b60629bde19680af3b42a9e1f73cd9b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-2.7.0-np2py312h2ed9cc7_16.conda
+  sha256: ede29adac9d6d97527429d7a10bd3d49ad95abb1e706dd71b761daa4a2973f7b
+  md5: cf18d5c12666fd2c6b1b1a8f7a9dc9c7
   depends:
   - libboost-devel
   - python
@@ -34142,18 +34052,18 @@ packages:
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   - libboost >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: MIT
-  size: 171854
-  timestamp: 1768978692966
+  size: 171760
+  timestamp: 1771187075359
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-2.7.0-np2py312h61f2ce4_14.conda
   sha256: 4ebe982461f283d682795833e5d07455d65d922181df3121503fa14c3436aea6
   md5: a7e47882198cceb16d8e049937711571
@@ -34176,25 +34086,25 @@ packages:
   license: MIT
   size: 170378
   timestamp: 1768947227480
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_14.conda
-  sha256: 5d175a908440ea234af2fd64c7ca9b5216a66f323e60b08debe641a6bb097535
-  md5: 7607f3599e98873d646dcfed24ad86c1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_16.conda
+  sha256: 3b33ad90b7e7c1d1d5e18c42958653ff81b935db6db51cc940c6292b64701960
+  md5: 50ec534daafe7f334e37998368b517d6
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: MIT
-  size: 127023
-  timestamp: 1768976585467
+  size: 127896
+  timestamp: 1771184664080
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pal-statistics-msgs-2.7.0-np2py312h61f2ce4_14.conda
   sha256: 698b640823312ea520f1eb46ae8f4e7e302220aeb78b78fcdd5dcecdb759061d
   md5: 1c153c65edb80265e849c7c80f695463
@@ -34212,9 +34122,9 @@ packages:
   license: MIT
   size: 131127
   timestamp: 1768945596657
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 82c49ae1744bb5b92076117dc1ce812d4590b1b3b700fb9d5352df0268aa02fe
-  md5: 956b6612b3956416615764e538efefdf
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parallel-gripper-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 138eb2a5d424b2b1b12a686b237e46146315046e5f39e5d6318a699081c81fb1
+  md5: 5f862fc5a02ac6e40134c0bf1bfd2419
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -34228,16 +34138,17 @@ packages:
   - ros-jazzy-rclcpp-action
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 163050
-  timestamp: 1768981538816
+  size: 163004
+  timestamp: 1771189914963
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parallel-gripper-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: ce6353a3227319c1bda00e11f1b79d422fc94e1756e85baf5fcea2077d2ae182
   md5: 2fdf5b7734db870cb9cabcbb6dc4411a
@@ -34263,9 +34174,9 @@ packages:
   license: Apache-2.0
   size: 159113
   timestamp: 1768949598455
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.6.0-np2py312h2c89a96_14.conda
-  sha256: 935cac827333c0b4e9c262a8f51a79ef5ce36c0f9afe4096a28ea0b49ae66be2
-  md5: 9c35bbd662a957d60374ab55600d2747
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-parameter-traits-0.6.0-np2py312h2c89a96_16.conda
+  sha256: 88d9c3e695028b240837158e5cec7a34629457269f3a93e576e62b3f9d7acb63
+  md5: 00029c06b5501173f879fa6c42d5bd09
   depends:
   - fmt
   - python
@@ -34274,18 +34185,18 @@ packages:
   - ros-jazzy-rsl
   - ros-jazzy-tcb-span
   - ros-jazzy-tl-expected
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
   license: BSD-3-Clause
-  size: 50952
-  timestamp: 1768978650922
+  size: 50826
+  timestamp: 1771187033418
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-parameter-traits-0.6.0-np2py312h8b5252a_14.conda
   sha256: e8c7795700c7890bce90b2e7b4411714839fd82b43b8cd5b9e6ef737165b4da3
   md5: 5f8b4b4a9c78a1a416d40d2029f47e3a
@@ -34307,9 +34218,9 @@ packages:
   license: BSD-3-Clause
   size: 50686
   timestamp: 1768947172626
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: c14c0dc046536a9829df25d65088eaf22efa4f288649bdead681f2e30438f317
-  md5: e3180f710015333f9e7f38b3f2b83a82
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pid-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 58a0bc516e2263d28a8afb1fd3c9c86e80f4f75916a3fedc475d2ded12e87628
+  md5: cfcdbd880ca0d884d0adbb5b6f3b29a0
   depends:
   - python
   - ros-jazzy-angles
@@ -34324,17 +34235,16 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-srvs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 315606
-  timestamp: 1768981483370
+  size: 315522
+  timestamp: 1771189860914
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pid-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 62ba9734b2dcc283c1ce620eaf42ce5f83b7248ffa983a84ff4d5b0a613124f7
   md5: 27590f98e80027187af2e63c0996292c
@@ -34362,9 +34272,9 @@ packages:
   license: Apache-2.0
   size: 307117
   timestamp: 1768949540335
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.4-np2py312h2ed9cc7_14.conda
-  sha256: 1cda406671991a3930216562d77a6e60112a4275b6cfe6fad34288f828e070ef
-  md5: 6f19d678c419bd2058f90df84b4b9569
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pluginlib-5.4.4-np2py312h2ed9cc7_16.conda
+  sha256: 18287fc5bb668e439d421a1814ec106f17493a5bc52b5da1333e4a619bc7ebec
+  md5: 64ebc082f192e6539a8601f6f32002ab
   depends:
   - python
   - ros-jazzy-ament-index-cpp
@@ -34373,16 +34283,17 @@ packages:
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-tinyxml2-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 138704
-  timestamp: 1768975727582
+  size: 138585
+  timestamp: 1771183415149
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pluginlib-5.4.4-np2py312h61f2ce4_14.conda
   sha256: 3544f5c5d088601bfd49ab9cc5136d768f1079d3ed137f9159274141360f4466
   md5: 2500a656999b03b73027dd3e1f454fd1
@@ -34404,9 +34315,9 @@ packages:
   license: BSD-3-Clause
   size: 139290
   timestamp: 1768944710819
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.6-np2py312h2ed9cc7_14.conda
-  sha256: 8ffa7058cfc6fabb2bc90152f08cd6215719d1508c7e47a54c8c85899bc1be0f
-  md5: fca56ea1c3c0d87d0f8af7de5de2a28f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-point-cloud-transport-4.0.7-np2py312h2ed9cc7_16.conda
+  sha256: 4a26224773397c11c88b347c60f6324b1cfa77df6f054f899995e33a02d8d58a
+  md5: 8d829a2af2610a43d77d61a430d60ec6
   depends:
   - python
   - ros-jazzy-message-filters
@@ -34417,17 +34328,17 @@ packages:
   - ros-jazzy-rmw
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 457512
-  timestamp: 1768979117761
+  size: 460597
+  timestamp: 1771187477752
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-point-cloud-transport-4.0.6-np2py312h61f2ce4_14.conda
   sha256: 37e2e6a1923ca2628d50640c29c2694fc1edfcef0153547ffccc4a2486fd34b3
   md5: afb4723d2d196fcfdf4b1093abe00ad4
@@ -34451,9 +34362,9 @@ packages:
   license: BSD-3-Clause
   size: 457513
   timestamp: 1768947565519
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 43fdfc2733449ad33a87ed8473946e188c9dc8f99197533e105ae4110521c4d5
-  md5: f83f46d17e87c817dc8e8905c6200bf1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pose-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: f058e7fd1f69446246bfe2f524405c10f055468fb8199e4a11783d64ebcebda8
+  md5: f30fa79a5af3b7139f7874d0744b4561
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -34466,16 +34377,17 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 173603
-  timestamp: 1768981603408
+  size: 173496
+  timestamp: 1771189998349
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pose-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: a5c1cb76625653be7d56ec2f737d8e9e54533c7ec14435708178350c151416ce
   md5: 9754bfaea10dd717ff2dea169f3f7374
@@ -34501,9 +34413,9 @@ packages:
   license: Apache-2.0
   size: 172186
   timestamp: 1768949679734
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 71711caa9b9bf8afd81bf306eb9662726e57e32be89583455f76fb68b3e98974
-  md5: a8b42ed4f1e68bdadb34d8701666e940
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-position-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 30aeb42041573295bb620914760fcfd7bc7d03d83dd0ba9422c3380d2874dc89
+  md5: a9032c763977b7b879c90243ab043780
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -34511,17 +34423,16 @@ packages:
   - ros-jazzy-pluginlib
   - ros-jazzy-rclcpp
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 76420
-  timestamp: 1768981958477
+  size: 76345
+  timestamp: 1771190360660
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-position-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: e7abea83f9cc3d9af5ccdbfb98ab0236b670350ac2accc80eba3a22d32dc64c4
   md5: 7193a7fd8e6375621470e7ca36238f9f
@@ -34542,24 +34453,24 @@ packages:
   license: Apache-2.0
   size: 77127
   timestamp: 1768949950175
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np2py312h2ed9cc7_14.conda
-  sha256: 56c8ee3cda3cd21ca27f32da429c7e58799c739360e17f4a20c816e0497f99c3
-  md5: a100e13e94fe4405aaa8827e398709dc
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-pybind11-vendor-3.1.3-np2py312h2ed9cc7_16.conda
+  sha256: 1336a60d0ce0600aa9f08d23b353cdabddd00948b8bfc5eee14ae4d294d2c20f
+  md5: 0e36c1f52af4ead0964d2c7b912b320d
   depends:
   - pybind11
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 23260
-  timestamp: 1768974403067
+  size: 23010
+  timestamp: 1771181904803
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-pybind11-vendor-3.1.3-np2py312h61f2ce4_14.conda
   sha256: fec3393eff1c2d4cf2e917e39900ae68f9317203b95dd3e653664baba13d117f
   md5: d3cdf1ce549aeb86adef6d54c75da48d
@@ -34576,23 +34487,23 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 23289
   timestamp: 1768943349546
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np2py312h2ed9cc7_14.conda
-  sha256: e0047fff1c399850a62227f329833e78789d03ae4ba6c257ed3d739a1ba84a28
-  md5: eb952691c28706d73bad84c95fd8d1c6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-cmake-module-0.11.1-np2py312h2ed9cc7_16.conda
+  sha256: 37ec6548e1788772d6bbee38be1e11cadb3e51c396e576bc82d86f25db2c2583
+  md5: 68ba3f685fa6c80b3a02734ecf5e90f8
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27935
-  timestamp: 1768974983495
+  size: 27762
+  timestamp: 1771182668331
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-python-cmake-module-0.11.1-np2py312h61f2ce4_14.conda
   sha256: d46c2a28d980dce4972396d4dbd388d66a936b38236004185fe5706c98e3ab85
   md5: 7016d939582c7c30138f45aeda091844
@@ -34609,27 +34520,27 @@ packages:
   license: Apache-2.0
   size: 27895
   timestamp: 1768943940214
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_14.conda
-  sha256: f54fd4ef91e05bb46d7c2926b24a300b83e94c24f8061941cf4712661a97ae63
-  md5: ca2187fc758bbad2251a80c59c49dbb2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np2py312h2ed9cc7_16.conda
+  sha256: a196033c24ac9291d37498e474c25d2e2922963190595d6378e70494e1c62e4b
+  md5: fd0b21b7ab315bd8f8762410eef3824e
   depends:
   - python
   - python-orocos-kdl
   - ros-jazzy-orocos-kdl-vendor
   - ros-jazzy-pybind11-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   - python-orocos-kdl >=1.5.3,<1.6.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 27812
-  timestamp: 1768975351921
+  size: 27638
+  timestamp: 1771183044414
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-python-orocos-kdl-vendor-0.5.1-np2py312h61f2ce4_14.conda
   sha256: 9614f979f281ed535fe22d714bf52b5e0d26b59ffcda8e5da78dbc2d1cd4da01
   md5: a338249a528629c34e29beb7cb62b548
@@ -34650,9 +34561,9 @@ packages:
   license: Apache-2.0 OR LGPL-2.1-or-later
   size: 27747
   timestamp: 1768944237479
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 5d9d64cf8519340c8a31ed9d52db00b0c1753cd485c69c898d860d8297fd2f29
-  md5: 0d2430079812a572c64f782afa0633ea
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-range-sensor-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 409603625465e9bb87b1b76bb0501b071790dff0ca00194986b2c5dfa3b57a03
+  md5: 4e4d6d3a3cbcd078a1027f8f0eca428f
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -34665,16 +34576,17 @@ packages:
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 149638
-  timestamp: 1768981589443
+  size: 149576
+  timestamp: 1771189980690
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-range-sensor-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: dbed6436d8afe3312c77a0ef215d64e86704a7d6070fdf3a9c791ba3a7ac55d8
   md5: 59a07bff5f764a05703bb94a5d29d5b5
@@ -34699,9 +34611,9 @@ packages:
   license: Apache-2.0
   size: 148187
   timestamp: 1768949660911
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.8-np2py312h2ed9cc7_14.conda
-  sha256: 1c7cde7016ad5ad1be6e41ed390bcc5c8ffc4dafacab55bc088a0f8c650aba58
-  md5: 06b959e1b92ef2d77470956ccbc7b850
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-9.2.9-np2py312h2ed9cc7_16.conda
+  sha256: 334efe122cd22e89ee784f839b7cb0aed4eec33631ca7dccfd788c01b5e3f7af
+  md5: d675a6725fc706996d125fa7ce6a76bb
   depends:
   - python
   - ros-jazzy-libyaml-vendor
@@ -34717,7 +34629,7 @@ packages:
   - ros-jazzy-service-msgs
   - ros-jazzy-tracetools
   - ros-jazzy-type-description-interfaces
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - yaml
   - yaml-cpp
   - __glibc >=2.17,<3.0.a0
@@ -34726,12 +34638,12 @@ packages:
   - libgcc >=14
   - yaml >=0.2.5,<0.3.0a0
   - python_abi 3.12.* *_cp312
-  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0
-  size: 201622
-  timestamp: 1768977844926
+  size: 201496
+  timestamp: 1771185627706
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-9.2.8-np2py312h61f2ce4_14.conda
   sha256: 877f2e46572494522ebfbd12a162dfbd3cd0683e10d64e4190abe9733f48408c
   md5: f8ae6288ec6f7349df5f0c660eefd122
@@ -34763,9 +34675,9 @@ packages:
   license: Apache-2.0
   size: 206935
   timestamp: 1768946371863
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.8-np2py312h2ed9cc7_14.conda
-  sha256: fe369f5896b6103ff61d8aa6c027f649c434c998e0a99e9fbd4507bf364ca1ab
-  md5: a1ea8b44b9ae35faa3819677a94550d2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-action-9.2.9-np2py312h2ed9cc7_16.conda
+  sha256: 4b673d28557941f244e669b9ecebb02dec1a34c48fe7c00ea8c39b610941686b
+  md5: 2f571ff1f9e7359335cd8791d3a9e16a
   depends:
   - python
   - ros-jazzy-action-msgs
@@ -34774,16 +34686,16 @@ packages:
   - ros-jazzy-rmw
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 81163
-  timestamp: 1768978180405
+  size: 80999
+  timestamp: 1771186071654
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-action-9.2.8-np2py312h61f2ce4_14.conda
   sha256: 7923ab7f1e29819a2af075e67d52dc1090d7cadd4c3c17b14f645bce698a47cc
   md5: 868b4cd30c8f98e545194e88979b5234
@@ -34805,25 +34717,25 @@ packages:
   license: Apache-2.0
   size: 81708
   timestamp: 1768946707074
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: aa7783d0cf05302de58e975d1eef6fbf0368d7bc16b2f6fdd221172a4e40f421
-  md5: 2bce0706b67791d52af863956ca949c8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: 5848614a0b4e9cc9a74e949963e8f087f991dc0e6abca584a5d18093a155e387
+  md5: e701320b929470b56d14a6f4f26e8bd4
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 569511
-  timestamp: 1768976453398
+  size: 572876
+  timestamp: 1771184516240
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-interfaces-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 9312da236d1e61804ea10118e8170f2cd944b0c0135a9eb390c40096cba6cf62
   md5: 67e9a9566aebeb66db62f9b9ddb02ae5
@@ -34842,9 +34754,9 @@ packages:
   license: Apache-2.0
   size: 580936
   timestamp: 1768945454837
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.8-np2py312h2ed9cc7_14.conda
-  sha256: 053688b26ebcdd475ecb5010340c392beecda070ad1042d3c6aa7747bd8b0cc9
-  md5: 7930c8d143261bcac343020cadeac459
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-lifecycle-9.2.9-np2py312h2ed9cc7_16.conda
+  sha256: 81f1c54712cb80cc12133b40a965c9665b3f86d7767c6ba58c1b333e54df9367
+  md5: 9df89a18b67b8863ef51d1c2b0b2dc67
   depends:
   - python
   - ros-jazzy-lifecycle-msgs
@@ -34854,17 +34766,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 58370
-  timestamp: 1768978173912
+  size: 58145
+  timestamp: 1771186063838
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-lifecycle-9.2.8-np2py312h61f2ce4_14.conda
   sha256: c451de337d8184138f124757bbb5e53c9acc3b27b663615fc3354c2084418670
   md5: 8b00f75658367aec0dc371b7f7d90f95
@@ -34887,24 +34798,24 @@ packages:
   license: Apache-2.0
   size: 59012
   timestamp: 1768946697384
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np2py312h2ed9cc7_14.conda
-  sha256: 967429a426b0809ddb8ac6feba05964e9a35bd5bf26ef5e05f74af619d2f56b2
-  md5: d50a835756fbddb6c515bd9d364526a9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-interface-3.1.1-np2py312h2ed9cc7_16.conda
+  sha256: 999614ff7fcb88e80fb5402ca3f25fd23f8a3f986e21abdd8a2de6927eb00e22
+  md5: 0d7b2956f6c06102a31395c0ff5859e3
   depends:
   - python
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 35777
-  timestamp: 1768975640279
+  size: 35579
+  timestamp: 1771183333973
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-logging-interface-3.1.1-np2py312h61f2ce4_14.conda
   sha256: 7621ce576861cf3ba8dc6833382260250ac9073e5403bc380b27f0dc36b891dc
   md5: bdd0af083b5e6c180ca9d5b2ba25b111
@@ -34922,9 +34833,9 @@ packages:
   license: Apache-2.0
   size: 36086
   timestamp: 1768944603685
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np2py312h918b84f_14.conda
-  sha256: 47fc35efa603542d51f36b3b38cea752473c08fb3add167fb8337bd3631e3723
-  md5: 754c71354eac1429fb7b1ff4c8ad1b87
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-logging-spdlog-3.1.1-np2py312h918b84f_16.conda
+  sha256: 74aef73546a7b99842b7adba2dd228c1bb2c664f8306f919833d9539ca4747ea
+  md5: 2a4c11f4ee3f14613ebbf47ee5b8cab0
   depends:
   - fmt
   - python
@@ -34933,20 +34844,19 @@ packages:
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-spdlog-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - spdlog
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - fmt >=12.1.0,<12.2.0a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - spdlog >=1.17.0,<1.18.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - spdlog >=1.17.0,<1.18.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46361
-  timestamp: 1768975763128
+  size: 46226
+  timestamp: 1771183448086
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-logging-spdlog-3.1.1-np2py312ha677571_14.conda
   sha256: 7cd4851b9a22a80c2247f9e527fcaae6bb98752247fbf1a8aa9b880c74611756
   md5: b21afbc9170aa5f27229f388c1a9ebd4
@@ -34971,30 +34881,30 @@ packages:
   license: Apache-2.0
   size: 48000
   timestamp: 1768944748898
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.8-np2py312h2ed9cc7_14.conda
-  sha256: 1ebc21df430035e1d1a3dce22a6c3eb42f0015e27e76cd8d436d86e3aa66e1e6
-  md5: cba13abce8198c1dab68eaad4c46b178
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcl-yaml-param-parser-9.2.9-np2py312h2ed9cc7_16.conda
+  sha256: cffc9089805ea71528cfbb55d874d8a2c5c2eba78b6545b7198758438169db50
+  md5: c898299a7129b53cf8b8bc436629caa0
   depends:
   - python
   - ros-jazzy-libyaml-vendor
   - ros-jazzy-rcutils
   - ros-jazzy-rmw
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - yaml
   - yaml-cpp
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   - python_abi 3.12.* *_cp312
   - yaml-cpp >=0.8.0,<0.9.0a0
-  - numpy >=1.23,<3
-  - yaml >=0.2.5,<0.3.0a0
   license: Apache-2.0
-  size: 51898
-  timestamp: 1768975891823
+  size: 51786
+  timestamp: 1771183554960
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcl-yaml-param-parser-9.2.8-np2py312h61f2ce4_14.conda
   sha256: d34be781c66fe8038e025fefe4c8e138cdd549241780cc69ca76c9fb6bb4de3c
   md5: d68957d81e87afacde89da3330f04dd9
@@ -35018,9 +34928,9 @@ packages:
   license: Apache-2.0
   size: 53448
   timestamp: 1768944891282
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.15-np2py312h2ed9cc7_14.conda
-  sha256: e256e3ab02c258c5bcaf91e98fe9d62c9be698781f255dbac097410e5050aac1
-  md5: f87f9a6cf86a992947efa5b26d5fcd10
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-28.1.16-np2py312h2ed9cc7_16.conda
+  sha256: e9b72ae24d7443d00ef787c32b711630251557f61284e2861e7c40de45b72a46
+  md5: 72b384006da571b380926eea7803407b
   depends:
   - python
   - ros-jazzy-ament-index-cpp
@@ -35042,17 +34952,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-cpp
   - ros-jazzy-statistics-msgs
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 1095467
-  timestamp: 1768978260712
+  size: 1095145
+  timestamp: 1771186571686
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclcpp-28.1.15-np2py312h61f2ce4_14.conda
   sha256: 0f3b6a8f7f3bb160e73da27cb3080f7433c9efb13e3ea84ed1ce27a36731d15d
   md5: 4b7c28ae0d6da955a82349183497a3ad
@@ -35087,9 +34997,9 @@ packages:
   license: Apache-2.0
   size: 1059039
   timestamp: 1768946815975
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.15-np2py312h2ed9cc7_14.conda
-  sha256: 6341d98fb8c77cbfcc1921d83d30878eb80fca2ea14eb06a2bc682bbb2bcf6a8
-  md5: 3ad40873435938a024ff0bee421343c7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-action-28.1.16-np2py312h2ed9cc7_16.conda
+  sha256: 7662fab04cdf46448b7f9b43c6e1247dd8a1d4ffab92a9e9a935acf7a8d9af12
+  md5: 7295a5538848a3d2a3b62e8a7449b62d
   depends:
   - python
   - ros-jazzy-action-msgs
@@ -35100,17 +35010,16 @@ packages:
   - ros-jazzy-rcpputils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 116958
-  timestamp: 1768978503206
+  size: 116852
+  timestamp: 1771186807079
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclcpp-action-28.1.15-np2py312h61f2ce4_14.conda
   sha256: 620170a88aa86734bdfd260004b204d6dadb545ecffe930bece9b979c7b7343f
   md5: 242901b23896b49d103c17538af670e4
@@ -35133,9 +35042,9 @@ packages:
   license: Apache-2.0
   size: 118049
   timestamp: 1768947054034
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.15-np2py312h2ed9cc7_14.conda
-  sha256: f2e855351daab270fd6dda12cf1fff28fdb4d4c3d170844981a9c78142eb900b
-  md5: b2a094803b3ff245fe62718c1b6e4d45
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-components-28.1.16-np2py312h2ed9cc7_16.conda
+  sha256: e3a37dedcaf7c7fc4e6c54e4f76e090e0193f5a0885f116257434c95418de8fa
+  md5: 90326d9dab528b15e13d6f3a6cc92567
   depends:
   - python
   - ros-jazzy-ament-index-cpp
@@ -35143,17 +35052,17 @@ packages:
   - ros-jazzy-composition-interfaces
   - ros-jazzy-rclcpp
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 140530
-  timestamp: 1768978451108
+  size: 140410
+  timestamp: 1771186756065
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclcpp-components-28.1.15-np2py312h61f2ce4_14.conda
   sha256: d6b155fe0d1ac8a6e881858a32b503f82812308fed35c64c67d99365685d122e
   md5: 1519c9b5bf86546a97f19ca7273f05a2
@@ -35174,9 +35083,9 @@ packages:
   license: Apache-2.0
   size: 142259
   timestamp: 1768946978330
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.15-np2py312h2ed9cc7_14.conda
-  sha256: 00a2e724cefdbbb1e25bdd5e1df14e66b11d78f4c009b9574068b8d9864a1681
-  md5: 828de2495d3c3981d27d4f895b593743
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclcpp-lifecycle-28.1.16-np2py312h2ed9cc7_16.conda
+  sha256: ca4fdcec6f64809d7b9f72a410c5f2c55f67bc701e3347e204312d86376c6e0d
+  md5: f57ecbcf923515b724b168794c38c8a3
   depends:
   - python
   - ros-jazzy-lifecycle-msgs
@@ -35188,17 +35097,16 @@ packages:
   - ros-jazzy-rmw
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 131343
-  timestamp: 1768978488167
+  size: 131194
+  timestamp: 1771186792961
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclcpp-lifecycle-28.1.15-np2py312h61f2ce4_14.conda
   sha256: e5a302e4d5013a49d5b9ca106a4b30b021d1e8ebae2108e714d7a45eb442e215
   md5: 02cb811800348e2451df2f72f9ba3c8a
@@ -35222,9 +35130,9 @@ packages:
   license: Apache-2.0
   size: 127761
   timestamp: 1768947036999
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.8-np2py312h2ed9cc7_14.conda
-  sha256: e4a4ae0ea390bee4b59b536290999e459858618669a586521cb40cb1b8d91d8c
-  md5: ff3460adf5e2ab3279507dd480e2f40a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rclpy-7.1.9-np2py312h2ed9cc7_16.conda
+  sha256: e24d8ffb33a634755be274ef93b38913f78c94a913ac58f2dc5992cb44cb686f
+  md5: 307564f2ab926a3197b3ce8d23626cff
   depends:
   - python
   - pyyaml
@@ -35245,16 +35153,16 @@ packages:
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-rpyutils
   - ros-jazzy-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 735886
-  timestamp: 1768978360779
+  size: 739117
+  timestamp: 1771186670659
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rclpy-7.1.8-np2py312h61f2ce4_14.conda
   sha256: a0846342ca478969c04a77e2ff0ae6a80e69b594005f6de5983b79bfff76d7e9
   md5: 35900a6c095fb8d9d3586c0441d1f249
@@ -35287,24 +35195,24 @@ packages:
   license: Apache-2.0
   size: 686152
   timestamp: 1768946900393
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.2-np2py312h2ed9cc7_14.conda
-  sha256: ffe1935988dffcbe6f501b508adb5de33de1b44695a373f8262ab0fcc73c892e
-  md5: dacbfb3bb7ec86747ccde9085b112ae9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcpputils-2.11.3-np2py312h2ed9cc7_16.conda
+  sha256: 9c374b29e1bddffcb2fd5ef58ebf767cf2f0db8a7d10f52d88515acd680f02f6
+  md5: d8713f2ebf5765d5833aebc4da02e58b
   depends:
   - python
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 80726
-  timestamp: 1768975554650
+  size: 79031
+  timestamp: 1771183231290
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcpputils-2.11.2-np2py312h61f2ce4_14.conda
   sha256: 7ff68a426c550dc7217ebf6b28567321ac7869bd4cf1fff3ccc2c9374be08664
   md5: f577edb9772dd9645bf51afa200b671a
@@ -35321,23 +35229,23 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 81145
   timestamp: 1768944448322
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.5-np2py312h2ed9cc7_14.conda
-  sha256: df6214a2a2ba8352257795789e2ac94eab5ff079a32620cc9cf63198ce578168
-  md5: 9319e625a9560b6cb5e430684918015c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rcutils-6.7.5-np2py312h2ed9cc7_16.conda
+  sha256: a724a08459d84debc7dcc03cf9e44f398263073384f7f070fce45293c430471e
+  md5: 1ea22cde7a2e790721f56ef22b90756d
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 122709
-  timestamp: 1768975435896
+  size: 122532
+  timestamp: 1771183114442
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rcutils-6.7.5-np2py312h61f2ce4_14.conda
   sha256: d0fda8219f7f7f70078a90658afcd4233ec44c8e1f15abbc3a8dc0c6f7c0ab23
   md5: d73774b69e279ea54a4ab0652b93b6d7
@@ -35353,9 +35261,9 @@ packages:
   license: Apache-2.0
   size: 127166
   timestamp: 1768944320544
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.10.1-np2py312h31007e0_14.conda
-  sha256: 001cd9307ad795deee0f1901eb3619e0392246c2621484ac3e7a05f38f58e5bb
-  md5: 1a10c2aff45319969121306d4738c737
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-realtime-tools-3.10.1-np2py312h31007e0_16.conda
+  sha256: 5bedf3bfefd70d1f86343ce5079dbf5bd212cd4ee8964288766467ddbe2a9585
+  md5: 6c69125d285f506df3c3891ada44b652
   depends:
   - libboost-devel
   - libcap
@@ -35364,18 +35272,18 @@ packages:
   - ros-jazzy-rclcpp
   - ros-jazzy-rclcpp-action
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
-  - libboost >=1.88.0,<1.89.0a0
-  - libcap >=2.77,<2.78.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libcap >=2.77,<2.78.0a0
+  - libboost >=1.88.0,<1.89.0a0
   license: BSD-3-Clause
-  size: 79679
-  timestamp: 1768978675497
+  size: 78141
+  timestamp: 1771187057839
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-realtime-tools-3.10.1-np2py312hbd2122f_14.conda
   sha256: 6ea5b3fad181c30caedefbcca3d954f1d15d75f8c06482dc947ee2fcd197623f
   md5: f1eacdb44694be154e3af55dcc6d8bb5
@@ -35398,26 +35306,25 @@ packages:
   license: BSD-3-Clause
   size: 81974
   timestamp: 1768947209089
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np2py312h2ed9cc7_14.conda
-  sha256: 13c832809294f4d0b612ea872c9f877884180dcbdfa0d18743337be8dd55a30b
-  md5: 59ed11c685187e4ababa21b34bf752e2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-resource-retriever-3.4.4-np2py312h2ed9cc7_16.conda
+  sha256: 2568183ee96ffd161c37bb5396936ebd88479e471769ee45c4014aed9cc6ee0d
+  md5: e13213d8bee4c1d434edf9fd58b6e6f9
   depends:
   - python
   - ros-jazzy-ament-index-cpp
   - ros-jazzy-ament-index-python
   - ros-jazzy-libcurl-vendor
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 45325
-  timestamp: 1768975357212
+  size: 45147
+  timestamp: 1771183049792
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-resource-retriever-3.4.4-np2py312h61f2ce4_14.conda
   sha256: 16642c2f947bc6b2ddb50ec5f8851a813f80210d1e4b669db16d5a23a383f566
   md5: 5f552d953c318caa40ec4c04b1791280
@@ -35436,26 +35343,26 @@ packages:
   license: BSD-3-Clause
   size: 45971
   timestamp: 1768944242644
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.2-np2py312h2ed9cc7_14.conda
-  sha256: 9c4858a19b525799a5d9a92d45130e731b5bc858b3317c1a230b37d7345eded5
-  md5: 1f0a131e3d46459cb835cb9c9c0181b1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-7.3.3-np2py312h2ed9cc7_16.conda
+  sha256: a2ad3f0a40afb8c4797a2e765563156c2c399d1cd113280f859f853843cb28b1
+  md5: 216859c70412164b34babeb69e063e0e
   depends:
   - python
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-dynamic-typesupport
   - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 97299
-  timestamp: 1768975743550
+  size: 97207
+  timestamp: 1771183428776
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-7.3.2-np2py312h61f2ce4_14.conda
   sha256: 847001801368bfa74a590a590fb59ca939e305e2ae643d8843e4db72a2868764
   md5: eed81aa12d1ee627a0606adacde4ea9a
@@ -35474,25 +35381,24 @@ packages:
   license: Apache-2.0
   size: 98404
   timestamp: 1768944730644
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.2-np2py312h2ed9cc7_14.conda
-  sha256: f99e36af7b2961ab959d6cfd151fa1b2a6a689b8781e1929a6d65d4b7422c9c6
-  md5: 5acb79abe4c14bb0bd0825ddca097e19
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-0.22.3-np2py312h2ed9cc7_16.conda
+  sha256: 4e8631ce85f619edb79b554673c53399f06db802da29f98ad02f9813d454d4bb
+  md5: 23a188fd815e107d697676e7a0227578
   depends:
   - python
-  - ros-jazzy-ament-cmake
   - ros-jazzy-rmw-connextdds-common
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 32329
-  timestamp: 1768976798404
+  size: 32204
+  timestamp: 1771184866432
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-connextdds-0.22.2-np2py312h61f2ce4_14.conda
   sha256: 7378b1744ca8e2b097cf0d66efd67c05e070b21aa370ba4e8287af886305e350
   md5: 7f41b82fca82eb1752a0288ba3a00222
@@ -35510,12 +35416,11 @@ packages:
   license: Apache-2.0
   size: 32252
   timestamp: 1768945771856
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.2-np2py312h2ed9cc7_14.conda
-  sha256: 0dfad90cab5264a20e14068cd32cc46a446c520c3c8a764dfda1ae79a5324c3d
-  md5: 34618631f78db85598103b9be7c45978
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-connextdds-common-0.22.3-np2py312h2ed9cc7_16.conda
+  sha256: 02a926f43109d4ff307ab0d70ce479ff74c033d64703426714e47d47fd390033
+  md5: 2155cce109184311bdb58158b30d2da6
   depends:
   - python
-  - ros-jazzy-ament-cmake
   - ros-jazzy-fastcdr
   - ros-jazzy-rcpputils
   - ros-jazzy-rcutils
@@ -35530,17 +35435,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-introspection-cpp
   - ros-jazzy-rti-connext-dds-cmake-module
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 54193
-  timestamp: 1768976624369
+  size: 54095
+  timestamp: 1771184693538
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-connextdds-common-0.22.2-np2py312h61f2ce4_14.conda
   sha256: b7ae49fd37b9f955d5730666f53f0a90a7e31448c53078a9a3303fe1add431aa
   md5: 7f34872a98a61c4b04c6b16154ff7775
@@ -35570,9 +35475,9 @@ packages:
   license: Apache-2.0
   size: 54103
   timestamp: 1768945609978
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np2py312h2ed9cc7_14.conda
-  sha256: 66a74e037b0dbbbc4e85a081e29ceb027aec5ee8d4c1651ae80b23546d4b8fef
-  md5: 3c54ed21c169d85959876c929656057b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np2py312h2ed9cc7_16.conda
+  sha256: a54ce17a1781b6ee5d88e29b202cabca58bbb9f40cd9c35e3dba777278fd9fc6
+  md5: 85dacffc42495c5044008393261614f9
   depends:
   - python
   - ros-jazzy-cyclonedds
@@ -35586,17 +35491,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-introspection-c
   - ros-jazzy-rosidl-typesupport-introspection-cpp
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 266229
-  timestamp: 1768976629746
+  size: 266097
+  timestamp: 1771184698042
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-cyclonedds-cpp-2.2.3-np2py312h61f2ce4_14.conda
   sha256: 3f5a3a830bc43228382b2408e4749e936265398422f365e5dde25e906f0fd79d
   md5: c3a1234c6215c82fdf2427ef1ea89ab7
@@ -35623,9 +35528,9 @@ packages:
   license: Apache-2.0
   size: 263704
   timestamp: 1768945616493
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.0-np2py312h2ed9cc7_14.conda
-  sha256: 2905a5a97b0f5af1477f8715096fc094e95c16cec3e0f9af4667fef229dd97ed
-  md5: 770e58be48620344ebcbdf2095d63ef9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-dds-common-3.1.1-np2py312h2ed9cc7_16.conda
+  sha256: e0dc1cb00ba5f07a3635c904820f1ffcb850709d3415e34bf60845dcfda5091e
+  md5: 85d0161175ce225f99d230792c0eff30
   depends:
   - python
   - ros-jazzy-rcpputils
@@ -35635,17 +35540,17 @@ packages:
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 178466
-  timestamp: 1768976384062
+  size: 179827
+  timestamp: 1771184399405
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-dds-common-3.1.0-np2py312h61f2ce4_14.conda
   sha256: 8f3cf1f5d4ef5189f3e394f22e1fb3511c6ec402baaece4451b832e4d6265c6d
   md5: ce0fc46c1793bcf9b2e327eeb47e99a7
@@ -35667,9 +35572,9 @@ packages:
   license: Apache-2.0
   size: 178125
   timestamp: 1768945386554
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-  sha256: efd857334e45824b8fcf5189a696ff0ed053791393c8a965f8839c9007f0884e
-  md5: ec8b88678387d7950d826f099e03eaf3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+  sha256: f637cc599f849533e4318a2617e557f5d67f193d2b5fe4cdb14986e3b98d794e
+  md5: ec518dc77da5b32720c09ed4cbf060e2
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -35689,16 +35594,16 @@ packages:
   - ros-jazzy-rosidl-typesupport-fastrtps-c
   - ros-jazzy-rosidl-typesupport-fastrtps-cpp
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 160248
-  timestamp: 1768976774645
+  size: 160077
+  timestamp: 1771184842473
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-fastrtps-cpp-8.4.3-np2py312h61f2ce4_14.conda
   sha256: f3bf025fba044831d3dd76f75facf8b48d53fcc42acc1f498bfeb29d9b24eb2a
   md5: 9ccd7fc80c49b9dfe646b7bb440d5c39
@@ -35731,9 +35636,9 @@ packages:
   license: Apache-2.0
   size: 159013
   timestamp: 1768945752466
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-  sha256: 6e27fd7258807a84422e3e00e405f4167b3d6c84cefeaae956c897c3bb9fb8a3
-  md5: f751d214875063e22b465eac98efc164
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+  sha256: e7a64c11b35d95df2320e5daad85ae3d22404e48069dbae48f511c8980744793
+  md5: 4d38f54095f1d0a0a9f01811d2fce7c3
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -35749,17 +35654,17 @@ packages:
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-rosidl-typesupport-introspection-c
   - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 187563
-  timestamp: 1768976737754
+  size: 187829
+  timestamp: 1771184803712
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-fastrtps-dynamic-cpp-8.4.3-np2py312h61f2ce4_14.conda
   sha256: 24c88bccbdc56a6e6d25fe6e6eb2b28808d440fcd4a343873df0345bb7d20f63
   md5: 19ae985392b7e82cc3bf870fcc9401e5
@@ -35788,9 +35693,9 @@ packages:
   license: Apache-2.0
   size: 180340
   timestamp: 1768945720892
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np2py312h2ed9cc7_14.conda
-  sha256: 7dae7103e2d8376606cd5d96c344b610dd7eedc85b787ccc716a4ba7a78ac37e
-  md5: ed4609ca17536cec026a80f03659db9b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np2py312h2ed9cc7_16.conda
+  sha256: cc2d5cd55b83466e8eb538923c59bcff43c3cf4462269ba600e95d700b5fd0ce
+  md5: 074bf0d2d3b950086b7bd299bd5f4315
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -35806,17 +35711,16 @@ packages:
   - ros-jazzy-rosidl-typesupport-introspection-c
   - ros-jazzy-rosidl-typesupport-introspection-cpp
   - ros-jazzy-tracetools
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 232149
-  timestamp: 1768976570653
+  size: 231929
+  timestamp: 1771184648419
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-fastrtps-shared-cpp-8.4.3-np2py312h61f2ce4_14.conda
   sha256: d35179dc37a118b354069dd9131f34aa42eff989158bc243029f5379a3b37273
   md5: af22771e1e06c46a01ed69ff0c577bcf
@@ -35845,9 +35749,9 @@ packages:
   license: Apache-2.0
   size: 219292
   timestamp: 1768945572684
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np2py312h2ed9cc7_14.conda
-  sha256: ffe0334f688571b9cbc3c1b63cf3b16ce657a3ab140bf839238f30a3e73a7ca7
-  md5: a2254994d551b9a2c35aff135be00073
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-2.15.6-np2py312h2ed9cc7_16.conda
+  sha256: b9a79cef42bcfda4f3ce031df79890d3aa41343c95475c9ab9e7d99ad0478158
+  md5: ec65c238aca59dc38df603c66e5748b9
   depends:
   - python
   - ros-jazzy-ament-index-cpp
@@ -35859,17 +35763,17 @@ packages:
   - ros-jazzy-rmw-fastrtps-dynamic-cpp
   - ros-jazzy-rmw-implementation-cmake
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 54560
-  timestamp: 1768977041693
+  size: 54464
+  timestamp: 1771185133078
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-implementation-2.15.6-np2py312h61f2ce4_14.conda
   sha256: 501215af622d09d24498c6c3725e6093e50e013f1e0b4f2eb23a258031d03931
   md5: b64c9d08f7577814a5ea6d352036591c
@@ -35893,23 +35797,24 @@ packages:
   license: Apache-2.0
   size: 56180
   timestamp: 1768945974101
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.2-np2py312h2ed9cc7_14.conda
-  sha256: 62e26c18b49c744bbac3f56046f0d8b97954cdddd508dfeacc61715c4bf0a339
-  md5: 2343037a0def9aff02f5142283e17c4c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rmw-implementation-cmake-7.3.3-np2py312h2ed9cc7_16.conda
+  sha256: 1d9003263d6e194c57617376e9da1aee51122c437b092c239cf689e89f0b49e4
+  md5: 4eee0a7c69ea7c6ec3bb7e3c8434af99
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 29430
-  timestamp: 1768975295492
+  size: 29333
+  timestamp: 1771182989381
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rmw-implementation-cmake-7.3.2-np2py312h61f2ce4_14.conda
   sha256: 2ec0b7ae1cfe1ae76ba44d58ea6c11603b32a893837226b1aa12d3f465fa04b8
   md5: 258cb888ac7394c3b1410d67a0c99059
@@ -35926,9 +35831,9 @@ packages:
   license: Apache-2.0
   size: 29509
   timestamp: 1768944175094
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np2py312h2ed9cc7_14.conda
-  sha256: eb91744342b96655dfa06322e6d4b1aa944aa1b0fb0f1db0c3d7c59870a415e5
-  md5: f51ae7fe899d397419a15746d7c2eb27
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-robot-state-publisher-3.3.3-np2py312h2ed9cc7_16.conda
+  sha256: 9469e55b1e37a86cf7c694078dec1e0c36af85debf3545f75bf695e93b66754f
+  md5: e53e8fb082f5b920abf528980b7e8016
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -35943,17 +35848,16 @@ packages:
   - ros-jazzy-std-msgs
   - ros-jazzy-tf2-ros
   - ros-jazzy-urdf
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 271296
-  timestamp: 1768979391154
+  size: 271262
+  timestamp: 1771187763376
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-robot-state-publisher-3.3.3-np2py312h61f2ce4_14.conda
   sha256: bee751e3746cdfb70f58278d0c9bb60a4dcb016e27175729f981419b9eb6e465
   md5: 19bad6402efe25971d696478e00d9de8
@@ -35980,9 +35884,9 @@ packages:
   license: BSD-3-Clause
   size: 268671
   timestamp: 1768947819003
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np2py312h2ed9cc7_14.conda
-  sha256: bbf46b1cdb2bab21b5be2b4eb5951d6cd972d16c360479b88b35faa8a335959f
-  md5: 90dc3d179fee8315101f475142a819f6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-core-0.11.0-np2py312h2ed9cc7_16.conda
+  sha256: 016ded134a8fad41627796f873d5e10abb3250813537506897eb3029fff9b8af
+  md5: 0e636acaa4186f70f1bad13271513208
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -36018,17 +35922,17 @@ packages:
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-sros2
   - ros-jazzy-sros2-cmake
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23140
-  timestamp: 1768981484745
+  size: 22890
+  timestamp: 1771189859407
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-core-0.11.0-np2py312h61f2ce4_14.conda
   sha256: 768544e2e211d06a7ba2e44da4d3c31883328c1ce1f1a2750cbe3b3ccd55c15c
   md5: 0823f369b40401ce523654db041a6b2b
@@ -36077,21 +35981,22 @@ packages:
   license: Apache-2.0
   size: 23165
   timestamp: 1768949540179
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np2py312h2ed9cc7_14.conda
-  sha256: 0a8a48bfbd5c8d55589dca785eb33e34dcb5407e8d6f3713bd5895b20d49b309
-  md5: a8f3763b9bf80f2655c88f33c3676378
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-environment-4.2.1-np2py312h2ed9cc7_16.conda
+  sha256: 877f0276fee7d11e0f9c920c4c81310126e3cbd1fa683e270a0dc4bc7052f4fe
+  md5: e1a41afbf06d6de34e28495e8348f0d0
   depends:
   - python
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 21436
-  timestamp: 1768973849657
+  size: 21118
+  timestamp: 1771181289237
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-environment-4.2.1-np2py312h61f2ce4_14.conda
   sha256: 90219c6c4232228960297cc17b12ed7a53123d4670679f58bd6c9d06ddb8618f
   md5: 0890ccc054443c0b255daa5487781521
@@ -36106,21 +36011,22 @@ packages:
   license: Apache-2.0
   size: 21449
   timestamp: 1768942689919
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np2py312h2ed9cc7_14.conda
-  sha256: b5a698ba2d85f3165078b53b3323944bbad903f92dfe212445fa7d2f7d2690d9
-  md5: 5b8de3785c7ed4184311fb3c675a6b74
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros-workspace-1.0.3-np2py312h2ed9cc7_16.conda
+  sha256: e5568204f0668026b6d01ab0d5a96b54ce9e224b52712b2189b44c4bf4b0edc2
+  md5: f032026ca2b898b6b3b645840f9bfd53
   depends:
   - python
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 35477
-  timestamp: 1768973829714
+  size: 35200
+  timestamp: 1771181278252
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros-workspace-1.0.3-np2py312h61f2ce4_14.conda
   sha256: 2f59817f4cc77512dc274deb4b1aaa4edf8d04dabbeac437983664608338aafa
   md5: 5defce5cc9ed20d47430fdb6aea7c389
@@ -36136,9 +36042,9 @@ packages:
   license: Apache-2.0
   size: 35475
   timestamp: 1768942678031
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 062e408210f4fdc67314925aa35b740aa33db2d5fbc6966aca0d15411f859474
-  md5: 7ed04136c5ed85b8f453282223b6979f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 9a97ff6ab7a4d1a532d3061c3b595797316f4235f02f1dc41a2b8f9a0250e1dd
+  md5: 9362a0fe7df1b9a1d0bd35518413d7ed
   depends:
   - python
   - ros-jazzy-ackermann-steering-controller
@@ -36168,17 +36074,17 @@ packages:
   - ros-jazzy-tricycle-controller
   - ros-jazzy-tricycle-steering-controller
   - ros-jazzy-velocity-controllers
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23165
-  timestamp: 1768982269271
+  size: 22920
+  timestamp: 1771190673622
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 7a027b2d439d690b08e49af815ca9828c1b6f0b5ff09c0e6f37d747b3624ec86
   md5: 1589f89947a4ea2453fe7a827c8fbc9f
@@ -36221,9 +36127,9 @@ packages:
   license: Apache-2.0
   size: 23188
   timestamp: 1768950278025
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 74f3bfac8edbe66cdcef9c250915358acf92166015f514dccfacd171f79a613e
-  md5: 726695d6b6deddec938ac5c214d3fab5
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2action-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 4be8a3c3e9ab2990859c0e67f2798a8f1176fd796287ad72b27633c025f801db
+  md5: adad4fef8bd7ce44fd2ce367931dede1
   depends:
   - python
   - ros-jazzy-action-msgs
@@ -36232,17 +36138,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 47789
-  timestamp: 1768979163443
+  size: 47610
+  timestamp: 1771187522502
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2action-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 124ba88085ec75f43df6e28b53a4cc73dd024565ce6c5076ef683f3bededc82e
   md5: 53d5a9971cb2a504ab7c339dca2def95
@@ -36264,9 +36170,9 @@ packages:
   license: Apache-2.0
   size: 47685
   timestamp: 1768947619690
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 2d7839340e9ab8f1968689bdca4279000e317d26431fe5292d1baaa513266b16
-  md5: 4b5d39304c2cf7893ea83b0e6da8af88
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 6bb3d96352d5deeb74c12128538b089dda9196d1784fa3bb90c7133652633de5
+  md5: debd07c073a84fb3ea9916aa534f1016
   depends:
   - argcomplete
   - importlib-metadata
@@ -36275,17 +36181,17 @@ packages:
   - python
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 75931
-  timestamp: 1768978512534
+  size: 75816
+  timestamp: 1771186817248
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2cli-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 460c387e6c64aa2b7b26b873346e69920a33474cadb17e312b585cd29d95ba27
   md5: 1038ad744f8a7bf0dd694fc8668828f6
@@ -36307,9 +36213,9 @@ packages:
   license: Apache-2.0
   size: 75814
   timestamp: 1768947068632
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.1-np2py312h2ed9cc7_14.conda
-  sha256: f4abb3569ce5278a1f6aef4009ba7e26c59def78535a8a18696ec9a709c52360
-  md5: 7ebd190255f639df0a53f1bb04e69e9d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2cli-common-extensions-0.3.1-np2py312h2ed9cc7_16.conda
+  sha256: a3b5f65780420ac95999ce0b9bc839c31057e691e13ab22ea275fcef4f623b28
+  md5: cd4ee884d61b527cc62a3f329b830d14
   depends:
   - python
   - ros-jazzy-launch-xml
@@ -36331,17 +36237,16 @@ packages:
   - ros-jazzy-ros2service
   - ros-jazzy-ros2topic
   - ros-jazzy-sros2
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26910
-  timestamp: 1768981120245
+  size: 26768
+  timestamp: 1771189529837
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2cli-common-extensions-0.3.1-np2py312h61f2ce4_14.conda
   sha256: 80b75fa47ecb385547b20058bb7bb797a5ab8aedf663de9c8f6c9aef0cb1032c
   md5: 27369921cb606bd5477885338c0964d8
@@ -36375,9 +36280,9 @@ packages:
   license: Apache-2.0
   size: 26841
   timestamp: 1768949263136
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 5d1332cf1460418d6dd97549145fd85a9ebaa45be861a84944d6b8537b95d59c
-  md5: 2656018ebe4ad9a411a63e5ed5f7edd0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2component-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 7510924ef676faee3501cfd82419d2c86401f99a7f8bf3268323a3ce7d799daa
+  md5: 732eb8e1f7fb21aec02788ce2751d587
   depends:
   - python
   - ros-jazzy-ament-index-python
@@ -36390,17 +36295,16 @@ packages:
   - ros-jazzy-ros2node
   - ros-jazzy-ros2param
   - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 38279
-  timestamp: 1768980306819
+  size: 38064
+  timestamp: 1771188700563
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2component-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 4ceb816c7337c2013a799c26e9ffe1ddf9658704fb15ce76fba2a6efd67f63ac
   md5: e2d25e1c7dc662a542d40f0a07421975
@@ -36426,9 +36330,9 @@ packages:
   license: Apache-2.0
   size: 38249
   timestamp: 1768948640796
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 0f045edab2401b62f061b57a1aa40a3965bb4735c4c5ccb4d70d4fdb4513a6d9
-  md5: c2ff63f58f9f6f3d8aff63563202a6c6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2doctor-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 8178f70ffd9bdf4a2b1baafa5bde2de254b4a212b35864119b91ea0128a9073f
+  md5: 93cf8e8092caa8b8f202bbe1e2faef92
   depends:
   - catkin_pkg
   - importlib-metadata
@@ -36440,18 +36344,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - rosdistro
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 68443
-  timestamp: 1768979157888
+  size: 68233
+  timestamp: 1771187516910
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2doctor-0.32.7-np2py312h61f2ce4_14.conda
   sha256: b419cd2b3a8c6e71c44a04368cc71dfe6fd439e0bbbe07f8ca0b7994054e5d9e
   md5: 4b06f37e1afef7630b20a5cf9ffbd95b
@@ -36476,9 +36379,9 @@ packages:
   license: Apache-2.0
   size: 68209
   timestamp: 1768947613612
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: b5cdff8b886ec4c20bf145f9f57b8d8f3d028b9a5635421828bbcbb8e5f282e7
-  md5: 1a7ddf9dbb4d1d83d9438170d2905af3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2interface-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 8e02ec8317ec16ba0414d3582e06188905fe9608021f9b9541b0eb6235ca736f
+  md5: 6ca0239d59e088d64802f94d233c0910
   depends:
   - python
   - ros-jazzy-ament-index-python
@@ -36486,17 +36389,17 @@ packages:
   - ros-jazzy-ros2cli
   - ros-jazzy-rosidl-adapter
   - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 46839
-  timestamp: 1768979152130
+  size: 46656
+  timestamp: 1771187510945
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2interface-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 00e49e5a280c1dd6b241f5fbf8171e506e8cbb2be6ca90b2df43c2c2a19e6379
   md5: 7d02075113afb6c12a64ed2ec9af1e41
@@ -36517,9 +36420,9 @@ packages:
   license: Apache-2.0
   size: 46717
   timestamp: 1768947606914
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.10-np2py312h2ed9cc7_14.conda
-  sha256: 0e8bd91e9a6f2cb17c48668c36ea9fc0ab15ad799cdb161f1c0b9103177229cf
-  md5: fef4dd172bf26b5f08cecb136dc98c6b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2launch-0.26.11-np2py312h2ed9cc7_16.conda
+  sha256: 2359d5f54c41808f4019c8ce0b0be8b19eacc2eec2acaa1a6a3316cc071a5c7b
+  md5: 8549ecb999653f2620476b82ff85d6e7
   depends:
   - python
   - ros-jazzy-ament-index-python
@@ -36530,16 +36433,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 46593
-  timestamp: 1768979370088
+  size: 46429
+  timestamp: 1771187746480
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2launch-0.26.10-np2py312h61f2ce4_14.conda
   sha256: 3f57bf561fc7b50e1d68143186417ac5d9c1d35d6008b3b8bebdd8b3b37b7190
   md5: 8f61d908b14f886f20822525c83d090f
@@ -36563,9 +36466,9 @@ packages:
   license: Apache-2.0
   size: 46472
   timestamp: 1768947804165
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: e1e14b1ee5cd275cdaf1d713f56b6f14b6917f30f70837acbd3b359f4a462594
-  md5: ac35e99c47b0c9a5ef58b1a1084c075f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2lifecycle-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: d5f85c5306aa7322e31710ee17aca7973d4d5389fdb8423245f76e1c00392ae6
+  md5: 34269438247484ed09c66222fe2d8f43
   depends:
   - python
   - ros-jazzy-lifecycle-msgs
@@ -36574,16 +36477,16 @@ packages:
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2node
   - ros-jazzy-ros2service
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 45451
-  timestamp: 1768979856824
+  size: 45321
+  timestamp: 1771188254880
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2lifecycle-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 4e118263b603f44ffc939be9bfa09934dd6af6c4755db4b66167b3aed3657926
   md5: 0ea2d1f8f790d02b20d1f6330f15dab4
@@ -36604,24 +36507,24 @@ packages:
   license: Apache-2.0
   size: 45329
   timestamp: 1768948242238
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 536c638f2ab4139c0b97a726f9abe0f8ea83f279ac6ed3774db4b671c4087425
-  md5: 4b261b2f8019822f218b11eddce47638
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2multicast-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: bf2485c83e0de4116de9fa0833c1268615ac212d16a623966c77b00312b7765e
+  md5: 0e84754699760ca554d9a508f58d1d84
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25808
-  timestamp: 1768978680139
+  size: 25572
+  timestamp: 1771187060875
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2multicast-0.32.7-np2py312h61f2ce4_14.conda
   sha256: edb6ee441b90a13494c5efa006f864fa028bb9c647e5bb3ef4ad1c19f97b8906
   md5: 333bb898345f29279e3e899e024f4460
@@ -36639,25 +36542,25 @@ packages:
   license: Apache-2.0
   size: 25801
   timestamp: 1768947204231
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 3dd8be7535c99fcae36bd80209b606fa84d98fc9fbd7cb7d4396f26012b0fb4b
-  md5: 7e7449de96b9a9734b7607d6ec819f2d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2node-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: c3de23f0cf4376db5a336a9244bab066acefc3102891fcc30fe778bb2039f2c9
+  md5: 3681abc2531379369bc945bc39018058
   depends:
   - python
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 43253
-  timestamp: 1768979146214
+  size: 43123
+  timestamp: 1771187505073
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2node-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 069b420c7047c867bcc0f9d65708a8509712bd9f3edffafd5683fed905940ed9
   md5: 8d662a717dc7a575191a09ed671710ea
@@ -36675,9 +36578,9 @@ packages:
   license: Apache-2.0
   size: 43118
   timestamp: 1768947598899
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 7659291272c73cb608156607ab946cfe67025d73d45337c5d6d93920c76917ee
-  md5: 962196896c34d1130afb27097dfed20f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2param-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: 77feb2a3f6cfd10b0bedbe16c06ff248c740c28e5cecad4f60abc16bc1af59c0
+  md5: c42915cdb309ffaec1be4985450d7146
   depends:
   - python
   - ros-jazzy-rcl-interfaces
@@ -36686,17 +36589,17 @@ packages:
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2node
   - ros-jazzy-ros2service
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 50525
-  timestamp: 1768979843742
+  size: 50492
+  timestamp: 1771188240997
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2param-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 189e1b610bd3f8ab99ff7d75abd34eccfe5217b0df93b94c4adbbe051330a53e
   md5: d8e30b4eb067d26e16b39398cdf1fb77
@@ -36718,9 +36621,9 @@ packages:
   license: Apache-2.0
   size: 50482
   timestamp: 1768948222959
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: c5b2e611d182f476b3101977859aaa18e72a5fbf9ad026f528ea1aa90d92d04c
-  md5: 64b34fb408cbfc74cfbf17a777428412
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2pkg-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: d2c5b98b40f37f9e80f031a864c0cc46b1c275a45757dec027f11b7df0d27195
+  md5: 48266922803fc585ab7a9d1225df5a49
   depends:
   - catkin_pkg
   - empy
@@ -36730,16 +36633,17 @@ packages:
   - ros-jazzy-ament-index-python
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 60620
-  timestamp: 1768979118240
+  size: 60549
+  timestamp: 1771187479207
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2pkg-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 2e076c2f2cd3699fec670c475da07643b00fe5882425e1eff77c1e7eb1f5f22b
   md5: d78ce573745a5a30ce9e6b567b8e2b4d
@@ -36761,9 +36665,9 @@ packages:
   license: Apache-2.0
   size: 59392
   timestamp: 1768947568391
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2plugin-5.4.4-np2py312h2ed9cc7_14.conda
-  sha256: 7b6e84afb6cd102a1e203e5e98a12b8f498099d01bef26074f9af42e73bb1047
-  md5: bb1978c4602798737792a0375b4865cb
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2plugin-5.4.4-np2py312h2ed9cc7_16.conda
+  sha256: 3c92f9174bd2be3045bcfcb548ac01f8f0b9fdd4fddfd3a19b1116f405e53ffa
+  md5: 58350a26f0a4300bcec601d43ae58093
   depends:
   - python
   - ros-jazzy-ament-index-python
@@ -36771,17 +36675,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25880
-  timestamp: 1768979366072
+  size: 25635
+  timestamp: 1771187740959
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2plugin-5.4.4-np2py312h61f2ce4_14.conda
   sha256: d54d69a142247c602ddad6f9ba80927ae034146fab261286981a14fc941070c7
   md5: 5f28c2dfeca1abb0b25a4c88c87d855d
@@ -36801,24 +36705,25 @@ packages:
   license: Apache-2.0
   size: 25888
   timestamp: 1768947798581
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 9a34174bd5c99b792a184b85e7f81f66ffeea4e8053441438b9bbb842b8fa1a9
-  md5: 6f1a3359f62f6111702c2983065fa3ba
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2run-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: d19f6157b073186b081c4107cc61d763ca7215de1174c50aa9c63532bf3f677b
+  md5: 7fc9d69b8b1892b9240b534e0c770a8a
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2pkg
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 24950
-  timestamp: 1768979350305
+  size: 24710
+  timestamp: 1771187727691
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2run-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 66ccbd642d2c7167303e6b76453dd91f4f706a04bec32b5928939f3a05193931
   md5: 4512d4ba450c216cf0150cbcd64dc33a
@@ -36837,9 +36742,9 @@ packages:
   license: Apache-2.0
   size: 24932
   timestamp: 1768947780337
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: bcb8e62b446606bfb1d275e8bb9c31c6c64e19ab1a2bbc33ab71d19c70f00a2f
-  md5: 0c700b76c3c1dd06442fe97fde6654c3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2service-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: ff0dbafb16e6222ec470bd2e2a41cd272d740103fcb73534478b6f788a0302cf
+  md5: a097677559f3c0a68389cc50ef23d7ff
   depends:
   - python
   - pyyaml
@@ -36848,16 +36753,16 @@ packages:
   - ros-jazzy-ros2cli
   - ros-jazzy-ros2topic
   - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51706
-  timestamp: 1768979384169
+  size: 51619
+  timestamp: 1771187755914
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2service-0.32.7-np2py312h61f2ce4_14.conda
   sha256: 968fcd2ad03c16dc1e3181213f5d78291f911633f3e39b24f163ccf753f86bd2
   md5: 17d8e310b6ad6be639726b89dc101c85
@@ -36879,9 +36784,9 @@ packages:
   license: Apache-2.0
   size: 51656
   timestamp: 1768947809954
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.7-np2py312h2ed9cc7_14.conda
-  sha256: 6a1701fe55d9964758fbd7a5e20c263ef7923f42537e9521f443cbe5e3cf9490
-  md5: bc807ac515c9d12cc9adbbcb75156e74
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-ros2topic-0.32.8-np2py312h2ed9cc7_16.conda
+  sha256: ac442657619ba0229e4de219d4797b07e3f679fc5751ea10f52d05bb0a410e1e
+  md5: ec8c68d8e2cb0f5180bd4047fa86624f
   depends:
   - numpy
   - python
@@ -36890,16 +36795,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 74302
-  timestamp: 1768979139036
+  size: 74199
+  timestamp: 1771187497358
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-ros2topic-0.32.7-np2py312h61f2ce4_14.conda
   sha256: d4606fbfe76f14c491fe84d530067d28d911312e1e12eeac4af9f78978e8c0aa
   md5: fa97b89c7d891ca494e72c518a087ee0
@@ -36921,25 +36826,25 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 74160
   timestamp: 1768947589489
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: e071cbd996676ea80a16876ee5d54f089f5bb7592bc370c1baa3923dc6402958
-  md5: f6a637814ac8250610871de351c1fab9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosgraph-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: 0693ee34c0073fe79975edee8aade3a1041330f0019ff5bece930ff8ecaa76bf
+  md5: fef12d2f153ad1d51b37fe69a4c2de36
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 72255
-  timestamp: 1768976417882
+  size: 72171
+  timestamp: 1771184449823
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosgraph-msgs-2.0.3-np2py312h61f2ce4_14.conda
   sha256: ac314e7691623e429d2fbd45f8ba3a2cf4fa0d8afdd78570323ee5e9e67d95f1
   md5: 6202cc7f06b5e036a48ed3ba8b8edd01
@@ -36957,25 +36862,25 @@ packages:
   license: Apache-2.0
   size: 75592
   timestamp: 1768945415168
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: d3259806850fed34eeb2ec720089c123a5c00aab2a7aa88acb5b065298901459
-  md5: 1e0671c1e71a1ec9abab278082aada67
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-adapter-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 6686eab32e987bc49090c692eb3ca582bb8880b4076c45804243315a9ed27c23
+  md5: 324a93d9fe5406a637117a2bfc79f395
   depends:
   - empy
   - python
   - ros-jazzy-ament-cmake-core
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-cli
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 63643
-  timestamp: 1768974996605
+  size: 63504
+  timestamp: 1771182696915
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-adapter-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 0b752b20a2f93bdbb420c939ec72eb2bfb07a938ca2d400098101457ce127131
   md5: a0846009bb1c8f57ccd9874e3c71268f
@@ -36995,25 +36900,25 @@ packages:
   license: Apache-2.0
   size: 63602
   timestamp: 1768943960590
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 6686be6bdcc5869cde6dc7b56620ec7511f221f5825657afb05e6ef768c3b156
-  md5: 48cba4506b616a6b5b3e7212f33b5ef6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cli-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: a9bd678149f983264ce7fb2c22c62ee6afdef1f3310258fa964c68886cd9e5cf
+  md5: a28e00c8aac4127088d090f19cbd29fc
   depends:
   - argcomplete
   - importlib-metadata
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 42873
-  timestamp: 1768974405863
+  size: 42619
+  timestamp: 1771181945163
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-cli-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 6f2864e946c1e65b902185b690d59cf639499d3568792e35dadc265facc23761
   md5: 07460fc7c8872f5e5096964b90d5a188
@@ -37031,26 +36936,26 @@ packages:
   license: Apache-2.0
   size: 42851
   timestamp: 1768943358043
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 60586ac2acae5ba308c386621c7f4ed2a8948d17e81655ff8834dba94fe635c9
-  md5: 2e9927816b7628d3c57b5fc4d392d88e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-cmake-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 798111877f95c449e67dcb25c3fa487e63fc213cbd43ea5682e36e47f9eb6395
+  md5: 588e3e26a783af3b3cf4a995387cf815
   depends:
   - empy
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-pycommon
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 36343
-  timestamp: 1768975550378
+  size: 36176
+  timestamp: 1771183227229
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-cmake-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 20bbcc667da344fc9e5c6376716247091e55888e9dad95769bfdef8aff24efd4
   md5: b0981501a020faa4e79d1c4a8d83f82b
@@ -37070,9 +36975,9 @@ packages:
   license: Apache-2.0
   size: 36252
   timestamp: 1768944444453
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np2py312h2ed9cc7_14.conda
-  sha256: 0b9395eca64e7f09fc12b0e34f1bfdf1741e1252dabeee43e9e07445a6a25e8f
-  md5: ff6ec3bd789ae50a8dedd82e398399e4
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-generators-0.2.0-np2py312h2ed9cc7_16.conda
+  sha256: a0941b8170077e2b3bd1f8a9de24962fb220adc558192ecc4f3eadf67eb60310
+  md5: bce2db74e510d4bc804aed15e9be9e0f
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37088,16 +36993,16 @@ packages:
   - ros-jazzy-rosidl-typesupport-fastrtps-cpp
   - ros-jazzy-rosidl-typesupport-introspection-c
   - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 32409
-  timestamp: 1768976223308
+  size: 32302
+  timestamp: 1771184210572
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-core-generators-0.2.0-np2py312h61f2ce4_14.conda
   sha256: 8e52cbcd4c2d340b575e8017eda07ef17001ebab54c0d496b6c4d57700a78230
   md5: e48398744cf2859b1972063da6f29e05
@@ -37126,9 +37031,9 @@ packages:
   license: Apache-2.0
   size: 32377
   timestamp: 1768945183843
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np2py312h2ed9cc7_14.conda
-  sha256: cf165575f3a3e17a37f17db719b3bf425c89d6d235ed33e020b01ddab793162b
-  md5: 9122797cdce8baad9ae6d685a0a09be4
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-core-runtime-0.2.0-np2py312h2ed9cc7_16.conda
+  sha256: f40c87772b16a1d37d59600047fc7ee0fc869e7d188de5bdd88dfa0fdbcc5814
+  md5: d17b7e43c337fc59043b0a607039d44f
   depends:
   - python
   - ros-jazzy-ros-workspace
@@ -37141,17 +37046,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-fastrtps-cpp
   - ros-jazzy-rosidl-typesupport-introspection-c
   - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 31468
-  timestamp: 1768976201624
+  size: 31394
+  timestamp: 1771184176701
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-core-runtime-0.2.0-np2py312h61f2ce4_14.conda
   sha256: 95ad94d17b912efd4fc9b089a469f192e2a1fa20953965da88e0e1740c62b49a
   md5: 5a081ff25a492a362733b0c8997d6672
@@ -37177,9 +37082,9 @@ packages:
   license: Apache-2.0
   size: 31468
   timestamp: 1768945168876
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np2py312h2ed9cc7_14.conda
-  sha256: 6b19ead996df328f3b712c4bc40cbc884f18ad8ecd8173533ae2499b9bc5d3f6
-  md5: abc7b251bd74db97187c701fd8febce7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-generators-1.6.0-np2py312h2ed9cc7_16.conda
+  sha256: 973f15c43f4ce9a3976049c6abe1bf3abbbc6a1aedea708bd7312d49ee1eacd5
+  md5: 12fa2b58c406064babe8745266b5469e
   depends:
   - python
   - ros-jazzy-action-msgs
@@ -37187,16 +37092,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-generators
   - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 32655
-  timestamp: 1768976362545
+  size: 32581
+  timestamp: 1771184380130
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-default-generators-1.6.0-np2py312h61f2ce4_14.conda
   sha256: aa06f894aa2c100aaca802194a852c6a6eb0a2b835469b0a6098a64efee9cc9e
   md5: 04cc6087dec031b31c083153e1982e1e
@@ -37216,25 +37122,26 @@ packages:
   license: Apache-2.0
   size: 32639
   timestamp: 1768945349761
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np2py312h2ed9cc7_14.conda
-  sha256: dd1116305775715cc6b713007dba47e509c75d30dde45cbc6daae596a6f42ede
-  md5: a315d882f66f9913720bf6c956f1f1de
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-default-runtime-1.6.0-np2py312h2ed9cc7_16.conda
+  sha256: d3eb7ce7b4befe039a50f1a1ea3f25a9cc432e08875b9810ecff667b8d0bb7a9
+  md5: 8154d3b4f4e1f5f7f4c4904451581e94
   depends:
   - python
   - ros-jazzy-action-msgs
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-runtime
   - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 32082
-  timestamp: 1768976348452
+  size: 31968
+  timestamp: 1771184348606
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-default-runtime-1.6.0-np2py312h61f2ce4_14.conda
   sha256: eda55e4dc46350f1344eafb5b73fbd63deeb06fbd20e3c419b728f38b884653b
   md5: 91f5fd8f50741cd64e79a9ae6e390434
@@ -37254,24 +37161,25 @@ packages:
   license: Apache-2.0
   size: 32080
   timestamp: 1768945327100
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np2py312h2ed9cc7_14.conda
-  sha256: 3dd527db71843c75520b5e682032585166d6e2f2741d3e9ffa2ec9839dad63b6
-  md5: a64fefcf3641dcbb4cd2372a03315d12
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np2py312h2ed9cc7_16.conda
+  sha256: b28fa3ffed22954b1ae35a6c4b93fb154ddbf859fcfe12fb50b4ef6d65dd32ee
+  md5: 5aa5c65ddc7bb05468bb01275b8f4e47
   depends:
   - python
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 63075
-  timestamp: 1768975635417
+  size: 62845
+  timestamp: 1771183328918
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-dynamic-typesupport-0.1.2-np2py312h61f2ce4_14.conda
   sha256: 6a2e3e0c7dede18e1289029098af8db0486398549ca94cb0ae4dd2a33fcb25d7
   md5: 5c11b2cff82517b805c3e12dcb986033
@@ -37290,9 +37198,9 @@ packages:
   license: Apache-2.0
   size: 60915
   timestamp: 1768944592983
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np2py312h2ed9cc7_14.conda
-  sha256: d6e6848393179d67e7025fe07c6132ee0bcf33a756caf280917d5ad77795fd4e
-  md5: 3088d0ce08c604414d6ee746e16c8c6a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np2py312h2ed9cc7_16.conda
+  sha256: 9e48853dbcb0bbae3a416abf7ccad150993581510fd7e038291d0ea28afe4aa0
+  md5: 609afdb70db98efbffa8641dbf48b1d1
   depends:
   - python
   - ros-jazzy-fastcdr
@@ -37300,16 +37208,17 @@ packages:
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 86542
-  timestamp: 1768975753839
+  size: 86318
+  timestamp: 1771183439867
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-dynamic-typesupport-fastrtps-0.1.0-np2py312h61f2ce4_14.conda
   sha256: 74e8ed1bf9d374acd7beebbdfff02b011756064696c74356b57e6b8fe5c79ced
   md5: 86ebc2da879779829b518f283b520a00
@@ -37329,9 +37238,9 @@ packages:
   license: Apache-2.0
   size: 78652
   timestamp: 1768944740501
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: b068ddee6e5b8f809c79805e834fdecd6007c3326aa7c8ddb3d414bf36af6338
-  md5: b27a8c8ea2ed0687a1dc84138a988edc
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-c-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 2c522b748d57772d2d2650f8f39a52b77ad99eec11033dc447c6b1d1e9592fba
+  md5: 2d6b36e6af54bfbf2862344ab3fa1a08
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37344,16 +37253,16 @@ packages:
   - ros-jazzy-rosidl-parser
   - ros-jazzy-rosidl-pycommon
   - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 53317
-  timestamp: 1768975630096
+  size: 53159
+  timestamp: 1771183321948
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-generator-c-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 94416aee58b0a4e639dbd2c39872451ae17cd30faf5ef9931681980662a18b5f
   md5: c09dd1f27891ef63688027f439aa5658
@@ -37378,9 +37287,9 @@ packages:
   license: Apache-2.0
   size: 53262
   timestamp: 1768944573167
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 6c01977fc91eb4532d8da01d8d9535711280aef10b823513704dad7e282b22b9
-  md5: 184ac8d7b9a2c5692324adf22e656596
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 3a605dff77f2a3ca452efb8f4a9a75ef37b7b4efff7434883203491d405df121
+  md5: c87adcebab7e334e0380af0923d51eec
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37393,16 +37302,17 @@ packages:
   - ros-jazzy-rosidl-parser
   - ros-jazzy-rosidl-pycommon
   - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 50171
-  timestamp: 1768975727423
+  size: 50055
+  timestamp: 1771183415246
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-generator-cpp-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 62108213bb008cbe6e9345f03fc7db162909c150811c5b5646b48ac99cd68f8f
   md5: 91a3176d0810b67244f93e70804987c3
@@ -37427,9 +37337,9 @@ packages:
   license: Apache-2.0
   size: 50080
   timestamp: 1768944710305
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.2-np2py312h2ed9cc7_14.conda
-  sha256: 0a6b80154cc2ceb65e9c9534c7f0e7d52ec2d6ab0eb8760bc010d6b0cb99f917
-  md5: 14c7ad681afe3b3d8de82549a20d4f3a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-py-0.22.2-np2py312h2ed9cc7_16.conda
+  sha256: 77c68305f3104ac92831017054f2fc203624f795a8bd624213c83caeb289ba21
+  md5: f1678e28dd61b6c07830a24c52516497
   depends:
   - numpy
   - python
@@ -37451,17 +37361,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-c
   - ros-jazzy-rosidl-typesupport-interface
   - ros-jazzy-rpyutils
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 60302
-  timestamp: 1768976170924
+  size: 60218
+  timestamp: 1771184124558
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-generator-py-0.22.2-np2py312h61f2ce4_14.conda
   sha256: a788c809fd74f1cd51dcf60383b8b6e5860e4d942a78652177adc07e90adb647
   md5: a28cec45cd21c7cd95a57ae6c68438aa
@@ -37496,9 +37406,9 @@ packages:
   license: Apache-2.0
   size: 60225
   timestamp: 1768945138594
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 62658037401a2e6ec188cf2b9ef5509ca0816020d424658251518650ae83ce47
-  md5: ddf070ad895e9dadad344c32101b8ac0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-generator-type-description-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 3666ef730c976f2b1ea234c3edbba24d8d345e17391e8a82c7fe5b22f62a747f
+  md5: e95b7416c30fd7f2ad06d8d59bb3e322
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37506,17 +37416,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-cli
   - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 48926
-  timestamp: 1768975455962
+  size: 48741
+  timestamp: 1771183136308
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-generator-type-description-4.6.7-np2py312h61f2ce4_14.conda
   sha256: b64622c1eb249a03e86d5f0e149a73dde929b08c94fcbd541f9bee5c2c2216ce
   md5: bd80fcd2293f75414e3af98280ea9f00
@@ -37537,25 +37447,24 @@ packages:
   license: Apache-2.0
   size: 48804
   timestamp: 1768944344692
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 367e1112971d86a7995c88928a66f24a97fc83c8792c3f3db7d855e60f11eb14
-  md5: 713f5af5decfe127084b72052599fcbc
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-parser-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 1af7c6de2e619c6c31aa48d778349faa2d762fec34e5c4957f70301e93863dd8
+  md5: 45e12d47741ec899824b729fec446753
   depends:
   - lark-parser
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-adapter
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 60375
-  timestamp: 1768975351221
+  size: 60245
+  timestamp: 1771183037489
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-parser-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 7e22f19a7874f02cc089caaf7b89fd3193ad48443616e6f92badeaacfb469257
   md5: 27d4ece87c3ad1e16808664ab12b639c
@@ -37574,23 +37483,23 @@ packages:
   license: Apache-2.0
   size: 60308
   timestamp: 1768944231706
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: de1ff664687167e7af5203b66df0b748e5432a55e8805ad750f1e46f21698213
-  md5: 4ee78d143cb687d7c6dd05970ba4ccc2
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-pycommon-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 8fe43097560291bcf78b8031b7709f5a50e3b8bd5de3af0cb1bc0b78ae9ebdc7
+  md5: ecfbf7590c451fc8469bae01ed4dfb3f
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25379
-  timestamp: 1768975451977
+  size: 25106
+  timestamp: 1771183131403
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-pycommon-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 4722acd0e0b5d735104556eb17fb1eeff0353528f3d645fa72ba294fd3bc1c58
   md5: 4af878cbcc461a03c8a3c7e3962c90f8
@@ -37608,26 +37517,26 @@ packages:
   license: Apache-2.0
   size: 25389
   timestamp: 1768944340131
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 195d2e9203e78720105eac13e233b66a8299c4b6545bced55d3e93a69574c640
-  md5: 5dadd0a01dba00817e67f4b6d868503e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-c-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: af4390f7f33bb5aafd96bbcdd8109ceaba901f70d66ecc228cf31e80a0fb2d0d
+  md5: e5dd7014031c92cd6a74af7a2f5d889f
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 83732
-  timestamp: 1768975532038
+  size: 83589
+  timestamp: 1771183210954
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-runtime-c-4.6.7-np2py312h61f2ce4_14.conda
   sha256: e865f1ec7ccecf83f324d6bd96221447c100638847f6dff2a77a217e4e1124b0
   md5: 6dc08ae1648bf428f4e5bf252a945214
@@ -37647,25 +37556,25 @@ packages:
   license: Apache-2.0
   size: 87973
   timestamp: 1768944425841
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 9c3972285f34d9e65485841e5cc681d62d177546d45ba1e546758d574293c9b2
-  md5: 618f6dd5b08e0a46e3aecc8869f1c6f1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 6c39ece1f6bf922765eb2a12737d7fddfdc3cbf5f4ab9ba42059ebfd9ec28121
+  md5: 56c80adedaa81bf7845c537a8fede222
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 41075
-  timestamp: 1768975615071
+  size: 40909
+  timestamp: 1771183308934
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-runtime-cpp-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 08a183da5d5c2cf059f3f400878befb919886253028a48df187c8cf21e32b8e3
   md5: c8f3c6f92b77107f44a33018924258d5
@@ -37683,26 +37592,26 @@ packages:
   license: Apache-2.0
   size: 40986
   timestamp: 1768944546873
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np2py312h2ed9cc7_14.conda
-  sha256: 5c6e84a44eefed39343e6e6ace12660bc7d16a67782a62681924e7e514c37534
-  md5: e29e6f8c0cf347e79f19fcd7979c2e78
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-runtime-py-0.13.1-np2py312h2ed9cc7_16.conda
+  sha256: e292f5bab68e8ae2e6a8bedfc69f326e6b1e7dfd8fcf6df984fc9055c20c4076
+  md5: 81682a0c6845eba8fbad9c06f6aa989e
   depends:
   - numpy
   - python
   - pyyaml
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-parser
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 47637
-  timestamp: 1768976570527
+  size: 47495
+  timestamp: 1771184649096
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-runtime-py-0.13.1-np2py312h61f2ce4_14.conda
   sha256: f342d0300c0df8dfd6be50660d2066c1ce213b2046db67788cead2226c52a139
   md5: e69d87da2fc9c99f38f8b8692b58e21d
@@ -37721,9 +37630,9 @@ packages:
   license: Apache-2.0
   size: 47535
   timestamp: 1768945573949
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np2py312h2ed9cc7_14.conda
-  sha256: 80a1e07e393a60e90e1abe9f7f981525c9442150ddd6a048c242a1a09c728ad5
-  md5: 1d9461e0ad5882c23be4c1ebcf65bbb3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-c-3.2.2-np2py312h2ed9cc7_16.conda
+  sha256: 4938e85ae06f70f3f2ae9af1d8548a14b4c99e30904d4239e33acbcb36710623
+  md5: ff051292d0466d6c086d9ff42fc1489b
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37738,16 +37647,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-fastrtps-c
   - ros-jazzy-rosidl-typesupport-interface
   - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51300
-  timestamp: 1768976122441
+  size: 51153
+  timestamp: 1771184061242
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-c-3.2.2-np2py312h61f2ce4_14.conda
   sha256: 142df303ccd53e7a08dfcf1916fa03104648257764457e05bf16d06b6d1dcdc1
   md5: f1e13102a4591ca86178ace9030033bd
@@ -37775,9 +37685,9 @@ packages:
   license: Apache-2.0
   size: 51241
   timestamp: 1768945095228
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np2py312h2ed9cc7_14.conda
-  sha256: 69dfc33c071318accc937361c45ccd035dfd0b18f0c389a2a98a6f35374c8e2a
-  md5: 34e03f7686eda69d240414f52d961585
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np2py312h2ed9cc7_16.conda
+  sha256: cafa3a03af533b8af224fd0c8ad574730671b7645a0e45162a60a98fd7f41c54
+  md5: a99caf805ceba646f17e4b89adab1c89
   depends:
   - python
   - ros-jazzy-ament-cmake-core
@@ -37795,16 +37705,17 @@ packages:
   - ros-jazzy-rosidl-typesupport-fastrtps-cpp
   - ros-jazzy-rosidl-typesupport-interface
   - ros-jazzy-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 50373
-  timestamp: 1768976165572
+  size: 50232
+  timestamp: 1771184119461
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-cpp-3.2.2-np2py312h61f2ce4_14.conda
   sha256: 1fb850238c3e41649e308695eee89e2a35586fe263ff46d2dd48cd6a2d2fbee6
   md5: 2c797341760fba2c05bde0a265898a3a
@@ -37835,9 +37746,9 @@ packages:
   license: Apache-2.0
   size: 50438
   timestamp: 1768945132958
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.3-np2py312h2ed9cc7_14.conda
-  sha256: 616080dc794d849f1bc95f3f737f686013b193728506ab88066bd98883f4c029
-  md5: de8a082e570de0acfd0490d0818a8a85
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.3-np2py312h2ed9cc7_16.conda
+  sha256: 261306419f469378eec4cc4aecc65e17e364ebdda3de7d72152e54f60508ed02
+  md5: 95eb64f662665ef115a535697945e224
   depends:
   - python
   - ros-jazzy-ament-cmake-ros
@@ -37853,16 +37764,17 @@ packages:
   - ros-jazzy-rosidl-runtime-cpp
   - ros-jazzy-rosidl-typesupport-fastrtps-cpp
   - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51987
-  timestamp: 1768976049147
+  size: 51901
+  timestamp: 1771183906586
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-fastrtps-c-3.6.3-np2py312h61f2ce4_14.conda
   sha256: 752aed6e2e30d3dc4426d15a701c961438876f2e0aa667345b4c00aa078e6ec9
   md5: b89da2f56cd0d59c66baa481e512b1ad
@@ -37890,9 +37802,9 @@ packages:
   license: Apache-2.0
   size: 52244
   timestamp: 1768945017851
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.3-np2py312h2ed9cc7_14.conda
-  sha256: ebc03d086473fbbba1c88da64c28a5d0f1d3b19fd8f5fd413c931fc1b7ee6b51
-  md5: 59a45dacb967b5c7a206ed9744c385af
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.3-np2py312h2ed9cc7_16.conda
+  sha256: 2977c67adc49ae6bb76511ef79afeca2160954f8a1ca508fd430b8cc4bb82a17
+  md5: 239766a682fb485a570dd510a988fa4a
   depends:
   - python
   - ros-jazzy-ament-cmake-ros
@@ -37908,17 +37820,17 @@ packages:
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-rosidl-runtime-cpp
   - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 54052
-  timestamp: 1768975861649
+  size: 53963
+  timestamp: 1771183533431
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-fastrtps-cpp-3.6.3-np2py312h61f2ce4_14.conda
   sha256: e449f80bf6901eae9aa9e00ecf2e7f3c9a0d186879facd6d5025cb0cfbfc2b1e
   md5: b8ad85726bc61a7cf6475121fcb3b545
@@ -37946,23 +37858,23 @@ packages:
   license: Apache-2.0
   size: 54263
   timestamp: 1768944867139
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 300c2a948a0da7a3932f342e08837116dddbbb6503dd112c178e2a870860e7b0
-  md5: 7a32cff7d1a5b69451dd6a7ec97ae260
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-interface-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: da27a99748ccb98e99b7f4474b6a4073996ffa108aee1144a92130d92cbb30f5
+  md5: a747b5d3335bc5be1ba0b972c9844428
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 29380
-  timestamp: 1768975013654
+  size: 29257
+  timestamp: 1771182722397
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-interface-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 4053a8f07eccf33bfc740c3e1ef982b8791682209e69eb5690cc3e22c898b58e
   md5: af03b5e7d91cf1229551c688dd84a93f
@@ -37978,9 +37890,9 @@ packages:
   license: Apache-2.0
   size: 29351
   timestamp: 1768943984812
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: 94f349bafc0315739d987f6ac7be5e32d8711e08479ebac47c80ce484c55e1dc
-  md5: 099afff89882fa2ebdb54ac1ba9bad91
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 229e95f2d2b1007f8176b3a5f6cb6d76412f967a8d63bc697f97327272704568
+  md5: afe3937df1c1ac3969577deb3ad46f91
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -37993,17 +37905,17 @@ packages:
   - ros-jazzy-rosidl-pycommon
   - ros-jazzy-rosidl-runtime-c
   - ros-jazzy-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 48428
-  timestamp: 1768975749573
+  size: 48258
+  timestamp: 1771183435622
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-introspection-c-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 94039b389e4d67ff54bf0abc916b17a8644e3be6c4a9b852e4530813e3d23136
   md5: 4f1569141ed7400269228f27ac7ec96d
@@ -38029,9 +37941,9 @@ packages:
   license: Apache-2.0
   size: 48821
   timestamp: 1768944736098
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.7-np2py312h2ed9cc7_14.conda
-  sha256: f7fe7bbd4a91b2c0875c2ba372c8908546c229bd5540758051149f24611bd4a1
-  md5: 5faba9b20f481175270e48fc307f58b6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.7-np2py312h2ed9cc7_16.conda
+  sha256: 4fb1071137e1eb052733db8ca068c6c55b80e5478afe96766387a66ba4495b21
+  md5: 9a8a70907b39b9e6088602c19f427f29
   depends:
   - python
   - ros-jazzy-ament-cmake
@@ -38047,17 +37959,17 @@ packages:
   - ros-jazzy-rosidl-runtime-cpp
   - ros-jazzy-rosidl-typesupport-interface
   - ros-jazzy-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 48647
-  timestamp: 1768975885152
+  size: 48476
+  timestamp: 1771183548922
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rosidl-typesupport-introspection-cpp-4.6.7-np2py312h61f2ce4_14.conda
   sha256: 9d0d4cd8d1e9444f2e24ae3e570967b085ee5af96c261d66e64a758c7936845d
   md5: d8072df79dc82e604186c7b5af70f2b2
@@ -38086,23 +37998,23 @@ packages:
   license: Apache-2.0
   size: 48991
   timestamp: 1768944882405
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np2py312h2ed9cc7_14.conda
-  sha256: ec46df788261a480ea44c61f5664b50f9d9e7ccd8a085b289e5728d77ecefd89
-  md5: e28ef177572cf8ea1dbe59399a041a1d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rpyutils-0.4.2-np2py312h2ed9cc7_16.conda
+  sha256: 35906624e018708ec023e24dfda8c3027f900778117c84af89a05809ae5fd2bd
+  md5: e80926851dc85690c0f18588fe1dd2ff
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26458
-  timestamp: 1768974380541
+  size: 26197
+  timestamp: 1771181892184
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rpyutils-0.4.2-np2py312h61f2ce4_14.conda
   sha256: e1330aa58f3a58d16312dfdb4c8829a096d0948f610d0a52efc4065cf75f21b9
   md5: 6677fc2b67622d845d0ee73b13b036f9
@@ -38118,9 +38030,9 @@ packages:
   license: Apache-2.0
   size: 26454
   timestamp: 1768943333479
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np2py312h88103e5_14.conda
-  sha256: 79fe7ffff02a2f3526b0e0766bc5b3dbdbcbba55e2a1665a374328ed7041fefd
-  md5: 54f1c51decf55e7951ccf06d4a2319a5
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rsl-1.2.0-np2py312h88103e5_16.conda
+  sha256: aa87de87131ed716c235ec1b86fa5cb03fbb79cb17ac7e57eb8f8ee933cb2d42
+  md5: ce14ba581e0cd22f993b8ebe103c5923
   depends:
   - eigen
   - fmt
@@ -38129,18 +38041,19 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tcb-span
   - ros-jazzy-tl-expected
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - graphviz >=14.1.1,<15.0a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - graphviz >=14.1.2,<15.0a0
   license: BSD-3-Clause
-  size: 61349
-  timestamp: 1768978452005
+  size: 61248
+  timestamp: 1771186757278
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rsl-1.2.0-np2py312hcab10f8_14.conda
   sha256: 10e78072d70505a68142c0a95b681f8453082fe924939def7bff35fea40a6e82
   md5: 938c71874f75ba92305d241efa8087eb
@@ -38164,24 +38077,24 @@ packages:
   license: BSD-3-Clause
   size: 62673
   timestamp: 1768946975508
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.2-np2py312h2ed9cc7_14.conda
-  sha256: 296710e45267ff030ef2f78513e2572210cd2cfc8026c63d56c2d01421354453
-  md5: df2cb55d63e74745a98834c8db119802
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rti-connext-dds-cmake-module-0.22.3-np2py312h2ed9cc7_16.conda
+  sha256: 9ae43edc00cc628a4d27c790192ab3d9aa1f17ebfea83e703826da8d7f33abec
+  md5: acae239a1387972479023365a1e14334
   depends:
   - python
   - ros-jazzy-ament-cmake
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 31692
-  timestamp: 1768975289885
+  size: 31616
+  timestamp: 1771182984679
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rti-connext-dds-cmake-module-0.22.2-np2py312h61f2ce4_14.conda
   sha256: b70189499a91e5c091c48188f72a34075d471171e9cf99d518c34f039725f756
   md5: 7434f0667a97a4eed2f99ad6884597f0
@@ -38199,24 +38112,25 @@ packages:
   license: Apache-2.0
   size: 31680
   timestamp: 1768944161091
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.19-np2py312h2ed9cc7_14.conda
-  sha256: 638a687c077b053f590d60603ce8a145678002c189796c4886262af1bac735f6
-  md5: 317ab4a4b664da5a8d8c2efe8dff4157
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-assimp-vendor-14.1.19-np2py312h4f3ad64_16.conda
+  sha256: 3d9b6abfb133d8633ac4d1d2e0b08b1cf2e42c093e6b35b9a20a23d239a5c32d
+  md5: 826cdfa416a5bb070e73e7c47997eb68
   depends:
   - assimp
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - assimp >=5.4.3,<5.4.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 25085
-  timestamp: 1768974952518
+  size: 24923
+  timestamp: 1771182635979
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-assimp-vendor-14.1.19-np2py312h61f2ce4_14.conda
   sha256: 6ba5cad5c5d5da1b09232b86a8d88a876cefb37889246a94c123780fb24e0b03
   md5: a94dcfae153e7b781527e3f317ee529f
@@ -38235,9 +38149,9 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 25163
   timestamp: 1768943907515
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.19-np2py312h2ed9cc7_14.conda
-  sha256: 093507b34fd37260a516e093147b0dcd6f840034115cd886f77b61f5df0751b2
-  md5: d94e867c83061d558633fef59ed5bc99
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-common-14.1.19-np2py312h2ed9cc7_16.conda
+  sha256: 9f80320b5df99344631ad29ea8e7a67bfbffa6fa0a006fa5a96aa0e19c04df0d
+  md5: 58ddff074026818712039442b7ca44d5
   depends:
   - libgl-devel
   - libopengl-devel
@@ -38259,19 +38173,19 @@ packages:
   - ros-jazzy-tinyxml2-vendor
   - ros-jazzy-urdf
   - ros-jazzy-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
   - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 889458
-  timestamp: 1768979368739
+  size: 889562
+  timestamp: 1771187747535
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-common-14.1.19-np2py312h61f2ce4_14.conda
   sha256: 5364d4b510761405aa9764b5f7ca73a6704fe10205748dfd1e42ec1d46dfd872
   md5: 101d67de2b5d8f9021588c108e249ed3
@@ -38308,9 +38222,9 @@ packages:
   license: BSD-3-Clause
   size: 881649
   timestamp: 1768947812465
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.19-np2py312h2ed9cc7_14.conda
-  sha256: c7c91b9e804902c4e46ed24d52cf372108b5325d1a6325726bcb722c36b989bc
-  md5: 984013bbdb27c8d26b388b0eb8923041
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-default-plugins-14.1.19-np2py312h2ed9cc7_16.conda
+  sha256: 1df69b2b7f8a39fbb1eb936d672d19989c819beb1a07587e83ade1be9b3d3234
+  md5: 2faa89202b9b69aefd7ffcbb149cc62b
   depends:
   - libgl-devel
   - libopengl-devel
@@ -38336,20 +38250,20 @@ packages:
   - ros-jazzy-tf2-ros
   - ros-jazzy-urdf
   - ros-jazzy-visualization-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libgl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - qt-main >=5.15.15,<5.16.0a0
   - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 2286747
-  timestamp: 1768980484930
+  size: 2286847
+  timestamp: 1771188901506
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-default-plugins-14.1.19-np2py312h61f2ce4_14.conda
   sha256: c8ed72c26cbb67d7c7b8c2c27b8e6c5e0f556d8c3a6157e013c953fa7ac1879b
   md5: c9d1d0becf04dc8b44bbefed525cafce
@@ -38390,9 +38304,9 @@ packages:
   license: BSD-3-Clause
   size: 2314394
   timestamp: 1768948764941
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.19-np2py312hf3be069_14.conda
-  sha256: a2f6e01ef771f0c955eac5a7b0d88327dc2412658da5d0a350e775d84932fc5f
-  md5: f551bbe3ab963c91345345e01b0f885e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-ogre-vendor-14.1.19-np2py312hf6702ba_16.conda
+  sha256: 5c3fe2e9c8520be42f42a9fe97f57a121c6aa54670007db4645f07869a334258
+  md5: d78f4fb45e89ff9e42e56513e9d401aa
   depends:
   - assimp
   - freetype
@@ -38401,7 +38315,7 @@ packages:
   - libopengl-devel
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - xorg-libx11
   - xorg-libxaw
   - xorg-libxrandr
@@ -38410,25 +38324,25 @@ packages:
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
   - pugixml >=1.15,<1.16.0a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libglu >=9.0.3,<9.1.0a0
-  - assimp >=5.4.3,<5.4.4.0a0
+  - libgl >=1.7.0,<2.0a0
   - libfreetype >=2.14.1
   - libfreetype6 >=2.14.1
-  - xorg-libxrandr >=1.5.4,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
   - zziplib >=0.13.69,<0.14.0a0
-  - freeimage >=3.18.0,<3.19.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - libglu >=9.0.3,<9.1.0a0
   - glew >=2.3.0,<2.4.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - numpy >=1.23,<3
+  - libopengl >=1.7.0,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
   license: Apache-2.0 OR MIT
-  size: 5377899
-  timestamp: 1768974741145
+  size: 5377838
+  timestamp: 1771182394150
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-ogre-vendor-14.1.19-np2py312h6bf9922_14.conda
   sha256: 4cca7ba3efe81c79ccc128c243940814841660066906d738250b5c24ce10749e
   md5: 1f789e25cad29f6dc9ef9ce542a5a5f4
@@ -38467,9 +38381,9 @@ packages:
   license: Apache-2.0 OR MIT
   size: 5261447
   timestamp: 1768943726612
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.19-np2py312h2ed9cc7_14.conda
-  sha256: 5872cb2b9d544a8e05c89ac91a259d80120c0a779b96bd0104c28eeceb9772eb
-  md5: c4fc24931095bdbb76ff9a095a462a87
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz-rendering-14.1.19-np2py312h2ed9cc7_16.conda
+  sha256: d31cba870c531ebd4d4bf679a0dd94a6d2e1ba607ebc26790f0002a80b10f195
+  md5: fe6a2996558070eba6e904e29f1bb0ea
   depends:
   - eigen
   - libgl-devel
@@ -38482,21 +38396,21 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rviz-assimp-vendor
   - ros-jazzy-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - glew >=2.3.0,<2.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libgl >=1.7.0,<2.0a0
   - libopengl >=1.7.0,<2.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - glew >=2.3.0,<2.4.0a0
+  - numpy >=1.23,<3
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 935692
-  timestamp: 1768975461577
+  size: 935895
+  timestamp: 1771183142474
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz-rendering-14.1.19-np2py312h61f2ce4_14.conda
   sha256: ec6c2277001569b8ad8f129b79eec58dd7021c70ebcc91aa0d50e7b80b67f367
   md5: cd1b427c72d955ad6e37f7824b411d4a
@@ -38526,29 +38440,29 @@ packages:
   license: BSD-3-Clause
   size: 927669
   timestamp: 1768944351988
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.19-np2py312h2ed9cc7_14.conda
-  sha256: c49f3f1b2ae5caf66859446668ab7def793fb4c51dcfbc5fbb0c4bf1618ecfc5
-  md5: 4fb3d8012696062219c1da8a5576170b
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-rviz2-14.1.19-np2py312h2ed9cc7_16.conda
+  sha256: 7efa1b6bf99ad2a5e9d6feded0a5d478771f80e78a0f97cd90c6914fe288ea11
+  md5: eeb31eac42d6081475baf789b6edd54e
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rviz-common
   - ros-jazzy-rviz-default-plugins
   - ros-jazzy-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.23,<3
   - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
   license: BSD-3-Clause
-  size: 76201
-  timestamp: 1768981252070
+  size: 76431
+  timestamp: 1771189661775
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-rviz2-14.1.19-np2py312h61f2ce4_14.conda
   sha256: 1c1129de628231fba12228b506674a30dd4592c658fb005e5b8a8c95d2499e5e
   md5: 966eb9b7024f74c1958057b518a48ed6
@@ -38571,9 +38485,9 @@ packages:
   license: BSD-3-Clause
   size: 77246
   timestamp: 1768949363038
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np2py312h2ed9cc7_14.conda
-  sha256: ad1c61884c03434bbad1395e9170784df86cfa221397c1203b50d63a742224aa
-  md5: c56f3cd07a8874d7ed26c425a00c4b71
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-urdf-1.0.2-np2py312h2ed9cc7_16.conda
+  sha256: 6fc5ef8bee19b88d4ccc2396dfe6ec63098f7ca367fee23b00ec9d382e867bb6
+  md5: 4feef62b49c0028b98b9299f67f31e65
   depends:
   - python
   - ros-jazzy-ament-cmake-ros
@@ -38584,17 +38498,17 @@ packages:
   - ros-jazzy-tinyxml2-vendor
   - ros-jazzy-urdf
   - ros-jazzy-urdf-parser-plugin
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - urdfdom_headers
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 85594
-  timestamp: 1768976064787
+  size: 85455
+  timestamp: 1771183944213
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-urdf-1.0.2-np2py312h61f2ce4_14.conda
   sha256: ecb05ce3bc1811a398602991751e4dda54e83234edb366ccebf80477261d7204
   md5: c3d1ccd44caeff3a0d2f0737260755b8
@@ -38619,9 +38533,9 @@ packages:
   license: Apache-2.0
   size: 88421
   timestamp: 1768945035558
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np2py312h6021aa6_14.conda
-  sha256: 74c9bff35f9318fb8eceef84ddb64ef025e2fd34669a52953149b4b829257bd0
-  md5: 623bdcab31d0dca215621f5ea714798f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sdformat-vendor-0.0.10-np2py312h6021aa6_16.conda
+  sha256: 6579d09093739b635c61a7199a7678b0a7e1ab3f99249cc9b3a7ed83a65fe2f0
+  md5: 32f2cf4158801b81238ea1ce31019e91
   depends:
   - pybind11
   - python
@@ -38631,23 +38545,22 @@ packages:
   - ros-jazzy-gz-utils-vendor
   - ros-jazzy-ros-workspace
   - ros-jazzy-urdfdom
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - sdformat14
   - tinyxml2
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - libsdformat14 >=14.8.0,<15.0a0
+  - numpy >=1.23,<3
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   license: Apache-2.0
-  size: 32190
-  timestamp: 1768975560610
+  size: 32074
+  timestamp: 1771183237287
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sdformat-vendor-0.0.10-np2py312h287f2fd_14.conda
   sha256: c7332303dbde9434dac33ba58a6e8259d62312b6350015d3198e2b9486e2578d
   md5: 419ad1a189b81c53fdebf21311eb56f4
@@ -38676,9 +38589,9 @@ packages:
   license: Apache-2.0
   size: 32110
   timestamp: 1768944453530
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: ee0859957992f3910f34fac3254ebdbd71764585472bf9a1fb464a0745e972b0
-  md5: 89a7a6e3349f2d78349c7bac2eded259
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 4eb2c2a6a383a36d05c518eb102e43cc05cee97dbe2782f5cbc0b99f761b6f52
+  md5: 53d32c3c53dab08544ae708c83b3e256
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -38686,16 +38599,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 546181
-  timestamp: 1768976803769
+  size: 549740
+  timestamp: 1771184872168
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sensor-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: ba8c367952ec8dc4c49f92d2a7146119d53338fb87347b072b6d36bc567561c4
   md5: da845b852c9b1615680129f0f9cecddf
@@ -38715,26 +38629,26 @@ packages:
   license: Apache-2.0
   size: 555452
   timestamp: 1768945785689
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: b930b4b924bbf383d7a0ad85dca48b47ccda605a0ce28af9066a605b804e8993
-  md5: 15c18ca474aa917020c19072566d811d
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sensor-msgs-py-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 24e75b4ba5b484f05d1f6a1507b05a5a4b2074bb0c9d9d039eaad7b997143924
+  md5: 06205df43be843fdc75833e8fe5c16b9
   depends:
   - numpy
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 30731
-  timestamp: 1768977042011
+  size: 30482
+  timestamp: 1771185132039
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sensor-msgs-py-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 9d0f4657008d8abd2cd9c3fbfb77b3f02114da0bc88070f2481a9f6591f30a4f
   md5: a203053c789bafdce3553ef05756c035
@@ -38753,25 +38667,25 @@ packages:
   license: BSD-3-Clause
   size: 30733
   timestamp: 1768945974308
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: 97109e64f4aa38bc632726ad7726086ea616db1a59cd7ce4bd770401dafbd515
-  md5: 701048cd10cd00dfae1ac0602f831c37
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-service-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: 551e222052e6c1f4ddd3f239db1b802cbc27dbe39bbbc0bc84950c9c8b48fd82
+  md5: 8036867899d108279f701ca0fae16181
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 80803
-  timestamp: 1768976271809
+  size: 80601
+  timestamp: 1771184250589
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-service-msgs-2.0.3-np2py312h61f2ce4_14.conda
   sha256: e869c0b1750c63fb4bde09030e6b9f03a8a3337da115dc468764995aaa4d5885
   md5: c32352441409ef5b964a9ab9cbcac165
@@ -38790,25 +38704,25 @@ packages:
   license: Apache-2.0
   size: 83659
   timestamp: 1768945232362
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 99b3ceff00e8064f792fbb463b5a84e7ae6f03d060771fd511dfd3e5e3a0c3a1
-  md5: cb2bf185c2bd707b3faeba786a1fee84
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-shape-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 726930374f4e3255c17c85abd03beb6d2435b79478ceabe8a6d5116449ad1876
+  md5: 3467a90fd4f44db616abdda4b95ab73a
   depends:
   - python
   - ros-jazzy-geometry-msgs
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 128269
-  timestamp: 1768976806291
+  size: 128090
+  timestamp: 1771184858677
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-shape-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: f0133188e8ade4df93a8d8202c2ce6c85c2483e8f2544942fbe9ed65eea095d7
   md5: 9a5901652bf8612c2148c1ceec1b4b96
@@ -38827,26 +38741,27 @@ packages:
   license: Apache-2.0
   size: 133271
   timestamp: 1768945770026
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np2py312h918b84f_14.conda
-  sha256: 4725102e66c4a2d0089dafa54f767c89a0cc2da0812dd58e306d072a4f3d2caa
-  md5: 3826650a48bb219f4f56804524ab8a9c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-spdlog-vendor-1.6.1-np2py312h918b84f_16.conda
+  sha256: 4a9f30c459b910f3b6539c174b90295d86903b34509bd99f24e2164e5f1e4f67
+  md5: a1e4a4227444eba2566ed915a339bb11
   depends:
   - fmt
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - spdlog
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
   - spdlog >=1.17.0,<1.18.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR MIT
-  size: 27447
-  timestamp: 1768974995526
+  size: 27316
+  timestamp: 1771182666242
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-spdlog-vendor-1.6.1-np2py312ha677571_14.conda
   sha256: ff0699e0452ae489abd95b62948d68a07f27d18d9df28afe76fb3e5314770929
   md5: 4c55ddff0944e72d6836be6d9c3eee87
@@ -38866,9 +38781,9 @@ packages:
   license: Apache-2.0 OR MIT
   size: 27413
   timestamp: 1768943939196
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.4-np2py312h2ed9cc7_14.conda
-  sha256: 7aad1b03e0a52894d9359e9fd416d16b693b305ffef9af1b5ce35bce93064aff
-  md5: 23f16a30c5a1266554c864ffd3072a62
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-0.13.5-np2py312h2ed9cc7_16.conda
+  sha256: 8365c232277ccc76ae225fa7ce9367b202de22c2e875964506c04b2add34f319
+  md5: cae47dd9415e62cae02504c559def171
   depends:
   - argcomplete
   - cryptography
@@ -38879,16 +38794,17 @@ packages:
   - ros-jazzy-rclpy
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 75922
-  timestamp: 1768979850997
+  size: 75849
+  timestamp: 1771188248674
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sros2-0.13.4-np2py312h61f2ce4_14.conda
   sha256: 58b90943367384a1055e48d2467531c4f019d059846a99d5087b885f0a9e89b4
   md5: 8f87d87a3ed58c8ebd92edb62d0dce70
@@ -38912,25 +38828,25 @@ packages:
   license: Apache-2.0
   size: 75869
   timestamp: 1768948233619
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.4-np2py312h2ed9cc7_14.conda
-  sha256: d69055e813c394da21bea92ca9283bf39059c875f5a7cdf468be385e95934d07
-  md5: 9e0396901e12ee585b97388028acbf74
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-sros2-cmake-0.13.5-np2py312h2ed9cc7_16.conda
+  sha256: 5cd5b0d28424b681aa25677a50b00c8a0d8e9722acb2594368bafe3fa6a0cef8
+  md5: c0a55058b92d1b95c1967f756f63cc93
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-ros2cli
   - ros-jazzy-sros2
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 39864
-  timestamp: 1768980461706
+  size: 38284
+  timestamp: 1771188658221
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-sros2-cmake-0.13.4-np2py312h61f2ce4_14.conda
   sha256: 67f74647ccf64ebda3405d7cd2b53841082353afc86db71638f7d1e4d924ceb4
   md5: 9e5f3258b99a5e725aae53b43dce23bf
@@ -38948,9 +38864,9 @@ packages:
   license: Apache-2.0
   size: 38367
   timestamp: 1768948773691
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-state-interfaces-broadcaster-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: f21ffe33203bf83a49ce393b7e6c96634fc3dcb88ce480686d2fbaba5c35c2c3
-  md5: 284fbb25e38ad699a7e87a0e7cb7d861
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-state-interfaces-broadcaster-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: fe18970ae2d80ffe10aa672a97407884a157458661bf7d8e73656f846dd21729
+  md5: 0429e2aabe289f24cd3852e5bb45096f
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -38962,16 +38878,17 @@ packages:
   - ros-jazzy-rclcpp-lifecycle
   - ros-jazzy-realtime-tools
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 161309
-  timestamp: 1768981573337
+  size: 161205
+  timestamp: 1771189962115
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-state-interfaces-broadcaster-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 53ece92b8eae438a85fb558170aec959658fab97215d5d6a6e4d48bce53f4c74
   md5: 01d86e05826fa7650b5e581470a00618
@@ -38996,24 +38913,25 @@ packages:
   license: Apache-2.0
   size: 162173
   timestamp: 1768949640474
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: eb971e6dc45338139f9dcc50efe7833b50dbd17eda988aff59a19a58ac7f3bbe
-  md5: c02c27b6b19e833ea428d5014d1157f8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-statistics-msgs-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: 24aabbaa8822137c4e05689b095128997e5a63dfea67d5c810065b60f82be589
+  md5: cd2e472d0a05a1c562d46c0188906bbe
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 109245
-  timestamp: 1768976528840
+  size: 110950
+  timestamp: 1771184613704
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-statistics-msgs-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 3b7be6004e87c13ecd1132007156a63c269bc516fc2ceae67592dc7c32bf7a37
   md5: a1d9a4896cd05b5e5b83d0295c6ea89c
@@ -39031,25 +38949,24 @@ packages:
   license: Apache-2.0
   size: 113664
   timestamp: 1768945528904
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: d643a5d459fd291afdc2f5494598d3f5dbe3a72aa6b151a6d559f505a426c14d
-  md5: f11cc514ac3dba9c6ab35154580cb889
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: a98c031ff4534ed77f5fe1bfefaec05b3c14a02c1bd396cea7321551c19bcae7
+  md5: 2c96e87743f48341ba7a673ee8d0350b
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 340113
-  timestamp: 1768976491799
+  size: 341629
+  timestamp: 1771184569550
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-std-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: d5e9143d57c69479bcb158a6872c377e4620ae53999831fd705eec55ec0bb06e
   md5: 25ca2e404415d356e42c8c628af9f662
@@ -39068,24 +38985,23 @@ packages:
   license: Apache-2.0
   size: 345885
   timestamp: 1768945496162
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 1178f6f924be8ea716f8f4e038d30ee4d6ec03ee6f7a02f25e54fe2399522f7c
-  md5: 97e8c19113d873d62ee44a974510140e
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-std-srvs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 82c1fcaa122e5960b56d06f3b9d7386b514c858f219e5681a413ac6392b53547
+  md5: 1c3ddc036e412c8d1999efe0a7fd557b
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 169027
-  timestamp: 1768976426146
+  size: 169989
+  timestamp: 1771184459197
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-std-srvs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 064816bad8b0c29765d7c1407c24a5fbb648a972f37436091b2453e71714fe85
   md5: 54f1421443c48cf4f1bb4ac855997a52
@@ -39102,9 +39018,9 @@ packages:
   license: Apache-2.0
   size: 173896
   timestamp: 1768945423165
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 9ece2ed3282643bc32aa3e857fd6c85b5352c9b0fb9e621dc745495db17bba92
-  md5: 55bdd60d74d56c5031fabff8c42cdb21
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-steering-controllers-library-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 12633c2b51efbfe36dfde1344fc85e61c11e2967de96d6f3599954210823202a
+  md5: 6cf1c57f7c30439c722aa0d055cd5fd3
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -39124,16 +39040,16 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-geometry-msgs
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 309322
-  timestamp: 1768981563433
+  size: 309316
+  timestamp: 1771189928436
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-steering-controllers-library-4.36.0-np2py312h61f2ce4_14.conda
   sha256: f9305778670d111b4cacde604ee62b6af1f2f5b6c657b04507ea344912c7e481
   md5: 3b9b53f3e16b8d6f192cafae2969d72a
@@ -39165,25 +39081,26 @@ packages:
   license: Apache-2.0
   size: 298676
   timestamp: 1768949624775
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: c5215b34bce939e6cb4b054015857ddef6939d4327ec174a7b44fda001de7f24
-  md5: 62c78b3d674a5b6ab0b4780c5a4521a0
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-stereo-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: c5256ebe3f96362cf35273a312914f6b4b5bcf4b738844154be967693ab5c194
+  md5: 6e7c43694474c179be9e623bd8da2ef3
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 83425
-  timestamp: 1768977193815
+  size: 83700
+  timestamp: 1771185286288
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-stereo-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 61344b9096caf0c43ca3168b60a896c047b07993d6b84be90323c4fac9e6700c
   md5: 1f4e7bdd8305ea1cef5289c6fc6a2ba5
@@ -39202,22 +39119,23 @@ packages:
   license: Apache-2.0
   size: 87654
   timestamp: 1768946104929
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.2.0-np2py312h2ed9cc7_14.conda
-  sha256: 00ec2ddb2c7057456ff05f4a1079990d8d3689f26205d1c1bb8d8ee7575dfaeb
-  md5: 648d58a0debc570a5d74bd15de840c2a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tcb-span-1.2.0-np2py312h2ed9cc7_16.conda
+  sha256: 18c3cefc6ec6a20242417a98c1fedb9b0142175843ef66462861ed5a1ec69847
+  md5: 863d65c8c53646ac67667e6afd340852
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSL-1.0
-  size: 28023
-  timestamp: 1768974414580
+  size: 27782
+  timestamp: 1771181918270
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tcb-span-1.2.0-np2py312h61f2ce4_14.conda
   sha256: 99cdb0f65ad24d85591b97e1180c40623747e7b93a54a4f21e7648d8b5c5f3d0
   md5: fcd0db883fbb1e8e1bd5b82643db45c7
@@ -39234,9 +39152,9 @@ packages:
   license: BSL-1.0
   size: 28021
   timestamp: 1768943359320
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: e8c2685e16710f9e9369cbd39fa2df46d8004e051bd0de0d0f98a74c319c4e50
-  md5: 552df13a86e6e62b07938a1e0cf84b65
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: f15a3f08270a54f62f4f15f07bd513a9b7c9cda4bfa1d5ea688e96c33e156a27
+  md5: 61f124693dc2eb99117f7d7e832f8c06
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39244,16 +39162,17 @@ packages:
   - ros-jazzy-rcutils
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 135237
-  timestamp: 1768976780129
+  size: 135103
+  timestamp: 1771184833100
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-0.36.18-np2py312h61f2ce4_14.conda
   sha256: bcbbc64144cbdd14552d0409027a21786cd9dfa8a9a94c5b9c06b951297e95eb
   md5: 857de20d97f59bba50eabfad35924563
@@ -39274,9 +39193,9 @@ packages:
   license: BSD-3-Clause
   size: 132805
   timestamp: 1768945745479
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 1cf28f7c0aaf9645b12e7001a66be70d7d03663682b95f5fb2b453581e1b5079
-  md5: dbab85a1b3d7fc6e3ad023dc7f9e0096
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-eigen-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: d56ea8de2bd4aab229177551fb0389585c302bbde362ec4c071b6d62316ddb77
+  md5: 3fb5cabe2e6417a842c2756e4252bce1
   depends:
   - eigen
   - python
@@ -39284,17 +39203,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tf2
   - ros-jazzy-tf2-ros
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 46144
-  timestamp: 1768979351035
+  size: 46058
+  timestamp: 1771187727542
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-eigen-0.36.18-np2py312h61f2ce4_14.conda
   sha256: f27e429810a0394d2063f8abae3078951993be2d1702b8c42a63115216584e72
   md5: dfe7173710e5e75bb83937888a460401
@@ -39314,9 +39232,9 @@ packages:
   license: BSD-3-Clause
   size: 45982
   timestamp: 1768947779555
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 815eb482136c17fb0d46e61c5a5195d1eee0e2564ba537b53b1c617313fa84f5
-  md5: d1c567648f14b870f339f5ed922ee91c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-geometry-msgs-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: 488ed824860866430e39025684b6b6b925940fc47b66fec7a4e2fb5110ac7d1d
+  md5: 91c450dc9c4a68b63cbddbdd022afe2a
   depends:
   - numpy
   - python
@@ -39326,17 +39244,16 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-ros
   - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 58124
-  timestamp: 1768979431905
+  size: 57956
+  timestamp: 1771187792812
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-geometry-msgs-0.36.18-np2py312h61f2ce4_14.conda
   sha256: 0e9f2cac3971b8ba74a5d043cec8a8248cfb0fcffe678070058972c00cc7db00
   md5: 938074cf90006b2ac3cf237fea7c27e3
@@ -39359,9 +39276,9 @@ packages:
   license: BSD-3-Clause
   size: 57906
   timestamp: 1768947855685
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 10fb592a2ec32a9c813e1645135ea6e6953fe75be81db22ac1f675f0da32b8a6
-  md5: c579fbfe5683245eeb66f08eb799b5f6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-kdl-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: d7a293fdf24765dac8dc26cbcf692cfdd27a325d58730a0498830ac5210bfba6
+  md5: 5a6b898d2bc8a468401aa3bb332b74f1
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39372,17 +39289,17 @@ packages:
   - ros-jazzy-tf2
   - ros-jazzy-tf2-ros
   - ros-jazzy-tf2-ros-py
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 47574
-  timestamp: 1768979381132
+  size: 47445
+  timestamp: 1771187759703
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-kdl-0.36.18-np2py312h61f2ce4_14.conda
   sha256: 4ade748bbb73d026a5a292be03b637d9f85b728bb9a009a4b308538a0894b296
   md5: c81eb3c15195b86a4ffff7997e43a92b
@@ -39405,26 +39322,26 @@ packages:
   license: BSD-3-Clause
   size: 47420
   timestamp: 1768947830906
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 6ada4a035bb06f3fdf062bfc1c412dcaa6366acc32123527856f0e0eeb58cd6e
-  md5: c56e132c717f298fdba76d20f717839f
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-msgs-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: ba2477f0234a194f8dfabc6b8bac64ea8b8c35bcfa3fb4ae6c9ef7929ec6bbc6
+  md5: 35bd705e093569b548c7c2c6e18271c0
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-geometry-msgs
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 256319
-  timestamp: 1768976737716
+  size: 259096
+  timestamp: 1771184803914
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-msgs-0.36.18-np2py312h61f2ce4_14.conda
   sha256: 7aa53a278b073e09efd802052c77c2c216e4ef4b1bf5ac67fce32096d1d70548
   md5: 07ce9cdbd94090adb271bb78f6ba6a2b
@@ -39443,9 +39360,9 @@ packages:
   license: BSD-3-Clause
   size: 262316
   timestamp: 1768945720961
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 346b604330890f60dc5b7fa4ee066539a5d5138da514e21d99910dc62393cb22
-  md5: 07d49d4419f00e26a8b3892ba3c338ae
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-py-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: 158a742fdc3d0765764804a20bbac0147d1a378c937378b814a624ace096f178
+  md5: 880d62644e3923b9d0ba52749041f5bc
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39454,17 +39371,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rpyutils
   - ros-jazzy-tf2
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 59215
-  timestamp: 1768978478550
+  size: 59029
+  timestamp: 1771186779960
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-py-0.36.18-np2py312h61f2ce4_14.conda
   sha256: 23204df914dd1de499a80ac225a78ac7b1ced2f26ed0519ec11c2a1bd3202068
   md5: f966be3c1eccf4347794141c271cd8d2
@@ -39486,9 +39402,9 @@ packages:
   license: BSD-3-Clause
   size: 57373
   timestamp: 1768947004698
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: e4a14eb8b4db2be77b16647a60f18abf112265f4b8cd56b566023da389fe8fbf
-  md5: 9cda41a6263286bd8cd3a3aabcc2fa70
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: 1b93412e2f42e2caa15d678dc06535fde422e0dc893fef1731504ea661258b84
+  md5: 79c1ac1f5a0bf3e577dc5974ce2a1998
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39501,17 +39417,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tf2
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 467356
-  timestamp: 1768979151034
+  size: 467162
+  timestamp: 1771187510105
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-0.36.18-np2py312h61f2ce4_14.conda
   sha256: bbc457d5ddbac757c48a98a9b40eed7bffe2cacf8b817045ee2382e7d2b57261
   md5: b92a5f0e79e8db6e9488336d3c0fecdc
@@ -39536,9 +39451,9 @@ packages:
   license: BSD-3-Clause
   size: 476237
   timestamp: 1768947607361
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.18-np2py312h2ed9cc7_14.conda
-  sha256: 2b8bac286a18c3b53d97ab4eb01b76f9e7b264bb07269a9296f60c2254547228
-  md5: 42407e60839a4411b733aba21ca52b4c
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tf2-ros-py-0.36.19-np2py312h2ed9cc7_16.conda
+  sha256: b8377da1a81a5a7c916fd240b9f95b92ecc7ce8c89fc9da01bcff59ec3537b78
+  md5: ab6e6e69546459ab0e4db1b0ed1f30d6
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39549,17 +39464,16 @@ packages:
   - ros-jazzy-std-msgs
   - ros-jazzy-tf2-msgs
   - ros-jazzy-tf2-py
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 49024
-  timestamp: 1768978651320
+  size: 48950
+  timestamp: 1771187032239
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tf2-ros-py-0.36.18-np2py312h61f2ce4_14.conda
   sha256: dbd6060f602dfc6e02ac16bfe6b15ac4fdbdc0cde0d3c8436ff54a5218de25c1
   md5: 3c13d217b6af4ebb8dda1c1e72d20086
@@ -39582,25 +39496,25 @@ packages:
   license: BSD-3-Clause
   size: 48959
   timestamp: 1768947173901
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.2-np2py312h2ed9cc7_14.conda
-  sha256: dd3365bb71b174b7f13baae09809b5224cc6b0e950efaf71c671809e632b39e5
-  md5: 0c9bb6718153a3067b97a30018043bb7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tinyxml2-vendor-0.9.2-np2py312h2ed9cc7_16.conda
+  sha256: e4121f0b7f3332dd672dbeb5f0669b3a32d86fdd24892dca300aa69f920995c4
+  md5: d456d54274471e387bdacf4302177dc2
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - tinyxml2
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - tinyxml2 >=11.0.0,<11.1.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   license: Apache-2.0
-  size: 24667
-  timestamp: 1768974418792
+  size: 24397
+  timestamp: 1771181921486
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tinyxml2-vendor-0.9.2-np2py312h61f2ce4_14.conda
   sha256: f1f80db8a1937ee0988d3b69ea14447552e113950b074b37126a529ba2a17bf5
   md5: 21e5f1e297409a4e0b0bc50e0b3d75b4
@@ -39619,23 +39533,23 @@ packages:
   license: Apache-2.0
   size: 24640
   timestamp: 1768943363216
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.2.0-np2py312h2ed9cc7_14.conda
-  sha256: f7c0bd521de3cd90167688a1a0da92165c8484c2b5ce646d89fdf7a26e75119d
-  md5: 9ee33a719200988e64aab56942fc86d8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tl-expected-1.2.0-np2py312h2ed9cc7_16.conda
+  sha256: 101df364f4aec211c553d992f998e5b86b435750c964b62cc230a7997f1af04b
+  md5: f0abf9be2e2c7bbcfae7e036d8860ef9
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: CC0-1.0
-  size: 33945
-  timestamp: 1768974410585
+  size: 33632
+  timestamp: 1771181914921
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tl-expected-1.2.0-np2py312h61f2ce4_14.conda
   sha256: 5c1a6c9939fbcfe527782e4ae5da2a6036fb67e1e656c7b3bf40cf6a2bbace2c
   md5: 63f864594dc3dae701bfede23449502c
@@ -39651,9 +39565,9 @@ packages:
   license: CC0-1.0
   size: 33931
   timestamp: 1768943354914
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-1.3.3-np2py312h2ed9cc7_14.conda
-  sha256: bef40d0ed13d4b4b551d3af5a5e006930076e25c99baa08ba209b6c54cc55498
-  md5: 54c9c3995e99c0f37f26782c5ff2bdd8
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-1.3.3-np2py312h2ed9cc7_16.conda
+  sha256: 9b82a7d202397341c4883fede2720eef7e508423b473afc4d9b166bcdfcd3c5e
+  md5: a34d0d2f3217f2435fee85233929dd28
   depends:
   - python
   - ros-jazzy-rclcpp
@@ -39663,17 +39577,16 @@ packages:
   - ros-jazzy-ros2cli
   - ros-jazzy-rosidl-runtime-py
   - ros-jazzy-topic-tools-interfaces
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 281925
-  timestamp: 1768978684789
+  size: 281791
+  timestamp: 1771187065472
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-topic-tools-1.3.3-np2py312h61f2ce4_14.conda
   sha256: 91b1dabbb418ad1262348ef655e60657575994df94b7e17b3b8fc961a7b586a3
   md5: 5d48e1cc7c2365d5114369fb7606e37f
@@ -39695,25 +39608,25 @@ packages:
   license: Apache-2.0
   size: 283143
   timestamp: 1768947208887
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-interfaces-1.3.3-np2py312h2ed9cc7_14.conda
-  sha256: 250d63ad7e86833ef279966442758a86060a9ce8f0e8318aa04af32d483ff138
-  md5: 0f9219f0e2fda4bb7c14d36497f6e625
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-topic-tools-interfaces-1.3.3-np2py312h2ed9cc7_16.conda
+  sha256: 29cd2fbaa92af4cfe6a1e08c991ff1fb8a86a927f0d3834e9d8066ee1f29f186
+  md5: adfab2791cfe265adcedb09ba11563ee
   depends:
   - python
   - ros-jazzy-builtin-interfaces
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 317876
-  timestamp: 1768976383896
+  size: 319977
+  timestamp: 1771184398356
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-topic-tools-interfaces-1.3.3-np2py312h61f2ce4_14.conda
   sha256: 8bddfd2601a21ce993bd67df30960848d0dc59d177e7b8919ebc3174a69f6939
   md5: d6b2d4540c4047b967cc5ec27f80ecab
@@ -39732,25 +39645,25 @@ packages:
   license: Apache-2.0
   size: 322889
   timestamp: 1768945384345
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.4-np2py312h2ed9cc7_14.conda
-  sha256: 4284a87296e550ffdda07ef91dc0933a215f36248b854c6bdeb1504d76426a58
-  md5: 3292ba5058e700629d2c4c2ca7b0b2a1
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tracetools-8.2.5-np2py312h2ed9cc7_16.conda
+  sha256: f92a36b4678c4b4e34af47829e2c9becbc1f8432bb731e8511f2cfc32e425c93
+  md5: f20a69ef97896548be14b56382af03f9
   depends:
   - lttng-ust
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - libgcc >=14
   - lttng-ust >=2.13.9,<2.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 73002
-  timestamp: 1768975358676
+  size: 72853
+  timestamp: 1771183045095
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tracetools-8.2.4-np2py312h61f2ce4_14.conda
   sha256: 672e58a08771998c829dfc771199a31267f24e7fdf5a919a9e440b684e429c56
   md5: bc14cafb2c35b5118891707421b8838e
@@ -39768,9 +39681,9 @@ packages:
   license: Apache-2.0
   size: 72706
   timestamp: 1768944239397
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: bf3cbbd46f01173280d0b856a5a0ffe6334c80474e23524d0a2ff3a69479ea7c
-  md5: 6a0d989dec3e4b4080b64ddc6fa20ea3
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-trajectory-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 32c540b92233ff6df1307b6004365aeceebe7c801961b3e2d8ddc015782e36a7
+  md5: b4ea107c58e3bb65941c42bd527e50da
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -39778,16 +39691,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 150655
-  timestamp: 1768976857459
+  size: 150710
+  timestamp: 1771184926724
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-trajectory-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: 9094cffd677f273f4b53dd526ab881d67de4961d52a6eb09b46ef22c6f9e1475
   md5: 65d053ceb50a5ae7c02a5a925ebc9c80
@@ -39808,9 +39722,9 @@ packages:
   license: Apache-2.0
   size: 152130
   timestamp: 1768945826381
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 4625d4f157c6bcd52f8e6c9c81c1ac089b86313237bed2b6c928b476aa7feee4
-  md5: 31d6351bfec53a693052c78698c05c4a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 338851f66f1f57315f7daa2572a958b88afa43387a050991b57a2ea172bd3d7f
+  md5: 7ab0612f0bcc434d19c96f6437c7aaf3
   depends:
   - python
   - ros-jazzy-ackermann-msgs
@@ -39829,17 +39743,17 @@ packages:
   - ros-jazzy-std-srvs
   - ros-jazzy-tf2
   - ros-jazzy-tf2-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 321759
-  timestamp: 1768981536803
+  size: 321675
+  timestamp: 1771189919027
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: ed31e94469fe8543b951ca3f8b11beb700784a53f6a6d890a4ecf13e904a33b4
   md5: 38aae0e1a84077c97d83fe0b82ffbdee
@@ -39871,9 +39785,9 @@ packages:
   license: Apache-2.0
   size: 311124
   timestamp: 1768949594957
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 23808880c4a835bbd1f4eb3387bf18f4a96be5deb43798ed6019942bc7eba4ed
-  md5: 5703447e2863744aeff25d9f9ab77f4a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-tricycle-steering-controller-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: dc416f92446e4f1aa62a9d3aa65ed7197ba79724ad9aa534723555525df82822
+  md5: b9af21f873b2fef3a8c6466e8ef5abe7
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -39886,16 +39800,17 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-std-srvs
   - ros-jazzy-steering-controllers-library
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 106410
-  timestamp: 1768982087019
+  size: 106381
+  timestamp: 1771190497328
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-tricycle-steering-controller-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 79cf63d593ab86f028515b7bdf5a46b706356b0870ab5862505fa8e2297261bf
   md5: 55d6daef64417ce14b16b4ce21dd3380
@@ -39920,25 +39835,24 @@ packages:
   license: Apache-2.0
   size: 103959
   timestamp: 1768950081669
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np2py312h2ed9cc7_14.conda
-  sha256: fd118b689b63c4aece70e23cae91b568f9354017da85ced5687d335a1622d4e8
-  md5: f92c8cec2d8183091a8d243314d179f6
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-type-description-interfaces-2.0.3-np2py312h2ed9cc7_16.conda
+  sha256: f327a74f9c752c12a983043f325d75445a29778212faf0cab2ad5ef66dc4857d
+  md5: c07aaa255e38c55d5f92e667596e4b6f
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-runtime
   - ros-jazzy-service-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 232353
-  timestamp: 1768976307478
+  size: 236261
+  timestamp: 1771184301771
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-type-description-interfaces-2.0.3-np2py312h61f2ce4_14.conda
   sha256: 781bbdcab7cf06b4228884311eaf58f06129f58573d33d5238a2b9f1f6846726
   md5: 762ebbb946424c4d0f28835ea25a0cee
@@ -39957,25 +39871,25 @@ packages:
   license: Apache-2.0
   size: 237515
   timestamp: 1768945275430
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np2py312h2ed9cc7_14.conda
-  sha256: cbcc02dd96f1fe9a98a1c533824862445c8f2f350eb97fbaa21a5323972b9e77
-  md5: 82188bc12f938a9d494c18d4c54e0bb9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-uncrustify-vendor-3.0.1-np2py312h2ed9cc7_16.conda
+  sha256: c1c665c890fb4700d2265399f867f8a770fbdc8cd19d976c5e4bbca6acdd9799
+  md5: 892ac4a328bff739a69af59288b6783a
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - uncrustify
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - uncrustify >=0.81.0,<0.82.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - uncrustify >=0.81.0,<0.82.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR GPL-2.0-only
-  size: 23250
-  timestamp: 1768974393518
+  size: 23029
+  timestamp: 1771181915942
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-uncrustify-vendor-3.0.1-np2py312h61f2ce4_14.conda
   sha256: 4f38f4973353affad76a0800e8e48450b225ce8abb3ef424f83dffdd07acb300
   md5: 1e1d4af7375194820d13bf11f44c5045
@@ -39994,24 +39908,24 @@ packages:
   license: Apache-2.0 OR GPL-2.0-only
   size: 23244
   timestamp: 1768943345046
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np2py312h2ed9cc7_14.conda
-  sha256: 92de1c0bd7c860920dea52d301507da4a76ef717655146189784443e2a8b87d1
-  md5: c27db941a29aa3d29bbc4967c6c9b936
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-unique-identifier-msgs-2.5.0-np2py312h2ed9cc7_16.conda
+  sha256: 24080b7f5da6492cf9eeb5bb39372be9c98587a3a0595edd949ce88278d17680
+  md5: 3731565bfd87894cd84caf483c4330ca
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 74062
-  timestamp: 1768976238206
+  size: 73968
+  timestamp: 1771184222918
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-unique-identifier-msgs-2.5.0-np2py312h61f2ce4_14.conda
   sha256: cc23849fbf30653d6cce40cad6f8956208064e23c12cd11068c63cb4b04a345c
   md5: 7b2d842f232e0405af812961ddcadd55
@@ -40028,9 +39942,9 @@ packages:
   license: BSD-3-Clause
   size: 77767
   timestamp: 1768945195869
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np2py312h2ed9cc7_14.conda
-  sha256: cc3d50459aa436eb69955124336e0099a4aabba3abded7bb77c87f1eacdcd624
-  md5: fa8a1e60d54e95f43779457f361e2f1a
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-2.10.0-np2py312h2ed9cc7_16.conda
+  sha256: 1175970b6a9f94c2d69f143d8150feb86d739704501a49a829f5dd0f59d61bba
+  md5: 15875076ee45ccb9adbd8c833a4bca39
   depends:
   - python
   - ros-jazzy-pluginlib
@@ -40039,16 +39953,17 @@ packages:
   - ros-jazzy-urdf-parser-plugin
   - ros-jazzy-urdfdom
   - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 156220
-  timestamp: 1768975901965
+  size: 156100
+  timestamp: 1771183561414
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-2.10.0-np2py312h61f2ce4_14.conda
   sha256: 7b41cd7a07f3b07ddf282df4dd1b94c94ada427e09a5ea0bfad18da3522f3064
   md5: f3f3b1908b552518de2b664b8a308d75
@@ -40070,24 +39985,24 @@ packages:
   license: BSD-3-Clause
   size: 155420
   timestamp: 1768944897611
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np2py312h2ed9cc7_14.conda
-  sha256: 0c5e0e7c836869f8992e59244502e0c3b15d9d3aee2ff9f5568b875d4836b72a
-  md5: 1f2e2ac3c0a47ab3d568e404e9a583fd
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdf-parser-plugin-2.10.0-np2py312h2ed9cc7_16.conda
+  sha256: 14619f9cc1419b0b40a7b20e24b129c146cfc9929310945060c770d382ca76e7
+  md5: d5f8105e04a563f84e7782d0d06033f6
   depends:
   - python
   - ros-jazzy-ros-workspace
   - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 32147
-  timestamp: 1768975332064
+  size: 32040
+  timestamp: 1771183025646
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdf-parser-plugin-2.10.0-np2py312h61f2ce4_14.conda
   sha256: 650e2e2ea5fc5c23bd1577f90b8ac98a6e97126f084298cd1bbbcc68ed57f763
   md5: a4d592f29a631e5157d5c48d1ed323b8
@@ -40105,9 +40020,9 @@ packages:
   license: BSD-3-Clause
   size: 32145
   timestamp: 1768944215196
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_14.conda
-  sha256: c55d7fb615b702ae186ad39f3d484b38f4add0d66b4281680e5f2ebe8201f1e5
-  md5: fb7e257640c55c1cfaf0928b7a5d11c9
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-4.0.1-py312h24bf083_16.conda
+  sha256: 8bffe2f1b132cec0791fbc3fb37e374c977e19b07169058f65cde296361b71ac
+  md5: 4869077169bcb4b2223f9f6a3c2f1f5a
   depends:
   - console_bridge
   - python
@@ -40115,16 +40030,16 @@ packages:
   - ros-jazzy-ros-workspace
   - ros-jazzy-tinyxml2-vendor
   - ros-jazzy-urdfdom-headers
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - tinyxml2
   - urdfdom >=4.0.1,<4.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - console_bridge >=1.0.2,<1.1.0a0
-  - tinyxml2 >=11.0.0,<11.1.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   license: BSD-3-Clause
-  size: 8332
-  timestamp: 1768975460182
+  size: 8188
+  timestamp: 1771183141016
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-4.0.1-py312h9804fc4_14.conda
   sha256: 7af9dbe26228374fb029458e8212cd686a14915ae546d964f399043fca35504e
   md5: 53720abc8c6ba9e5ed7fdbd5eb714741
@@ -40145,19 +40060,19 @@ packages:
   license: BSD-3-Clause
   size: 8206
   timestamp: 1768944349251
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_14.conda
-  sha256: 6d73d9c046db8eda448ae4d9417c236d01431350df2384554c6066d8bb872dda
-  md5: 636dfa139b88e459deba5ae607dbe0ab
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-urdfdom-headers-1.1.2-py312h24bf083_16.conda
+  sha256: 6c9973ed9239a9be710f040b19edb0bd6c2905f3ad0471d1fc0b837edbc6f0d2
+  md5: 4a23df59af0b35f28c3c580d3040ea19
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - urdfdom_headers >=1.1.2,<1.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 7454
-  timestamp: 1768973890125
+  size: 7319
+  timestamp: 1771181329500
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-urdfdom-headers-1.1.2-py312h9804fc4_14.conda
   sha256: d270189fe2fa34c6baa5e3a8ed2965bc5681fbdc91f5930f5a08dab8287a7c37
   md5: 4a0e8cf38a01288e053bc47ee88f12b5
@@ -40171,9 +40086,9 @@ packages:
   license: BSD-3-Clause
   size: 7318
   timestamp: 1768942733104
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.36.0-np2py312h2ed9cc7_14.conda
-  sha256: 5ccb3dc0c4738200eee114d08a283cf6b787c9008f5a665309677d1e86835be5
-  md5: 2e2d5f389227d23ed644e938c141ebe7
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-velocity-controllers-4.37.0-np2py312h2ed9cc7_16.conda
+  sha256: 64d66ab1338111123f7f3c26205671fcd4ff89b82061c9314b4fd0ca4200bc0e
+  md5: 3051165fb6d9cbc1dc0027f46be4f137
   depends:
   - python
   - ros-jazzy-backward-ros
@@ -40181,17 +40096,16 @@ packages:
   - ros-jazzy-pluginlib
   - ros-jazzy-rclcpp
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 78092
-  timestamp: 1768982073595
+  size: 78026
+  timestamp: 1771190483775
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-velocity-controllers-4.36.0-np2py312h61f2ce4_14.conda
   sha256: 83519ec886d7e74b6d377481b1c0b328c972da993fa4b9cdc4ad34f29a813443
   md5: 4f2c06be64ad3ac0e110c30fe589c95e
@@ -40211,9 +40125,9 @@ packages:
   license: Apache-2.0
   size: 79152
   timestamp: 1768950065853
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np2py312h2ed9cc7_14.conda
-  sha256: 8d080fa0488084ea46b1e26b49acc342e3b29076a967e5a4e2b111ef183d1e48
-  md5: eb75c8ffb46841a6d41ed58e4df84a82
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-visualization-msgs-5.3.6-np2py312h2ed9cc7_16.conda
+  sha256: 5df02a243f0f6b6ea8b1950b9a3b27a0c9845b6e8856d8df326127e3564ba961
+  md5: 373fcf67b95eac16b7d98a4d230b4d7a
   depends:
   - python
   - ros-jazzy-builtin-interfaces
@@ -40222,16 +40136,17 @@ packages:
   - ros-jazzy-rosidl-default-runtime
   - ros-jazzy-sensor-msgs
   - ros-jazzy-std-msgs
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 370089
-  timestamp: 1768977161239
+  size: 375661
+  timestamp: 1771185254437
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-visualization-msgs-5.3.6-np2py312h61f2ce4_14.conda
   sha256: f1a963e3dc63a9f111ecbb4ca89bd051f15d5ef994e1bb9cd2925686bb1262f0
   md5: b68e58292c292b051a29adc5ae7d450d
@@ -40252,24 +40167,25 @@ packages:
   license: Apache-2.0
   size: 377931
   timestamp: 1768946078131
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np2py312h2ed9cc7_14.conda
-  sha256: aa9e085b0df02c96335b3b736b14e2c6b5ea7d84c71c986db5f4edbf368a166c
-  md5: 8cd0ab75744b00a294515720398c1d34
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros-jazzy-yaml-cpp-vendor-9.0.1-np2py312h2ed9cc7_16.conda
+  sha256: f1521fd4a5f7f4a18d7d0fd8de01cecfef9db760ba41e52330ed36b5ce2b0808
+  md5: 0cc176abf0fa25a05d7bea4d78eba1f0
   depends:
   - python
   - ros-jazzy-ros-workspace
-  - ros2-distro-mutex 0.13.* jazzy_*
+  - ros2-distro-mutex 0.14.* jazzy_*
   - yaml-cpp
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 23171
-  timestamp: 1768974400024
+  size: 22886
+  timestamp: 1771181913744
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros-jazzy-yaml-cpp-vendor-9.0.1-np2py312h61f2ce4_14.conda
   sha256: efdc3010912ae2520acedb791c8e6f0b15dadc65e0dbc3025bc604d3fb31c51f
   md5: 479dd299dd79cace22899145dcab9f8b
@@ -51441,9 +51357,9 @@ packages:
   license: BSD-3-Clause
   size: 2321
   timestamp: 1753307949132
-- conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.13.0-jazzy_14.conda
-  sha256: c350fd0ee9a1274907cff03137e09f18c08b03b58d886b7a8d622ef4cb8d9a24
-  md5: a9ea72dd3fbe2b854e30c0206323caee
+- conda: https://prefix.dev/robostack-jazzy/linux-64/ros2-distro-mutex-0.14.0-jazzy_16.conda
+  sha256: 1403aad956b039813e19bf600d1af15acb6e45eac9a1da365ff5eba35c0913d9
+  md5: 05725f6f4ec3e017f1dc8b1a435b29a4
   constrains:
   - libboost 1.88.*
   - libboost-devel 1.88.*
@@ -51452,8 +51368,8 @@ packages:
   - libprotobuf 6.31.1.*
   - vtk 9.5.2.*
   license: BSD-3-Clause
-  size: 2337
-  timestamp: 1768973793122
+  size: 2334
+  timestamp: 1771181243372
 - conda: https://prefix.dev/robostack-jazzy/linux-aarch64/ros2-distro-mutex-0.13.0-jazzy_14.conda
   sha256: 7bcd0d3084b6f576d65405104791337817bed29f790518dfb239a35d20cc719b
   md5: 3efd33d9f8c82481ec2089ea2ffb365f
@@ -52291,18 +52207,6 @@ packages:
   purls: []
   size: 2750235
   timestamp: 1742907589246
-- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-3.1.2-hecca717_0.conda
-  sha256: 34e2e9c505cd25dba0a9311eb332381b15147cf599d972322a7c197aedfc8ce2
-  md5: 9859766c658e78fec9afa4a54891d920
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 2741200
-  timestamp: 1756086702093
 - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
   sha256: e5e036728ef71606569232cc94a0480722e14ed69da3dd1e363f3d5191d83c01
   md5: 9a6117aee038999ffefe6082ff1e9a81
@@ -52326,17 +52230,6 @@ packages:
   purls: []
   size: 1975547
   timestamp: 1742910351387
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-3.1.2-hfae3067_0.conda
-  sha256: e4b482062da7cf259f21465274a0f3613d1dbd8ea649aca6072625f5038ac40d
-  md5: 7602d3004ed53b3f8e5e0e04e5de4de7
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 2106252
-  timestamp: 1756090698097
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-4.0.0-hfae3067_0.conda
   sha256: 8774d84e778d7dbf0d33efa17f873169c33886425bfc2dc0180a832ef236e711
   md5: 5e49aa65798c6ca640b1a784430f2a30
@@ -52424,7 +52317,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/tifffile?source=compressed-mapping
+  - pkg:pypi/tifffile?source=hash-mapping
   size: 183339
   timestamp: 1769690244546
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
@@ -52574,46 +52467,46 @@ packages:
   - pkg:pypi/tqdm?source=compressed-mapping
   size: 94132
   timestamp: 1770153424136
-- conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.1-pyh7b2049a_0.conda
-  sha256: c2e83bf6645f92f26b84e259453a23b7c726fa5df66d2ea9f42d523a88142ce3
-  md5: 0c40870078c5ffc1f0f190423994194b
+- conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.2-pyh7b2049a_0.conda
+  sha256: 263b8c2aa2a109f039d1747c455abeb9781643843be0e757d40dfc16dd82c140
+  md5: 2bda787a4c863943c063a4b12916db69
   depends:
   - numpy
   - python >=3.10
   constrains:
+  - xxhash
   - jsonschema
-  - meshio
-  - rtree
-  - svg.path
-  - lxml
-  - pillow
-  - setuptools
+  - mapbox_earcut
   - networkx
   - scikit-image
-  - msgpack-python
-  - xxhash
-  - pyglet
   - pycollada
-  - scipy
-  - chardet
-  - mapbox_earcut
-  - shapely
-  - psutil
-  - requests
-  - sympy
+  - msgpack-python
   - colorlog
+  - pillow
+  - rtree
+  - svg.path
+  - meshio
+  - shapely
+  - requests
+  - psutil
+  - pyglet
+  - sympy
+  - lxml
+  - setuptools
+  - chardet
+  - scipy
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/trimesh?source=compressed-mapping
-  size: 602357
-  timestamp: 1768770319835
-- conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
-  sha256: 591e03a61b4966a61b15a99f91d462840b6e77bf707ecb48690b24649fee921a
-  md5: 8b2613dbfd4e2bc9080b2779b53fc210
+  size: 602612
+  timestamp: 1770757644637
+- conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.0-pyhd8ed1ab_0.conda
+  sha256: 821e23d73e12e99ee5c722120b2c4cf164191adb56fb96a96bd725b2d60d9b10
+  md5: b514a7bd078dcb4520a1aea4d14c5a3a
   depends:
   - importlib-metadata >=3.6
-  - python >=3.9
+  - python >=3.10
   - typing-extensions >=4.10.0
   - typing_extensions >=4.14.0
   constrains:
@@ -52622,8 +52515,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/typeguard?source=hash-mapping
-  size: 35158
-  timestamp: 1750249264892
+  size: 37088
+  timestamp: 1771119690965
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -52695,9 +52588,9 @@ packages:
   purls: []
   size: 636572
   timestamp: 1747514438016
-- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py311h49ec1c0_1.conda
-  sha256: d3c0e3ca6eb49095159d8c78970a279a30b98863eff5c3eeb037296d2e1d1670
-  md5: 5e6d4026784e83c0a51c86ec428e8cc8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
+  sha256: 2bd8ee058dc98e614003591eb221a8b08449768b13aebe76dad8528bf0f5f88b
+  md5: 2889f0c0b6a6d7a37bd64ec60f4cc210
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -52707,11 +52600,11 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/unicodedata2?source=compressed-mapping
-  size: 408540
-  timestamp: 1763054987009
-- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
-  sha256: 3c812c634e78cec74e224cc6adf33aed533d9fe1ee1eff7f692e1f338efb8c5b
-  md5: a0b8efbe73c90f810a171a6c746be087
+  size: 409682
+  timestamp: 1770909108616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+  sha256: 895bbfe9ee25c98c922799de901387d842d7c01cae45c346879865c6a907f229
+  md5: 0b6c506ec1f272b685240e70a29261b8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -52720,12 +52613,12 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/unicodedata2?source=hash-mapping
-  size: 408399
-  timestamp: 1763054875733
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py311h19352d5_1.conda
-  sha256: da8a1f7a941d808edfac8ce1d819ccce630be740c4854954a30cdd75d18832d1
-  md5: 4a55814831e0ec9be84ccef6aed798c1
+  - pkg:pypi/unicodedata2?source=compressed-mapping
+  size: 410641
+  timestamp: 1770909099497
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py311h19352d5_0.conda
+  sha256: 79d7202c12505e4bf5628bc8013cfd069b118fa2c5a89f698774318a24e9ce24
+  md5: 22df73a2e312d88d56f6986e0a287edb
   depends:
   - libgcc >=14
   - python >=3.11,<3.12.0a0
@@ -52735,11 +52628,11 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/unicodedata2?source=hash-mapping
-  size: 408936
-  timestamp: 1763055077394
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.0-py312hcd1a082_1.conda
-  sha256: c85105d976dba34606c528698e50a518d68ac7113191e590b0546d0df8d10253
-  md5: 24e0209609c4372af491052b6c637b2e
+  size: 409417
+  timestamp: 1770909164934
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
+  sha256: c4bd27513664fb76665526e7f7c14ab103ede07558941d7631d9980fa92ab8df
+  md5: c72e6a7950d859966ae790cc844fcfdf
   depends:
   - libgcc >=14
   - python >=3.12,<3.13.0a0
@@ -52748,9 +52641,9 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/unicodedata2?source=hash-mapping
-  size: 408819
-  timestamp: 1763055001055
+  - pkg:pypi/unicodedata2?source=compressed-mapping
+  size: 409407
+  timestamp: 1770909146204
 - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-hae71d53_3.conda
   sha256: 70b1e7322bf6306de6186e91fb87c15f7ba5c1aeb6d0fd31780e088c42025fc4
   md5: a7830d1b7ade9d3f8c35191084fe7022
@@ -52803,6 +52696,18 @@ packages:
   purls: []
   size: 19201
   timestamp: 1726152409175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-2.1.0-hb700be7_0.conda
+  sha256: 20a4f01ac6f784c60961e4f5711bfe37495611bca5519951e70e0211922bb4cd
+  md5: dc23a5af59a77b43cc2d681d106f6366
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19396
+  timestamp: 1771081077146
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.0.6-hdd96247_2.tar.bz2
   sha256: 4de95999f7b4f3ea0cac350bce7cb6ae826d87fc1c5f24a97c4e60c85fb902cf
   md5: 63ae064ec6bfbbfb41cfcfa074c78a2a
@@ -52825,6 +52730,17 @@ packages:
   purls: []
   size: 19152
   timestamp: 1726152459234
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-2.1.0-hfefdfc9_0.conda
+  sha256: 33b03624d704c15302391b0c7ed92eccaf659089f20b1c7fa75d564527fae82f
+  md5: 619a9206ec0327ee59d9886a4d6be559
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19391
+  timestamp: 1771082230956
 - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
   sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
   md5: 9272daa869e03efe68833e3dc7a02130
@@ -52862,6 +52778,7 @@ packages:
   - yourdfpy >=0.0.53,<1.0.0
   - zstandard >=0.20.0,<1.0.0
   license: Apache-2.0
+  license_family: APACHE
   purls:
   - pkg:pypi/viser?source=hash-mapping
   size: 4502280
@@ -53217,29 +53134,29 @@ packages:
   purls: []
   size: 28701
   timestamp: 1741897678254
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
-  sha256: 51909270b1a6c5474ed3978628b341b4d4472cd22610e5f22b506855a5e20f67
-  md5: db038ce880f100acc74dba10302b5630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - libxcb >=1.17.0,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 835896
-  timestamp: 1741901112627
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
-  sha256: 452977d8ad96f04ec668ba74f46e70a53e00f99c0e0307956aeca75894c8131d
-  md5: 3df132f0048b9639bc091ef22937c111
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+  sha256: cf886160e2ff580d77f7eb8ec1a77c41c2c5b05343e329bc35f0ddf40b8d92ab
+  md5: 22dd10425ef181e80e130db50675d615
   depends:
-  - libgcc >=13
+  - libgcc >=14
   - libxcb >=1.17.0,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 864850
-  timestamp: 1741901264068
+  size: 869058
+  timestamp: 1770819244991
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
   sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
   md5: b2895afaf55bf96a8c8282a2e47a5de0

--- a/pixi.lock
+++ b/pixi.lock
@@ -281,6 +281,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-h82cca05_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-h27a6a8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -669,6 +670,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-habe6132_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h0922659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -1110,6 +1112,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-h82cca05_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-h27a6a8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/netifaces-0.11.0-py311h49ec1c0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
@@ -1801,6 +1804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-habe6132_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h0922659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/netifaces-0.11.0-py311h19352d5_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
@@ -2515,6 +2519,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-h82cca05_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-h27a6a8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -3241,6 +3246,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-habe6132_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h0922659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -3984,6 +3990,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-h82cca05_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-h27a6a8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -4715,6 +4722,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-habe6132_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h0922659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
@@ -16734,6 +16742,19 @@ packages:
   - pkg:pypi/munkres?source=hash-mapping
   size: 15851
   timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
+  sha256: 70068c7533a77d6d06a2e26599573a08bf3f80e8d0c967ad4ba36b7ef2ce617f
+  md5: 17c9b59ad7308f779ba0e8506c71ae76
+  depends:
+  - python >=3.10
+  constrains:
+  - nanobind-abi ==17
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nanobind?source=hash-mapping
+  size: 181693
+  timestamp: 1765369366075
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7

--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,7 @@ lttng-ust = ">=2.13.9,<3"
 # We could fix that: https://robostack.github.io/Contributing.html
 pinocchio = ">=3.7.0,<4"
 eigen = ">=3.4.0,<4"
+nanobind = ">=2.8.0,<3"
 
 [pypi-dependencies]
 xacro = ">=2.1.1, <3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -64,6 +64,9 @@ nanobind = ">=2.8.0,<3"
 xacro = ">=2.1.1, <3"
 pycollada = ">=0.9.2, <0.10"
 
+# For viser
+nodeenv = ">=1.9.1"
+
 [activation.env]
 # Ensures the linker knows where to look for conda managed packages
 LIBRARY_PATH = "${CONDA_PREFIX}/lib:${LIBRARY_PATH}"

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -68,7 +68,7 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(
   bindings
   STABLE_ABI
-  NB_SHARED
+  NB_STATIC
   NB_SUPPRESS_WARNINGS
   src/bindings.cpp
 )

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(pinocchio REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(tl_expected REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
@@ -79,9 +80,9 @@ set_property(TARGET bindings PROPERTY CXX_STANDARD 20)
 target_link_libraries(bindings PRIVATE
   roboplan_ros_cpp
   roboplan::roboplan
-  roboplan::expected
   roboplan_bindings::roboplan_bindings_utils
   ${rosidl_generator_cpp_LIBRARIES}
+  tl_expected::tl_expected
 )
 ament_python_install_package(${PROJECT_NAME})
 ament_get_python_install_dir(PYTHON_INSTALL_DIR)

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -68,7 +68,8 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(
   bindings
   STABLE_ABI
-  NB_STATIC
+  NB_SHARED
+  NB_SUPPRESS_WARNINGS
   src/bindings.cpp
 )
 target_include_directories(bindings PUBLIC

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -14,20 +14,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
-# For nanobind python bindings
-find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
-find_package(roboplan_bindings REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(rosidl_generator_cpp REQUIRED)
-include(FetchContent)
-FetchContent_Declare(
-  nanobind
-  GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-  GIT_TAG v2.9.2
-)
-FetchContent_MakeAvailable(nanobind)
-
 add_library(roboplan_ros_cpp SHARED
     src/type_conversions.cpp
 )
@@ -63,6 +49,19 @@ install(
   INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
+
+# For nanobind python bindings
+find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+find_package(roboplan_bindings REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_generator_cpp REQUIRED)
+
+# Detect the installed nanobind package and import it into CMake
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
 
 # Compile the nanobind python bindings for type conversions.
 nanobind_add_module(

--- a/roboplan_ros_cpp/package.xml
+++ b/roboplan_ros_cpp/package.xml
@@ -16,8 +16,9 @@
   <depend>roboplan_bindings</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <!-- While nanobind-dev is available from rosdistro the apt package installs it in -->
-  <!-- inconsistent places. Users should ensure nanobind is just installed with pip. -->
+  <!-- While nanobind-dev is available from rosdistro the apt package is very out of date. -->
+  <!-- Nanobind should only be installed manually from pip until this is released in a sync: -->
+  <!-- https://github.com/ros/rosdistro/pull/49894 -->
   <!-- <depend>nanobind-dev</depend> -->
   <depend>pinocchio</depend>
   <depend>rosidl_generator_cpp</depend>

--- a/roboplan_ros_cpp/package.xml
+++ b/roboplan_ros_cpp/package.xml
@@ -16,7 +16,9 @@
   <depend>roboplan_bindings</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>nanobind-dev</depend>
+  <!-- While nanobind-dev is available from rosdistro the apt package installs it in -->
+  <!-- inconsistent places. Users should ensure nanobind is just installed with pip. -->
+  <!-- <depend>nanobind-dev</depend> -->
   <depend>pinocchio</depend>
   <depend>rosidl_generator_cpp</depend>
   <depend>sensor_msgs</depend>

--- a/roboplan_ros_cpp/package.xml
+++ b/roboplan_ros_cpp/package.xml
@@ -20,6 +20,7 @@
   <depend>pinocchio</depend>
   <depend>rosidl_generator_cpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>tl_expected</depend>
   <depend>trajectory_msgs</depend>
   <depend>tf2_eigen</depend>
 

--- a/roboplan_ros_cpp/package.xml
+++ b/roboplan_ros_cpp/package.xml
@@ -16,6 +16,7 @@
   <depend>roboplan_bindings</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>nanobind-dev</depend>
   <depend>pinocchio</depend>
   <depend>rosidl_generator_cpp</depend>
   <depend>sensor_msgs</depend>

--- a/roboplan_ros_py/test/test_kinematics.py
+++ b/roboplan_ros_py/test/test_kinematics.py
@@ -27,7 +27,8 @@ def ik_solver(test_scene: Scene) -> RoboPlanIK:
     options.max_iters = 100
     options.step_size = 0.25
     options.damping = 0.001
-    options.max_error_norm = 0.0005
+    options.max_linear_error_norm = 0.001
+    options.max_angular_error_norm = 0.001
     options.check_collisions = False
 
     return RoboPlanIK(


### PR DESCRIPTION
Can pull it in from [rosdep/pip](https://github.com/ros/rosdistro/blob/ae825bb840868f36766840bcc2c4b089ba479afd/rosdep/base.yaml#L8050), rather than fetching it on the fly.

https://nanobind.readthedocs.io/en/latest/building.html#finding-nanobind

And while I'm at it bumping dependencies and the submodule.

