### PR TITLE
Repro Kilted Python Issue

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3234,8 +3234,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -3245,11 +3245,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.0-py312h0b2cbc4_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h4238392_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19-19.1.7-default_h99862b1_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19.1.7-default_h36abe19_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang_impl_linux-64-19.1.7-default_hbd963a2_8.conda
@@ -3271,10 +3271,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-mixin-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
@@ -3289,11 +3289,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.5-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py312h8a5da7c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.20.0-py312h014360a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.20.1-py312h014360a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
@@ -3301,14 +3302,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.12.0-np2py312h12264d8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -3323,16 +3324,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.1-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h49ef1fa_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h862fb80_21.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h862fb80_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/git-2.53.0-pl5321h6d3cee1_0.conda
@@ -3345,13 +3345,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.8.11-h18acefa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.2-h8b86629_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.51-ha5ea40c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.52-ha5ea40c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h59c6875_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h98b7566_23.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake4-4.2.0-h83e9d05_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-8.2.0-h91c16d2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-math8-python-8.2.0-py312hc0cb2ee_2.conda
@@ -3359,7 +3359,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-tools2-2.0.3-h89235b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-utils3-3.1.1-h67c99bb_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.1-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
@@ -3369,8 +3369,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.19-he45328a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
@@ -3379,14 +3379,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.6-gpl_hc2c16d8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libattr-2.5.2-hb03c661_1.conda
@@ -3400,14 +3400,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-7_h8e06fc2_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_h99862b1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.2-h969b668_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
@@ -3415,12 +3415,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.2-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.2-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_118.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
@@ -3447,12 +3447,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-7_h8876d29_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-hf7376ad_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.1-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.2-hc2fc477_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
@@ -3464,18 +3463,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.2-hb80d175_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_hfcc3fd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_h807e49d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2025.09.18-h6a3126d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_118.conda
@@ -3485,7 +3484,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liburcu-0.14.0-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
@@ -3493,14 +3492,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lld-19.1.7-hef48ded_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.3-h4922eb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lttng-ust-2.13.9-hf5eda4c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h63ddcf0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.0-py312h63ddcf0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
@@ -3515,7 +3514,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mimalloc-3.2.7-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mold-2.40.4-h122c784_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.20.0-py312h4c3975b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.21.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.8.2-h5a610fb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.8.2-hc1b3267_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
@@ -3527,20 +3526,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.10.0-h84d6215_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.7-h40f6f1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.10-h9f1635d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.27.0-h8d634f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
@@ -3551,20 +3550,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pybullet-3.25-py312hf49885f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py312h50ac2ff_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py312h50ac2ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
@@ -3574,275 +3573,276 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hc240232_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-hb82b983_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.0-pl5321h16c4a6b_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.8.3-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.11.3-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.11.3-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.11.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigenpy-3.12.0-np2py312h2e7a0af_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.6.0-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.11.3-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hpp-fcl-3.0.2-np2py312h60381d3_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.11.3-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.12.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.12.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osqp-vendor-0.2.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.6.0-np2py312h2c89a96_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pinocchio-3.9.0-np2py312hfc2d069_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.9-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.7.1-np2py312h31007e0_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.2.0-np2py312h88103e5_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.11-np2py312h4f3ad64_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.11-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.11-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.11-np2py312hf6702ba_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.11-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.11-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.11-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.6-np2py312h6021aa6_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.4-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.2.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.6-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.2.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-1.4.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-xacro-2.1.1-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.8.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.8.3-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.12.0-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.12.0-np2py312h2c89a96_18.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.12.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigenpy-3.12.0-np2py312h23fe623_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.7.1-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.12.0-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hpp-fcl-3.0.2-np2py312h60381d3_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.12.0-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.13.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.13.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osqp-vendor-0.2.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.7.1-np2py312h2c89a96_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pinocchio-3.9.0-np2py312h402d539_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.10-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.7.1-np2py312h31007e0_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.3.0-np2py312h88103e5_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.12-np2py312h4f3ad64_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.12-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.12-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.12-np2py312hf6702ba_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.12-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.12-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.12-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h9e410fd_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.7-np2py312h6021aa6_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.5-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.2.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h3ba0a76_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.6-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.2.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-1.4.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-xacro-2.1.1-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.14.0-kilted_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.4.8-h498564d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-4.0.2-h95e6935_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.10.0-h159367c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
@@ -3852,27 +3852,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-h04a0ce9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-h04a0ce9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.3-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.5-pyh7b2049a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-4.0.1-h8631160_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.24-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-15.0.1-py312h5253ce2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -3896,7 +3896,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.3.1-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.18-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.19-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
@@ -3907,8 +3907,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yourdfpy-0.0.57-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
@@ -3927,8 +3927,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.2-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zstd-1.3.0-py312h3d8e7d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.2.0-hd651790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.2.0-py312hac7b6a9_1.conda
@@ -3938,11 +3938,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.0-py312h007ed8f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h15c444b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py312h1b372e3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-19-19.1.7-default_he95a3c9_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-19.1.7-default_h395f21b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang_impl_linux-aarch64-19.1.7-default_h78643bd_8.conda
@@ -3964,10 +3964,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-mixin-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.4.0-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
@@ -3982,11 +3982,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.3-py312hf18b547_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coreutils-9.5-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.13.5-py312hd077ced_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.20.0-py312h5677ec4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cpp-expected-1.3.1-hdc560ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.20.1-py312h5677ec4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py312hf80642e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.7-py312hf80642e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.16.2-h70963c4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
@@ -3994,14 +3995,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.4.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h7ac5ae9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.12.0-np2py312he82bf0d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.194-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.3.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-builtins-3.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-comprehensions-3.17.0-pyhd8ed1ab_0.conda
@@ -4016,15 +4017,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.17.1-hba86a56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.62.0-py312ha4530ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.62.1-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-hfe23055_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.2-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-hcedddb3_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0139441_21.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.5-h90308e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0139441_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.6-h90308e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/git-2.53.0-pl5321h5dcfaa0_0.conda
@@ -4037,13 +4038,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.8.11-hfe111f1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-14.1.2-h45e821f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.11-hd6b5e5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.11-hf552038_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.17.0-h17cf362_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.51-h75d4e7a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.52-h75d4e7a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-ha48bfc4_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h86d4696_23.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-cmake4-4.2.0-h4d22069_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-8.2.0-hb1c1663_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-math8-python-8.2.0-py312ha2f5aa3_2.conda
@@ -4051,7 +4052,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-tools2-2.0.3-hd91f489_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gz-utils3-3.1.1-h2347e33_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.1.1-h1134a53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.0-h1134a53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
@@ -4061,8 +4062,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.2.2-h92288e7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.19-h3640754_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.9-h850eeee_1.conda
@@ -4071,14 +4072,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.5.0-py312h1683e8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.18-h9d5b58d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.6-gpl_hbe7d12b_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.7-gpl_hbe7d12b_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.25.1-h5e0f5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libattr-2.5.2-he30d5cf_1.conda
@@ -4092,14 +4093,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-hf9559e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-7_h8345d7a_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.7-default_he95a3c9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.8-default_he95a3c9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-22.1.0-default_h94a09a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp22.1-22.1.3-default_he95a3c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-22.1.3-default_h94a09a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.2-h244ce10_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
@@ -4107,12 +4108,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.4-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.5-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.2-h8af1aa0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.2-hdae7a39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_118.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_18.conda
@@ -4139,12 +4140,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.12.2-default_ha470c98_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.8-h99ff5a0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.2-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-7_hfc05e43_netlib.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.7-hfd2ba90_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm21-21.1.8-hfd2ba90_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm22-22.1.1-hfd2ba90_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.2-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm22-22.1.3-hfd2ba90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmicrohttpd-1.0.2-h3543b8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
@@ -4156,18 +4156,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.2-hf8816c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.3-h7d4fc67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h6af2d16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h588e91d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2025.09.18-h0bec7a6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.52.0-h10b116e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_118.conda
@@ -4177,7 +4177,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.1-hdb009f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburcu-0.14.0-h0a1ffab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42-h1022ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvulkan-loader-1.4.341.0-h8b8848b_0.conda
@@ -4185,14 +4185,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.13.1-h3c6a4c8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.2-h79dcc73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.2-h825857f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h79dcc73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h869d058_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.43-h6700d25_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lld-19.1.7-hd253d04_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-22.1.0-he40846f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-22.1.3-he40846f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lttng-ust-2.13.9-h8d236e2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-6.0.2-py312hfe2c7ef_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-6.1.0-py312hfe2c7ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-4.4.5-py312he78555a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lzo-2.10-h80f16a2_1002.conda
@@ -4207,7 +4207,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mimalloc-3.2.7-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mold-2.40.4-h4c4c02a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/msgspec-0.20.0-py312hcd1a082_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/msgspec-0.21.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.8.2-h5fb23a2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.8.2-h35f29ae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
@@ -4219,20 +4219,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.118-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py312h6615c27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/octomap-1.10.0-h17cf362_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.7-hd0c962a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.10-hda3a014_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.3-h55827e0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.27.0-h55827e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.13-h2fb54aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.2-h546c87b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.3-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.26.2-h376a255_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/patch-2.8-he30d5cf_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/perl-5.32.1-7_h31becfc_perl5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.2.0-py312h3b21937_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
@@ -4243,20 +4243,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.15-h6ef32b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-hcf98165_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybullet-3.25-py312h88173f1_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.10.2-py312hfc1e6cc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.0-py312hfc1e6cc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.13-h91f4b29_0_cpython.conda
@@ -4266,275 +4266,276 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-h5343e53_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-ha9b3be2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.11.0-pl5321h598db47_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-action-msgs-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-actionlib-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-core-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-python-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-test-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-version-2.7.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-copyright-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cppcheck-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cpplint-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-flake8-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-cpp-1.11.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-python-1.11.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-auto-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-common-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-package-0.17.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-pep257-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-uncrustify-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-xmllint-0.19.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-builtin-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-class-loader-2.8.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-common-interfaces-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-composition-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.7.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.8.3-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.11.3-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.11.3-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.11.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-cyclonedds-0.10.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigenpy-3.12.0-np2py312h3e490f4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastcdr-2.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastdds-3.2.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.6.0-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.6.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry2-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gmock-vendor-1.15.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gtest-vendor-1.15.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.11.3-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hpp-fcl-3.0.2-np2py312hd7e41bc_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-posh-2.0.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.11.3-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.12.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.12.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-keyboard-handler-0.4.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-3.8.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-ros-0.28.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-3.8.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ros-0.28.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-xml-3.8.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-yaml-3.8.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-liblz4-vendor-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libstatistics-collector-2.0.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libyaml-vendor-1.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mcap-vendor-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-nav-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osqp-vendor-0.2.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osrf-pycommon-2.1.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.6.0-np2py312h8b5252a_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pinocchio-3.9.0-np2py312h66a98ff_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pluginlib-5.6.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-10.1.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-action-10.1.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312ha677571_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-29.5.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-action-29.5.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-components-29.5.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclpy-9.1.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcpputils-2.13.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcutils-6.9.9-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.7.1-np2py312hbd2122f_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-7.8.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-1.1.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-dds-common-5.0.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-3.0.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-security-common-7.8.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-base-0.12.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-core-0.12.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-environment-4.3.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-workspace-1.0.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2action-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2bag-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2component-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2doctor-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2interface-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2launch-0.28.5-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2lifecycle-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2multicast-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2node-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2param-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2pkg-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2plugin-5.6.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2run-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2service-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2topic-0.38.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-py-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-transport-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-adapter-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cli-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cmake-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-parser-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rpyutils-0.6.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.2.0-np2py312hcab10f8_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.11-np2py312h617ce90_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.11-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.11-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.11-np2py312h4ccd639_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.11-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.11-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.11-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.6-np2py312h287f2fd_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-service-msgs-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-shape-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-spdlog-vendor-1.7.0-np2py312ha677571_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-0.15.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-cmake-0.15.4-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-statistics-msgs-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-srvs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-stereo-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.2.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-bullet-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-tools-0.41.6-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.2.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-1.4.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-visualization-msgs-5.5.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-xacro-2.1.1-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_15.conda
-      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.13.0-kilted_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.4-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-action-msgs-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-actionlib-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-core-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-python-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-test-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-version-2.7.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-copyright-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cppcheck-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cpplint-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-flake8-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-cpp-1.11.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-python-1.11.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-auto-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-common-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-package-0.17.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-pep257-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-uncrustify-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-xmllint-0.19.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-builtin-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-class-loader-2.8.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-common-interfaces-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-composition-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.8.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.8.3-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.12.0-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.12.0-np2py312h8b5252a_18.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.12.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-cyclonedds-0.10.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigenpy-3.12.0-np2py312ha1f14ce_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastcdr-2.3.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastdds-3.2.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.7.1-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry2-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gmock-vendor-1.15.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gtest-vendor-1.15.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.12.0-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hpp-fcl-3.0.2-np2py312hd7e41bc_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-posh-2.0.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.12.0-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.13.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.13.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-keyboard-handler-0.4.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-3.8.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-ros-0.28.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-3.8.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ros-0.28.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-xml-3.8.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-yaml-3.8.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-liblz4-vendor-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libstatistics-collector-2.0.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libyaml-vendor-1.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mcap-vendor-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-nav-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osqp-vendor-0.2.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osrf-pycommon-2.1.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.7.1-np2py312h8b5252a_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pinocchio-3.9.0-np2py312h2f67575_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pluginlib-5.6.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-10.1.4-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-action-10.1.4-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312ha677571_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-29.5.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-action-29.5.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-components-29.5.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclpy-9.1.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcpputils-2.13.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcutils-6.9.10-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.7.1-np2py312hbd2122f_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-7.8.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-1.1.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-dds-common-5.0.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-3.0.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-security-common-7.8.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-base-0.12.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-core-0.12.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-environment-4.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-workspace-1.0.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2action-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2bag-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2component-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2doctor-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2interface-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2launch-0.28.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2lifecycle-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2multicast-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2node-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2param-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2pkg-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2plugin-5.6.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2run-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2service-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2topic-0.38.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-py-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-transport-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-adapter-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cli-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cmake-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-parser-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rpyutils-0.6.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.3.0-np2py312hcab10f8_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.12-np2py312h617ce90_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.12-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.12-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.12-np2py312h4ccd639_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.12-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.12-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.12-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h14a8626_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.7-np2py312h287f2fd_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-service-msgs-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-shape-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-spdlog-vendor-1.7.0-np2py312ha677571_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-0.15.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-cmake-0.15.5-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-statistics-msgs-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-srvs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-stereo-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.2.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-bullet-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h78fd680_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-tools-0.41.6-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.2.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-1.4.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-visualization-msgs-5.5.2-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-xacro-2.1.1-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_17.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.14.0-kilted_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.4.8-h3df7994_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-4.0.2-h706e587_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.10.0-h112f5b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312he5b0e10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
@@ -4544,27 +4545,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.17.0-h9f97df7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.52.0-hf1c7be2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.0-he8854b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.3.0-hfefdfc9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-11.0.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.3-py312hefbd42c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.5-py312hefbd42c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.3-pyh7b2049a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.11.5-pyh7b2049a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.35-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-4.0.1-hcc88bc6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-1.1.2-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/viser-1.0.24-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.24.0-h4f8a99f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/websockets-15.0.1-py312hd41f8a7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
@@ -4588,7 +4589,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.6-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.3.1-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.18-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.19-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.5-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
@@ -4599,8 +4600,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yourdfpy-0.0.57-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-ng-2.3.3-ha7cb516_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.25.0-py312hd41f8a7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
@@ -4958,16 +4959,6 @@ packages:
   purls: []
   size: 4683754
   timestamp: 1774197535605
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
-  sha256: 4826f97d33cbe54459970a1e84500dbe0cccf8326aaf370e707372ae20ec5a47
-  md5: dec96579f9a7035a59492bf6ee613b53
-  depends:
-  - binutils_impl_linux-64 2.45.1 default_hfdba357_101
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 36060
-  timestamp: 1770267177798
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
   sha256: 78a58d523d072b7f8e591b8f8572822e044b31764ed7e8d170392e7bc6d58339
   md5: 2a307a17309d358c9b42afdd3199ddcc
@@ -4978,16 +4969,6 @@ packages:
   purls: []
   size: 36304
   timestamp: 1774197485247
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_101.conda
-  sha256: 4ed3cf8af327b1c8b7e71433c98eb0154027e07b726136e81235276e9025489a
-  md5: 99924e610d9960dc3d8b865614787cec
-  depends:
-  - binutils_impl_linux-aarch64 2.45.1 default_h5f4c503_101
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 36223
-  timestamp: 1770267249899
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_102.conda
   sha256: ad076ff5f3d7734c48ea241a99c16336c278081a5f7a523329d0d5956723c481
   md5: 68d0661516aed9cab68d2ad6e287941f
@@ -5244,30 +5225,6 @@ packages:
   purls: []
   size: 927045
   timestamp: 1766416003626
-- conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.0-py312h0b2cbc4_5.conda
-  sha256: c3688c19c130d7ab9a83b69ec11cbeeccdf1d6b4c2628da53e30387c6a369038
-  md5: c3bad559671e5c75631270590eede469
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ipopt >=3.14.19,<3.14.20.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libblasfeo >=0.1.4.2,<0.1.5.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libfatrop >=0.0.4,<0.0.5.0a0
-  - libgcc >=14
-  - liblapack >=3.9.0,<4.0a0
-  - libosqp >=1.0.0,<1.0.1.0a0
-  - libstdcxx >=14
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/casadi?source=hash-mapping
-  size: 6577661
-  timestamp: 1756987139139
 - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h4238392_2.conda
   sha256: 7f3bc5e1983a6446318b73c222807555a120983728847a42282fac5969908533
   md5: 2d0abd8364e3f1a7091824fae0749806
@@ -5294,30 +5251,6 @@ packages:
   - pkg:pypi/casadi?source=hash-mapping
   size: 6616169
   timestamp: 1775547321087
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.0-py312h007ed8f_5.conda
-  sha256: ba79e6123d48ceb6727cf0e3bd01f778157f4412991174853578116afa784eea
-  md5: d95420402d4cf175f0675c66f170d1bd
-  depends:
-  - ipopt >=3.14.19,<3.14.20.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libblasfeo >=0.1.4.2,<0.1.5.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libfatrop >=0.0.4,<0.0.5.0a0
-  - libgcc >=14
-  - liblapack >=3.9.0,<4.0a0
-  - libosqp >=1.0.0,<1.0.1.0a0
-  - libstdcxx >=14
-  - numpy >=1.23,<3
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/casadi?source=hash-mapping
-  size: 5804307
-  timestamp: 1756987087931
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h15c444b_2.conda
   sha256: c99e0343a26ee18ae21d504a435f605f78c22a7a5d79892d74748898ebad8e9e
   md5: 53c6338ab701d03835a9038b69499e22
@@ -6300,24 +6233,27 @@ packages:
   - pkg:pypi/coverage?source=compressed-mapping
   size: 388836
   timestamp: 1773762166448
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.20.0-py312h014360a_0.conda
-  sha256: 7f7c16c20c296f9527b45a114152d4a7dd29d6504bbd2830346a6f26f3df5bec
-  md5: f65ae40ce08e9d666e3a590e04979b06
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
+  sha256: 0d9405d9f2de5d4b15d746609d87807aac10e269072d6408b769159762ed113d
+  md5: d17488e343e4c5c0bd0db18b3934d517
   depends:
-  - pygments
-  - python
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  license: CC0-1.0
+  purls: []
+  size: 24283
+  timestamp: 1756734785482
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cpp-expected-1.3.1-hdc560ac_0.conda
+  sha256: 4edebca2a9dadd8afabb3948a007edae2072e4869d8959b3e51aebc2367e1df4
+  md5: 13f0be21fdd39114c28501ac21f0dd00
+  depends:
   - libstdcxx >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - pcre >=8.45,<9.0a0
-  - python_abi 3.12.* *_cp312
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls:
-  - pkg:pypi/cppcheck-htmlreport?source=hash-mapping
-  size: 3100256
-  timestamp: 1772702948382
+  - libgcc >=14
+  license: CC0-1.0
+  purls: []
+  size: 25132
+  timestamp: 1756734793606
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.20.1-py312h014360a_0.conda
   sha256: 8edc0745980da25273a9f3cbd26249872d496667f110840cddff19155316db1e
   md5: ffdb2c0e2468df8ddfe48d0677f67639
@@ -6336,24 +6272,6 @@ packages:
   - pkg:pypi/cppcheck-htmlreport?source=hash-mapping
   size: 3100257
   timestamp: 1774598936120
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.20.0-py312h5677ec4_0.conda
-  sha256: 0a6d3bda58620ec1a4bb9dad9f7a26224c3c0eb35c2780c293d462fecf3ffa73
-  md5: 3846a50a452c8bf633af90636e9a50ff
-  depends:
-  - pygments
-  - python
-  - python 3.12.* *_cpython
-  - libgcc >=14
-  - libstdcxx >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - pcre >=8.45,<9.0a0
-  - python_abi 3.12.* *_cp312
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls:
-  - pkg:pypi/cppcheck-htmlreport?source=hash-mapping
-  size: 2947204
-  timestamp: 1772702952674
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.20.1-py312h5677ec4_0.conda
   sha256: 2dd8e318d714cb20b82a97c41990a94f81fae268ae413d093cb743f02d55496a
   md5: 5e210a0cb0d8e350a0938bc445a72c25
@@ -6383,24 +6301,6 @@ packages:
   purls: []
   size: 46463
   timestamp: 1772728929620
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
-  sha256: 3a20020b7c9efbabfbfdd726ff303df81159e0c3a41a40ef8b37c3ce161a7849
-  md5: 4c69182866fcdd2fc335885b8f0ac192
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi >=1.14
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=compressed-mapping
-  size: 1712251
-  timestamp: 1770772759286
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
   sha256: ec1635e4c3016f85d170f9f8d060f8a615d352b55bb39255a12dd3a1903d476c
   md5: ab9e1a0591be902a1707159b58460453
@@ -6419,24 +6319,6 @@ packages:
   - pkg:pypi/cryptography?source=compressed-mapping
   size: 2534262
   timestamp: 1775637873338
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.5-py312hf80642e_0.conda
-  sha256: 3560e2499b76ebb375a2a086b0f4d1c806d84ee78857a2d65b255c74eeee8d44
-  md5: d29f4faf486a8f63ec15a3f45df4e3e9
-  depends:
-  - cffi >=1.14
-  - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1704221
-  timestamp: 1770772496997
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-46.0.7-py312hf80642e_0.conda
   sha256: c0141ed04f1b2ad7c0b670d1756c9bd1c783d4e3ce9ed1c7cf71c3ed96da03ce
   md5: 5e2591c29d10edbfe430e00d39849ae3
@@ -6645,14 +6527,6 @@ packages:
   purls: []
   size: 1173140
   timestamp: 1771922508919
-- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_1.conda
-  sha256: ad5db2ecef863c0ee1c76bb4e5c239fb061e6f44049ce06c3f4132aa262c4f7c
-  md5: d60bd452063a6a02ae3823b88d6595b2
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 12814
-  timestamp: 1771590573476
 - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
   sha256: 6060ac3c240bfd079946aa4ba9b4749b4ffecbdc734b14910a44eb9d2ec84d6f
   md5: aca8e2d59adae20b4715ab372b8d9b9f
@@ -6663,14 +6537,6 @@ packages:
   purls: []
   size: 13146
   timestamp: 1771922274215
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_1.conda
-  sha256: 5a56e56a0c9af962fde82f6920de6e39970dd3a8ea132c5fe2e29eb28e039e57
-  md5: dcc201594a39f072397bcf24afe1c80f
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 12807
-  timestamp: 1771590818256
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-3.4.0.100-h9a8c16c_2.conda
   sha256: e2eae8161afbc27a3cd40131adb436a3157c63c34c10644924af23e52c4a2d65
   md5: 3bb2210aa3661ae1db92626d5d2d8515
@@ -7061,6 +6927,23 @@ packages:
   - pkg:pypi/fonttools?source=compressed-mapping
   size: 2935817
   timestamp: 1773137546716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.1-py312h8a5da7c_0.conda
+  sha256: e81f6e1ddadbc81ce56b158790148835256d2a3d5762016d389daaa06decfeab
+  md5: 2396fee22e84f69dffc6e23135905ce8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fonttools?source=compressed-mapping
+  size: 2953293
+  timestamp: 1776708606358
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.62.0-py312ha4530ae_0.conda
   sha256: ca4e2e03dc6c2b34880a7b450fe9bd66d7b2b26b5ee62dc2aa605f8e974ff758
   md5: d2038fcea211e3e59fa78fa03938edad
@@ -7078,6 +6961,23 @@ packages:
   - pkg:pypi/fonttools?source=compressed-mapping
   size: 2936215
   timestamp: 1773137278297
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.62.1-py312ha4530ae_0.conda
+  sha256: bb7e6bd4d132e46a6cec80b4987e9c6423759cd8b8e508830595ec4e5a90dd49
+  md5: a0c70e3072ea9b760bff36e6f6ded16b
+  depends:
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fonttools?source=compressed-mapping
+  size: 2934375
+  timestamp: 1776708275616
 - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
   sha256: 28d9fce64ee8b5e94350feb0829e054811678f9638039f78ddff8a8615c1b693
   md5: 2a3316f47d7827afde5381ecd43b5e85
@@ -7267,18 +7167,6 @@ packages:
   purls: []
   size: 73516504
   timestamp: 1771378256368
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h862fb80_21.conda
-  sha256: de02364d7eb088d8fa9c91ddafc572a359f49070388b1981541064ecf75ea0b8
-  md5: be589fb742197599a6275c5e69df1c43
-  depends:
-  - gcc_impl_linux-64 15.2.0.*
-  - binutils_linux-64
-  - sysroot_linux-64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 28948
-  timestamp: 1770908206658
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h862fb80_23.conda
   sha256: 15baa12c7c1f9540525b1cee4e6d42bc26c632aed7088eecf89b9d22b8b94d81
   md5: 3251d2b55a91af721d3d6924c45d6bb1
@@ -7291,18 +7179,6 @@ packages:
   purls: []
   size: 28920
   timestamp: 1775508945710
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0139441_21.conda
-  sha256: ab58398e378ef6d14262298d2d149f3ad07f93f4a6a6ffe0e5b458d6c974bf91
-  md5: c210bf3a031fbdd9f2b25fe6e58edce5
-  depends:
-  - gcc_impl_linux-aarch64 15.2.0.*
-  - binutils_linux-aarch64
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 28685
-  timestamp: 1770908219560
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0139441_23.conda
   sha256: 87f167959007840ae3546382b4aa4c686eb7f607f93abf5487dbde876a00f972
   md5: 2c27a5e9c0356b075498b096f35d9613
@@ -7315,33 +7191,6 @@ packages:
   purls: []
   size: 28668
   timestamp: 1775508896722
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdbm-1.18-h0a1914f_2.tar.bz2
-  sha256: 8b9606dc896bd9262d09ab2ef1cb55c4ee43f352473209b58b37a9289dd7b00c
-  md5: b77bc399b07a19c00fe12fdc95ee0297
-  depends:
-  - libgcc-ng >=7.5.0
-  - readline >=8.0,<9.0a0
-  license: GPL-3.0
-  license_family: GPL
-  purls: []
-  size: 194790
-  timestamp: 1597622040785
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_1.conda
-  sha256: b2a6fb56b8f2d576a3ae5e6c57b2dbab91d52d1f1658bf1b258747ae25bb9fde
-  md5: 7eb4977dd6f60b3aaab0715a0ea76f11
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 575109
-  timestamp: 1771530561157
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
   sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
   md5: 7892f39a39ed39591a89a28eba03e987
@@ -7358,21 +7207,6 @@ packages:
   purls: []
   size: 577414
   timestamp: 1774985848058
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.5-h90308e0_1.conda
-  sha256: aa95b37da0750fb93c5eeef79073b9b0d50976fa0dc02ed0301ff7bbbfc7ff36
-  md5: c75ae103325db056719dd51d6525e1cd
-  depends:
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 584221
-  timestamp: 1771532437279
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.44.6-h90308e0_0.conda
   sha256: 53ac38045a8c0b6aa9cfaf784443a3744dc86ab4737c1479b44ae85c96926fe1
   md5: bdd860e72c5e10eb4ffa3d61f9b02ee0
@@ -7713,40 +7547,6 @@ packages:
   purls: []
   size: 2578234
   timestamp: 1769427141106
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
-  sha256: f43bc8fd2c8b0c4317cf771f2cf8a9e7eee47105c233bfed00158f6579e41340
-  md5: fd9738c3189541787bd967e19587de26
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - gstreamer 1.26.10 h17cb667_0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.3,<3.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.5.2,<2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libstdcxx >=14
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pango >=1.56.4,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  - xorg-libxshmfence >=1.3.3,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2928142
-  timestamp: 1766699713774
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.11-h6d08254_0.conda
   sha256: 5a227ac457b9cc7a70b14008df1f91fd5dd2b3fda9641e5445c950b06d04be9e
   md5: 971da16e7fc43161329213557688d315
@@ -7782,39 +7582,6 @@ packages:
   purls: []
   size: 3199241
   timestamp: 1776268376145
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
-  sha256: 3a0e73405ead3038e2e52ccc1c8302a417b0c6fcf4c4953a145d98a820328c8c
-  md5: 5c483a9308fbee6d5f7deca21fe36e70
-  depends:
-  - alsa-lib >=1.2.15.1,<1.3.0a0
-  - gstreamer 1.26.10 hc24f651_0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglib >=2.86.3,<3.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.5.2,<2.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libstdcxx >=14
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pango >=1.56.4,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxau >=1.0.12,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  - xorg-libxshmfence >=1.3.3,<2.0a0
-  - xorg-libxxf86vm >=1.1.6,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2906491
-  timestamp: 1766705232717
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.11-hd6b5e5b_0.conda
   sha256: 08921a08bb06079819cf9f64dd282a854807bd67cad09bb8049072503a9d4f22
   md5: 58272f8232b377a6a7bf9293b5b92a34
@@ -7849,22 +7616,6 @@ packages:
   purls: []
   size: 3216930
   timestamp: 1776268752110
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
-  sha256: 35044ecb0b08cd61f32b18f0c0c60f8d4aa610352eee4c5902e171a3decc0eba
-  md5: 0c38cdf4414540aae129822f961b5636
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - glib >=2.86.3,<3.0a0
-  - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2059388
-  timestamp: 1766699555877
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.11-h29cf534_0.conda
   sha256: 6b9f6c7de3207b7d3a76741713587dd9f7fe2f00720f9ba047632f0900cfa5e5
   md5: 1e0e854b77451ac918b4a68f28932b1d
@@ -7881,21 +7632,6 @@ packages:
   purls: []
   size: 2281638
   timestamp: 1776268376145
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
-  sha256: 5b36e58daf3542dbf798ed8bda28ec1bfd3d382689beb498ebb5a3ad6ce43e3d
-  md5: 9c3c6463c6dd86114e37e8ba195dd651
-  depends:
-  - glib >=2.86.3,<3.0a0
-  - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2080140
-  timestamp: 1766703002402
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.11-hf552038_0.conda
   sha256: 02271b91ea352aba6c9d0064e2e773626c4f50e34a1b2b91376d5b893aa05b00
   md5: 207fe720a805928c5b02be94d1b112fa
@@ -7938,49 +7674,6 @@ packages:
   purls: []
   size: 409213
   timestamp: 1748320114722
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.51-ha5ea40c_0.conda
-  sha256: 70f25f28bd696477e57caf015f1449b7311bb5c718051ba6a6bd74d11d16ceba
-  md5: 4f646b4ee5bcceb30cfedf5021e2fa89
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - at-spi2-atk >=2.38.0,<3.0a0
-  - atk-1.0 >=2.38.0
-  - cairo >=1.18.4,<2.0a0
-  - epoxy >=1.5.10,<1.6.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.16,<2.0a0
-  - gdk-pixbuf >=2.44.5,<3.0a0
-  - glib-tools
-  - harfbuzz >=12.3.2
-  - hicolor-icon-theme
-  - libcups >=2.3.3,<2.4.0a0
-  - libcups >=2.3.3,<3.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pango >=1.56.4,<2.0a0
-  - wayland >=1.24.0,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - xorg-libxcomposite >=0.4.7,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxinerama >=1.1.6,<1.2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 5913603
-  timestamp: 1772669326412
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.52-ha5ea40c_0.conda
   sha256: c6bb4f06331bcb0a566d84e0f0fad7af4b9035a03b13e2d5ecfaf13be57e6e10
   md5: bcaea22d85999a4f17918acfab877e61
@@ -8024,48 +7717,6 @@ packages:
   purls: []
   size: 5939083
   timestamp: 1774288645605
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.51-h75d4e7a_0.conda
-  sha256: 031787ffb325b8ad43f15ca6d744aa466815fe16e5c673227d42a042f9235a2a
-  md5: 0c499e96c3a0fcee46c354e0cb927e47
-  depends:
-  - at-spi2-atk >=2.38.0,<3.0a0
-  - atk-1.0 >=2.38.0
-  - cairo >=1.18.4,<2.0a0
-  - epoxy >=1.5.10,<1.6.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.16,<2.0a0
-  - gdk-pixbuf >=2.44.5,<3.0a0
-  - glib-tools
-  - harfbuzz >=12.3.2
-  - hicolor-icon-theme
-  - libcups >=2.3.3,<2.4.0a0
-  - libcups >=2.3.3,<3.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pango >=1.56.4,<2.0a0
-  - wayland >=1.24.0,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - xorg-libxcomposite >=0.4.7,<1.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libxdamage >=1.1.6,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - xorg-libxinerama >=1.1.6,<1.2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 5980180
-  timestamp: 1772676984873
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.52-h75d4e7a_0.conda
   sha256: 5db1347513253a2d200b111717eb452d4b95e9380db48b6dd2c8bb7bb256d754
   md5: f6a9ed300bcf3217da7f1955f57facec
@@ -8158,19 +7809,6 @@ packages:
   purls: []
   size: 15371317
   timestamp: 1771378487467
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h59c6875_21.conda
-  sha256: 61b50182316dfeca7e167af336d2b03acecc61d7bf65483be6b471d4b8fdd7ef
-  md5: 0d444f3378fa921314caf7a152fa917e
-  depends:
-  - gxx_impl_linux-64 15.2.0.*
-  - gcc_linux-64 ==15.2.0 h862fb80_21
-  - binutils_linux-64
-  - sysroot_linux-64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 27491
-  timestamp: 1770908206662
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-h98b7566_23.conda
   sha256: b42e47b9e3a549be01606e09bd070d18d24a7cc5437e51ea52d39759c1417764
   md5: 249806b139b4f6178475d39938182875
@@ -8197,19 +7835,6 @@ packages:
   purls: []
   size: 27241
   timestamp: 1775508896722
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-ha48bfc4_21.conda
-  sha256: fb1486b68b463327f56863948fe050a7b5ef7bdb26fa42e37a878704e472d5e0
-  md5: 918dca8247adabdfb32e9c240080faf4
-  depends:
-  - gxx_impl_linux-aarch64 15.2.0.*
-  - gcc_linux-aarch64 ==15.2.0 h0139441_21
-  - binutils_linux-aarch64
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 27259
-  timestamp: 1770908219565
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gz-cmake3-3.5.5-h05f81b2_0.conda
   sha256: b654d0102a8b8242836a5863c0157945b5c549d505383f4f8b724926a55f68aa
   md5: fda2ad837ffe2ed7f73ddfab260d82e3
@@ -8498,6 +8123,25 @@ packages:
   purls: []
   size: 2338203
   timestamp: 1775569314754
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+  sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
+  md5: e194f6a2f498f0c7b1e6498bd0b12645
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.86.4,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  purls: []
+  size: 2333599
+  timestamp: 1776778392713
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-13.1.1-h1134a53_0.conda
   sha256: 519585a32a9374d2ff0ca93139665e65061117b70156f6c94ce8bc5b5b47c687
   md5: 46a7a399537501c4501be18a9f871976
@@ -8536,6 +8180,24 @@ packages:
   purls: []
   size: 2503367
   timestamp: 1775574309404
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.0-h1134a53_0.conda
+  sha256: cb3e67e8045577b944b64534907d194ebc44e0959e0842847c18a4067eeeb9f6
+  md5: 1775defbef30aa990498e753a948cb18
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.86.4,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  purls: []
+  size: 2800967
+  timestamp: 1776783366021
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
   sha256: 6d7e6e1286cb521059fe69696705100a03b006efb914ffe82a2ae97ecbae66b7
   md5: 129e404c5b001f3ef5581316971e3ea0
@@ -8694,20 +8356,6 @@ packages:
   - pkg:pypi/importlib-metadata?source=compressed-mapping
   size: 34387
   timestamp: 1773931568510
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
-  sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
-  md5: c85c76dc67d75619a92f51dfbce06992
-  depends:
-  - python >=3.9
-  - zipp >=3.1.0
-  constrains:
-  - importlib-resources >=6.5.2,<6.5.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/importlib-resources?source=hash-mapping
-  size: 33781
-  timestamp: 1736252433366
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
   sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
   md5: 0ba6225c279baf7ea9473a62ea0ec9ae
@@ -8805,7 +8453,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jinja2?source=compressed-mapping
+  - pkg:pypi/jinja2?source=hash-mapping
   size: 120685
   timestamp: 1764517220861
 - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
@@ -9108,26 +8756,6 @@ packages:
   purls: []
   size: 115093
   timestamp: 1706132568525
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.6-gpl_hc2c16d8_100.conda
-  sha256: 69ea8da58658ad26cb64fb0bfccd8a3250339811f0b57c6b8a742e5e51bacf70
-  md5: 981d372c31a23e1aa9965d4e74d085d5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - liblzma >=5.8.2,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lzo >=2.10,<3.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 887139
-  timestamp: 1773243188979
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_100.conda
   sha256: 2071a3eb03a868effef273eee8bb7baed6ee9fb2fb94421e9958dcf48ab2c599
   md5: dbeb5c8321cb2408d406a3da16a0ff0d
@@ -9148,25 +8776,6 @@ packages:
   purls: []
   size: 891114
   timestamp: 1776096017113
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.6-gpl_hbe7d12b_100.conda
-  sha256: 635a78a04461e82150263ee9a1fbf6c965de0b811a10e87392a1e44be1115a39
-  md5: f2c45cbb67fd0f668a1a0c152b70dc5f
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - liblzma >=5.8.2,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lzo >=2.10,<3.0a0
-  - openssl >=3.5.5,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 1000663
-  timestamp: 1773243230880
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.8.7-gpl_hbe7d12b_100.conda
   sha256: 9d295367da81b4df58223f4f7fc02a9f76bbea073de8d77a4f5f2de12c21ed91
   md5: ce6df629d7ba0db89930b5411623815a
@@ -9556,18 +9165,6 @@ packages:
   purls: []
   size: 309304
   timestamp: 1764017292044
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
-  sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
-  md5: 09c264d40c67b82b49a3f3b89037bd2e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - attr >=2.5.2,<2.6.0a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 121429
-  timestamp: 1762349484074
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
   sha256: 37c41b1024d0c75da76822e3c079aabaf121618a32fe05e53a897b35a88008fc
   md5: 499cd8e2d4358986dbe3b30e8fe1bf6a
@@ -9579,17 +9176,6 @@ packages:
   purls: []
   size: 124432
   timestamp: 1774333989027
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
-  sha256: 154eefd8f94010d89ba76a057949b9b1f75c7379bd0d19d4657c952bedcf5904
-  md5: 10fe36ec0a9f7b1caae0331c9ba50f61
-  depends:
-  - attr >=2.5.1,<2.6.0a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 108542
-  timestamp: 1762350753349
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-hf9559e3_1.conda
   sha256: e04f0c4287362ea2033421c1b516d7d83c308084bcc9483b2e6038ec7c711e0a
   md5: bdda58ab0358b0e9ff45fd2503b38410
@@ -11920,21 +11506,6 @@ packages:
   purls: []
   size: 345579
   timestamp: 1776441217688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_hfcc3fd4_2.conda
-  sha256: 2c2030d8dc2a4af1bbeac2c25de74fd3269afaf72d3ba666b6bd5af6f4b534ba
-  md5: 263641cd867b74db096f6f30752bd502
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - liblzma >=5.8.2,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: CECILL-C
-  purls: []
-  size: 345169
-  timestamp: 1771828417189
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h588e91d_3.conda
   sha256: 45f2e776298ddda5d12ea234c501d24cbbf90cb09e96b2eae1f8ab59381b95ec
   md5: 8bfb63d364cb3f4fb12ea4419952cf6a
@@ -11949,20 +11520,6 @@ packages:
   purls: []
   size: 378646
   timestamp: 1776441269980
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h6af2d16_2.conda
-  sha256: 585123426e81fc210b18929ffa5ca1bc07247650f098231a73d6fcb3f68195a4
-  md5: b22f22b1b2e922922946a4e457338687
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - liblzma >=5.8.2,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: CECILL-C
-  purls: []
-  size: 380118
-  timestamp: 1771828483074
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py312h1f51ce1_2.conda
   sha256: 41a56a57a0bb78429a5ad571226dbe4cffed586446d11ad30cc4173f89c1cee8
   md5: 6dc0e6dc04a710e77bfe2865dad3f3b8
@@ -13726,22 +13283,22 @@ packages:
   purls: []
   size: 239860
   timestamp: 1728635298509
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.7-h40f6f1d_0.conda
-  sha256: f471cb0eefd54b99f9496a0041786d42f4c41bc36c88b5b3de03a45637a214c0
-  md5: 391f28825fc933d1490af692e7c06251
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.10-h9f1635d_0.conda
+  sha256: fdc523a0af9edc3a3e59c79ae0b966d439641a688a965be22d98ef60b78de903
+  md5: d99acfa404408ea141415f74196699a9
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - openjph >=0.26.3,<0.27.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - openjph >=0.27.0,<0.28.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1218023
-  timestamp: 1773694822821
+  size: 1217976
+  timestamp: 1776647563893
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.9-h9f1635d_1.conda
   sha256: 4e69273732071fb9ebb8d5d0c4646d15c8d95b056c6957173014f8820c03730a
   md5: 28f0a06fb37d1467b4eb9297fa955f27
@@ -13758,21 +13315,21 @@ packages:
   purls: []
   size: 1217945
   timestamp: 1776245949905
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.7-hd0c962a_0.conda
-  sha256: b2c52a3fc14d0eac562a8d544be4edec63fcfa145ffa606f9b25517e247fa7f6
-  md5: 185cb9766831cf48f16808251d4dba33
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.10-hda3a014_0.conda
+  sha256: a59d3123da3c5611261d49d21b2d3073b65816641a4c04ca1955e6a5b4fa5bd3
+  md5: 31510fbf213f77253fc233abee71eb51
   depends:
   - libstdcxx >=14
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
   - imath >=3.2.2,<3.2.3.0a0
-  - openjph >=0.26.3,<0.27.0a0
+  - openjph >=0.27.0,<0.28.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1176094
-  timestamp: 1773694836606
+  size: 1176164
+  timestamp: 1776647569061
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.4.9-hda3a014_1.conda
   sha256: debb22fe68742cbef3635baf40125ef826825db3982a3afd80f263a9e7d2763b
   md5: 2a6cba6460a92de3927f67457dfd6386
@@ -13817,19 +13374,6 @@ packages:
   purls: []
   size: 392636
   timestamp: 1758489353577
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
-  sha256: 4587e7762f27cad93619de77fa0573e2e17a899892d4bed3010196093e343533
-  md5: 792d5b6e99677177f5527a758a02bc07
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 279846
-  timestamp: 1771349499024
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.27.0-h8d634f6_0.conda
   sha256: 7feff0a0cf14ee008ae03fc83fa556d5d0acfac870a6ce4371d6a75e5edc8d0a
   md5: 8397bb8cf4b370f5df7d7ee3d80ea977
@@ -13843,18 +13387,6 @@ packages:
   purls: []
   size: 282674
   timestamp: 1776138260696
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.26.3-h55827e0_0.conda
-  sha256: b3bb469fed20d795c03ca45272f247b4f216df12de8a726ea1fa8dcd04348ab7
-  md5: cc1ebab576bd98d2cd82b0fbca20d033
-  depends:
-  - libstdcxx >=14
-  - libgcc >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 228534
-  timestamp: 1771349510383
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjph-0.27.0-h55827e0_0.conda
   sha256: 1735bfcd4ce96c13fb59e8438ac333c81b7e7426997a0d89805a372d7de5811c
   md5: 33946e3bfbf4c4a85b4c47f1f068dd1c
@@ -14074,27 +13606,6 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 89360
   timestamp: 1776209387231
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
-  sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
-  md5: 79f71230c069a287efe3a8614069ddf1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=11.0.1
-  - libexpat >=2.7.0,<3.0a0
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
-  - libgcc >=13
-  - libglib >=2.84.2,<3.0a0
-  - libpng >=1.6.49,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 455420
-  timestamp: 1751292466873
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
   sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
   md5: d53ffc0edc8eabf4253508008493c5bc
@@ -14136,26 +13647,6 @@ packages:
   purls: []
   size: 470441
   timestamp: 1774284032397
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-he55ef5b_0.conda
-  sha256: dd36cd5b6bc1c2988291a6db9fa4eb8acade9b487f6f1da4eaa65a1eebb0a12d
-  md5: a22cc88bf6059c9bcc158c94c9aab5b8
-  depends:
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.10,<2.0a0
-  - harfbuzz >=11.0.1
-  - libexpat >=2.7.0,<3.0a0
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
-  - libgcc >=13
-  - libglib >=2.84.2,<3.0a0
-  - libpng >=1.6.49,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 468811
-  timestamp: 1751293869070
 - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
   sha256: 61d3a3ef79952014bf536ffd84828d3558fc58b332adb89ed198b77fb301c2c5
   md5: eaa73c6e5aff5b28675147abc350d49a
@@ -14655,21 +14146,6 @@ packages:
   purls: []
   size: 760306
   timestamp: 1763148231117
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
-  sha256: c2d16e61270efeea13102836e0f1d3f758fb093207fbda561290fa1951c6051f
-  md5: 44dff15b5d850481807888197b254b46
-  depends:
-  - python >=3.8
-  - pybind11-global ==3.0.2 *_0
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11?source=compressed-mapping
-  size: 245509
-  timestamp: 1771365898778
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.3-pyhfe8187e_0.conda
   sha256: 71a9524f44d6ac6304feae71e2bbe8d8ce0816f0be7a0271c15681ad1040965d
   md5: e0f4549ccb507d4af8ed5c5345210673
@@ -14693,21 +14169,6 @@ packages:
   purls: []
   size: 14671
   timestamp: 1752769938071
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
-  sha256: b97f25f7856b96ae187c17801d2536ff86a968da12f579bbc318f2367e365a02
-  md5: 0c2d37c332453bd66b254bc71311fa30
-  depends:
-  - python >=3.8
-  - __unix
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11-global?source=hash-mapping
-  size: 241244
-  timestamp: 1771365839659
 - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.3-pyh648e204_0.conda
   sha256: 97a0fbd2a81d95e90d714e5c628fe860b29a3caad53abcfb90add1965ad85bef
   md5: 7fdc3e18c14b862ae5f064c1ea8e2636
@@ -36500,9 +35961,9 @@ packages:
   license: Apache-2.0 OR BSD-3-Clause
   size: 23932
   timestamp: 1771182277261
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: f60c23a74a393283f780b86828f84184838c8d86dc08c96f19cae7f1d1d1899f
-  md5: cd250d5728c4d32013f105b534630961
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-action-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 33926ef352c7d1f0e78376b3edf1c7f0b813c97726a7c7b2bd6a62e990f11f4e
+  md5: c9e754c954d2658bd531419e9a6d3639
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -36510,20 +35971,19 @@ packages:
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 150396
-  timestamp: 1769483028288
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-action-msgs-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: 707e24bfe63b9513c52ca8e3b9b467edd91fa1c1c7756822ea5c1de0cbee23a2
-  md5: 0df7946ed709a66459ab087cb4e7d59d
+  size: 153676
+  timestamp: 1775549238659
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-action-msgs-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 8684712d00348f28761ed04cecde3b7834d3571bfb2dd892496ac88fc1bf61be
+  md5: 73d7da48fef9d5473517d9dfa48f956b
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -36531,58 +35991,55 @@ packages:
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 155748
-  timestamp: 1769483311094
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 8c048b3f8d0bbf2eaf972181dbd1fad7af495c936aa1187153d8ee20fb80251d
-  md5: 85215a31f763c8e1f53cb8a2e94d4758
+  size: 159246
+  timestamp: 1775549246361
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-actionlib-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 2b8ebe61b96614f2e1cc35ef60a61f0c2f5e70512e1e09a971e7bc616cf4d2d2
+  md5: 11d5a26861d86ebf0661e61604aedafd
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 110953
-  timestamp: 1769483406077
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-actionlib-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 180e3bdb21463adb592915514c4c305e5e7f251960e072e2a65074abfc28c681
-  md5: 5f2e258567ddeb4abcc7708c1deb1e5f
+  size: 113695
+  timestamp: 1775549582461
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-actionlib-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 94cfc00ae46c9e3c72d7404ad6e3128226029f8b2adb4092ae3e209e5d889c7f
+  md5: 70a65a0273d1d66579edd9b1d0554668
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 113957
-  timestamp: 1769483683241
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 04d2c3366ffca89ad11ea4c2ace80875007da2558bff58116c9e94efb44bf752
-  md5: 46da3fd3ab5893835d82f97182386e03
+  size: 117160
+  timestamp: 1775549588592
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 5d00da6dfcac81ff634b3be1dd9753107a0c0e1d5171698b1e65a8e6831706f0
+  md5: 21fc4d9b28df527df4537168a6a992aa
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -36600,21 +36057,20 @@ packages:
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cmake-version
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23311
-  timestamp: 1769481102393
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: cb29f82a85e84bc5b0d4fac3c03f305882e692682bfe905a7be3a209343156d9
-  md5: 77f5d4458bbb8dc3cd237332168a287b
+  size: 23273
+  timestamp: 1775547332725
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 096200de9af20d39d46f68f708a49a5cb011afd4acbb9c39a0febc971a4cda54
+  md5: a816f42a15106ace025b0fc06a37eedf
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -36632,816 +36088,787 @@ packages:
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cmake-version
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23334
-  timestamp: 1769481434272
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 66b0601e3cb0a89c8ff4cf9139dfef1f53811e6b4ad86107ee2a2570593cbc01
-  md5: c443427db41b72ac18a26ae09791aecf
+  size: 23414
+  timestamp: 1775547532408
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 6d4097441e1b2f0f623c65b0fe5848aa335da969e7c8c08f84f291f0cbbbe61a
+  md5: dc0ed6adaf5aa169c937b407ef36de8f
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ament-cmake-gmock
   - ros-kilted-ament-cmake-gtest
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 28345
-  timestamp: 1769481188917
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-auto-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 856ca9523c118b509e5192e383a53cd99b4343ed39539d07db837c11a4c8374a
-  md5: cee9c25c5343ece53da6491eb1f0467e
+  size: 28268
+  timestamp: 1775547411327
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-auto-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 0de15a65dffbe585aae6649f8d18843ee7dd5de9eb41e917e96819d8293c1c40
+  md5: e1ead74bb0f823c55444d8fefd0f77ac
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ament-cmake-gmock
   - ros-kilted-ament-cmake-gtest
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 28258
-  timestamp: 1769481522677
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 80d447ca5bd394174d3520cea91c923b6d13c5d7a58f3e824f3dda18cd468fd8
-  md5: a2baaa8ad0c19b6b90cd23ebee54f4b0
+  size: 28389
+  timestamp: 1775547640765
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 7eed979756b5dbad9fd34d65ea4b468f2e322b09017af4c56247a9de44ce9c7a
+  md5: a1b044f826d92146c00b8786c463c6b9
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-copyright
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22771
-  timestamp: 1769481463900
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 42eb58b30d5b3bf08a110d38c5d7481e19d08817a0c4744d2a185f8d5bd1d6ee
-  md5: bf1ff749ef6d0478a3cc9128527b372d
+  size: 22676
+  timestamp: 1775547771228
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-copyright-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: dbc775b7b583cbd210cb48de21847b702b2ca2bfe989f81bfcf23192e12fb3d6
+  md5: 58e5ea715a0c65c3750d15b3d4ab88b6
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-copyright
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22782
-  timestamp: 1769481793101
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 8f36dc1eb0162087fb01366234a6c048c64e81203f97e302f98113e3a0f9c7a0
-  md5: 85e9b5fc898f9cf6addc71dfa36e8b10
+  size: 22820
+  timestamp: 1775547910820
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-core-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: b75fae043a4026f3d2c2fc91094960860f4c536795cafca5defd33fe5875caff
+  md5: d919b96959c620a2a8113b8fafb95e50
   depends:
   - catkin_pkg
   - python
   - ros-kilted-ament-package
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
-  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 45111
-  timestamp: 1769480651203
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-core-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: ff2732efccd61de32f47444b1113456a09cff3627b5cc1c50cbd91e0bc89936c
-  md5: 90e30e8d53db8608c50b65ef9226f373
+  size: 45038
+  timestamp: 1775546826225
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-core-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 17dbca931b951f760ce737f621d1717ebcfd573155c5ae8ba0cc92365e2d5d6b
+  md5: 13c4d9c494bba319e8f9617ad3855c87
   depends:
   - catkin_pkg
   - python
   - ros-kilted-ament-package
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 45120
-  timestamp: 1769480935387
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 6540cdb6a1c18f79c864b02fa687cce8053122daa85baf19b6fefa9ab7df5f10
-  md5: 5f3c8b6a753e01f897da794dba844362
+  size: 45197
+  timestamp: 1775547083049
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: f3eaf026a91077ff49dd2ca957f2b4e2e4a7a304ea268cc4d8999330a3e44842
+  md5: 7320748b0b10a6adae8863e9bbf77960
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cppcheck
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24428
-  timestamp: 1769481507391
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 9f768d9b079e7f3b384d46b55a3b42079a95de64cf66fc76c969fff7673a5a62
-  md5: 0499f063ee89cc02fee8f80e2b7ccd26
+  size: 24460
+  timestamp: 1775547811988
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cppcheck-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: c81d7f6805fdeaf4320d312eba8397d8aaee44780f5c02dd28c13fa977e006a2
+  md5: 430af440de25a7373e0b19aca372ef9c
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cppcheck
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24444
-  timestamp: 1769481845431
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 7aec389707a2b0d3c1b59fd0e65536fa088cd85cc6564fd9d2b59a7d75597df9
-  md5: 93d99db9574a3a125f607ac9da1fe19a
+  size: 24571
+  timestamp: 1775547961214
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 2dde3a49053fce0a15d5bcdfa207fae005a9c0e41c481516a81b8d140a562538
+  md5: 1801ddc6f5a1f0a640cf0e1f98cab792
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cpplint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23392
-  timestamp: 1769481537257
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: de07ddffb094ef6bb02e5227c2da2c2342c762f32c17293cacf36c072cd3392e
-  md5: 7ef28590f100710097f75a485d30b01f
+  size: 23302
+  timestamp: 1775547844307
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-cpplint-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 168c26622541fe088eba8eeab7726eb2b60aff64b8754c7f9fa6df0a413c6c6c
+  md5: 4e69f215919e0eb6522f007c07955d54
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-cpplint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23405
-  timestamp: 1769481880581
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: a9b69457a535c895399087943eae06309326386c5524d58ceed801973c0ad2a7
-  md5: d089091beccce78e25b1651a4e8e2649
+  size: 23445
+  timestamp: 1775547991146
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 3a71ae5ba7232538d8cc0b7b6db0b371c50104c91b3abc99b295c2413b6a9463
+  md5: 638edba69790d39d6eb7297a0f2d1d82
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22114
-  timestamp: 1769480737763
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-definitions-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: b0888f66acc97c1cc6db159c01d1e5e3a2131f5d8601aa7a6ba06cf1dc31d111
-  md5: 941c792a1d30fa6c42c95fbb9fd886a7
+  size: 21999
+  timestamp: 1775546915500
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-definitions-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: d921e3bfb1383a17626e6626249f72e7bbc46d61e5f47f64ef6691551ee2360c
+  md5: 1b3c66649df99b558a83a428535918a7
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22116
-  timestamp: 1769481029712
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 2dce8aadb63053a32e9cde54649fd708a1de1ca8b37c25e102483d2e476676f1
-  md5: 8ac9eb866af22a19224ac3ece94c680d
+  size: 22145
+  timestamp: 1775547167437
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: a23be926b6ba9c0a0fc3553d5564f81c4bd7478a42e8d5a7ab99742abeede9d0
+  md5: 1e112901d7cc66c314f2ff43d54588ae
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23028
-  timestamp: 1769480813067
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-dependencies-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: af9942df9adce4a99dfb6eeed61eb7b51a93e2847f8f5c0d3a0d89a2f6d2547f
-  md5: 52a68ef86cd62780bbe35c6ffea452c6
+  size: 22944
+  timestamp: 1775546989653
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-dependencies-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 8c17d87e276de08e11d975725488fa984df479f5feb1cbc483a79493b353783e
+  md5: 4850d4661a9692536a3d8d2c93ef6f35
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23027
-  timestamp: 1769481143312
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 3146b32550989fd8f902c09ae3c980bed3fa4b804819122e23296a7dd4f34df2
-  md5: 399e9034be1db231768bbc88042300ad
+  size: 23055
+  timestamp: 1775547237375
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: b044fd47490d6bb63eda6486e4596c9172a7e3af0c133d6b2de95dc26de02a46
+  md5: 730bc10c6df375ace3f9532d225f7f58
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22522
-  timestamp: 1769480735309
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-include-directories-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 36c2686bc44e2753f2173dec6c8d2ef4adabd05b75380fcb7fdfe73cef7d8f06
-  md5: 891a0636fc7c02f433b1aa6314239648
+  size: 22435
+  timestamp: 1775546911345
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-include-directories-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 923160e3529966a6df704a52db59c62ecc1c4f8a594a645a124ce7a953712ba4
+  md5: dee065702b99fc7ff7631dfb76697888
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22508
-  timestamp: 1769481026559
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 9f344aea3c6c3189e1837d3e49f9cbb2f58f15ef894c0e363d5799c3093d1b9f
-  md5: 2c37d7ef87df5ffb736909a569b5677f
+  size: 22574
+  timestamp: 1775547163667
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 49bc3ed68e16f3a6ce1c7d81d526cd487c5dc7eae26f29e7f44578950256a207
+  md5: e0d6189736bff3a3f08c3e5ef94e5ca4
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-export-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22711
-  timestamp: 1769480789655
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-interfaces-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 4c314eeb288f4894414833be08256934be1aef70bc3f0cfdff7d2274d85c95d7
-  md5: 815b233c9cf36fa0987b7d8f2b68c7a9
+  size: 22644
+  timestamp: 1775546963050
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-interfaces-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 18c7fd70b7b86b3f9e9fd9d25a4e52cbad62c57f111bd770d12fde9c4c061f42
+  md5: db2a6e16aaf27bced0bed070ec65ea8c
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-export-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22734
-  timestamp: 1769481119799
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 74b890cb42fe3782240732c412335417f70efebf8f6f95951ffb2f0b89116758
-  md5: 003f824386ad0df5e28685886c935a54
+  size: 22757
+  timestamp: 1775547214504
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 43065ef921bb436a2ee7781dfb31bb90bf8530ecd7b336f663bd79e6476e542b
+  md5: 2097b645102b1d63757b1b4ed30c1a6c
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24064
-  timestamp: 1769480717067
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-libraries-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: a4512c2af1946aab6afc95d99a1d3d9f05fca13c32a6a32d0d3b2bcfbc86ed97
-  md5: afacdca62011ca7c1dc19497bd00b8ad
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 24066
-  timestamp: 1769481005371
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 467316e076be16bbcb06634bb4f95f0d79c05927b895202748247cc71ae40e1d
-  md5: 00b9c414a1ee9b08ede82a212e525559
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 23956
+  timestamp: 1775546891063
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-libraries-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 4509714fa6f2658397032a9d29728d5a93f42e137c91b220894a05937c488afa
+  md5: d7d40e8827b58625e5136b197745d0d8
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 24126
+  timestamp: 1775547142032
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 0dedd4cf45a73d279f85f284b42a2d9b508861026b2e1fb00fccffed219d97d3
+  md5: af61c4bae2c975c4b6b714f21c2c34fd
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 21962
+  timestamp: 1775546907187
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-link-flags-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: d8120111cc8fa8e6c1498d774aa5ff846497a314f1ecece9bbd45f65946d121b
+  md5: 5fbeb7ec4ead90a98a2c90be0a492ac6
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 22093
+  timestamp: 1775547159791
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 35ce95acc60b229e8614b82e0e8494c0708f86987f90aff64770083c9d4ed7f9
+  md5: 2e9e76938e608bd2863eb1b37dbab16b
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22796
+  timestamp: 1775546999584
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-targets-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: fff489a7d529928516108dbe57d5358fa01befa5e098fc530a0b2cd76434b72c
+  md5: 4485e9606c1b8068ea2b4fda1ad572d0
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ament-cmake-export-libraries
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 22918
+  timestamp: 1775547246800
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: aceeadf46266513c0253c7449c6ed12df9411be79488cea86d6602052fb3dd25
+  md5: 9523157b81f4e2f1864ac79a362aed56
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-flake8
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24300
+  timestamp: 1775547839333
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 3161fe56acb4288819eb253a1f14b46954218ee28d1dff8b98819706940b2cd9
+  md5: 2121eafbfa3cd6c13856b9eb9a9b60d7
+  depends:
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-ament-flake8
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24439
+  timestamp: 1775547986435
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: acc2405f656e89597f4afce49b563d99f5e1d3eeb0f95c8caaae411b7f0305d2
+  md5: 80072ff4b56dccb2fce2578b5366a73f
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24741
+  timestamp: 1775547207574
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gen-version-h-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: df7c6f3f8277720496d602c223354191e0bf86499ea95151c43a7e2ccdd31a38
+  md5: 5a4aba8e4922988c63615b47344216f6
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24889
+  timestamp: 1775547431738
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: be92c1a428b7d88a3b5309de8313afc448fe839f3c5ef7dfe3a94abc2a3cb284
+  md5: 0e789de3cdcc8cd0378fa39813f4aa9d
+  depends:
+  - gmock
+  - python
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gmock-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 24916
+  timestamp: 1775547221018
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gmock-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 63ae885a1126620d1024c33cb99fd8cf11f39476edd2a1b95c04fa0bbbfa1bf9
+  md5: 3bbe0cf7af9d4f69ce892dc7ac024647
+  depends:
+  - gmock
+  - python
+  - ros-kilted-ament-cmake-gtest
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gmock-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 25051
+  timestamp: 1775547438839
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 769ce5f530f840682fd976516ecca720769b2a0c1bbe82cede70bb9dda27cc9f
+  md5: e281945fab528fa1852d27e59b86892e
+  depends:
+  - gtest
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - gtest >=1.17.0,<1.17.1.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 24638
+  timestamp: 1775547078388
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gtest-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 916ba422a5da93c61e6c2b2a06cc121ac57be10488ce84b0f7dcfdb6b381fc66
+  md5: 58c353b5211022875951b7ec032def56
+  depends:
+  - gtest
+  - python
+  - ros-kilted-ament-cmake-test
+  - ros-kilted-gtest-vendor
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - gtest >=1.17.0,<1.17.1.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24777
+  timestamp: 1775547336777
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: ab7ff425c7a49b4e1317e8875e73d4611a2e726cce5087a56fdfabab8040de87
+  md5: 35059b446952f248a747b12968d733a2
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 21871
+  timestamp: 1775546918522
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-include-directories-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 50a246f1d4e7ed5c833ac22f3d9603773d632c70e6b3b71aafab2b8698fd13e1
+  md5: e04a1be81749c8fcf28a808baac515c0
+  depends:
+  - python
+  - ros-kilted-ament-cmake-core
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
   size: 22072
-  timestamp: 1769480732895
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-link-flags-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 5b8712da5f301604a85ea278176fedc25fc7c7b0fab453c4c92ceef0ae15e484
-  md5: ee9e430d64b799bf5a9769f2a341839d
+  timestamp: 1775547172489
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: d583899909dbf018fa87181f1a9b1511b04737f078b73d2a6992920e65a64456
+  md5: 4016fdfd9d2542dc053788da8409adf5
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22078
-  timestamp: 1769481022804
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: b9d9575853ae818e67a0a23b08bb5984afa3b1eb65ca36b73737e5af24b5ecf8
-  md5: fd5a17abd307705dcd3bdb2898dc50a7
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22842
-  timestamp: 1769480820688
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-export-targets-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 18eddef8d18344c9a1743e23d60145e95779d67af6292caa3ae85801a36b8921
-  md5: 0db9291c81d2310cfe463ea979473753
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ament-cmake-export-libraries
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 22880
-  timestamp: 1769481150652
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 2e598c5947b41a801132cec18f653f1ca1a8d144a5abf0984b2e92d9ca16f87b
-  md5: 72f532de20c5842c9155851f34e1a9ce
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-flake8
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24401
-  timestamp: 1769481533987
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-flake8-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 49d87e480a0215536ce10740cdbfb406aa8b6c8834c5833c9f6b4322c17394be
-  md5: f47bf63ad91e5bc523cc59d697645366
-  depends:
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-ament-flake8
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24396
-  timestamp: 1769481876780
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 26b18d2167ddf9142c0e23ad2830cbad7c483d2cf6922eeebd680cf85482ecc2
-  md5: 881401cd2f5543c7014b9b8ce9f58839
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 24858
-  timestamp: 1769481007827
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gen-version-h-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: bd25b02263c5fcdfe2754e0d2eafe8f46c9565677972a3a3b3b312e7cbbc393e
-  md5: 07906f5909b0f19c3d3ca85e76ccb414
+  size: 21567
+  timestamp: 1775546914327
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-libraries-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 36266ffe4ea38cf1b89f4cb275b45bb434d9958baf635af77cc9dae83d206c2b
+  md5: 40f303dd022cbb0787d61202d434e072
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24855
-  timestamp: 1769481323548
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 884697d38dd5d9f732a9a7298db85a8ad59c61c95c7859e09638fcb20ac81596
-  md5: 8b2c84b624599159f5fd52e8f53ffdf4
-  depends:
-  - gmock
-  - python
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gmock-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24969
-  timestamp: 1769481015135
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gmock-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 0a7198a4901283c2dd715d5d41e1cb228e889cde3c600ceab8d881924adc5381
-  md5: 12c955c30569d3ce536b1f8250263278
-  depends:
-  - gmock
-  - python
-  - ros-kilted-ament-cmake-gtest
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gmock-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 24958
-  timestamp: 1769481340647
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 2a93fe86af764b3d0f146cd504f2fbd58b79a84b81c9f7624b7907e2e02779dd
-  md5: 5e01157c6eeaca03a52c4433f144ee71
-  depends:
-  - gtest
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gtest-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - gtest >=1.17.0,<1.17.1.0a0
   - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 24727
-  timestamp: 1769480902483
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-gtest-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 517cbab0fe85f6958badca75ac663bef991df325da1e79dab3839cb41b022b4b
-  md5: 3773d1a1ff718831fe65ac326feec5c6
-  depends:
-  - gtest
-  - python
-  - ros-kilted-ament-cmake-test
-  - ros-kilted-gtest-vendor
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - gtest >=1.17.0,<1.17.1.0a0
-  license: Apache-2.0
-  size: 24732
-  timestamp: 1769481227656
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5f0f8e99de8873f83a86b0e270e0db8cd52b5a56509ec9d749bdb260b551c354
-  md5: f7ca94da299f30afddac7a57287e7254
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 21983
-  timestamp: 1769480743262
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-include-directories-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: e4bfbc2899b2fffb9e15bb5e1ac5d73d99232e7c9663cece4fe5c79c82153157
-  md5: 75e499e09e0a10c9869ecdeb80d87299
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 22021
-  timestamp: 1769481083926
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5c8829b5b649319911651dea098321d130d6df60d19c86bc4ef93cd4e3663eaa
-  md5: 8bfdcb115448d744bdce81e32968786d
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 21677
-  timestamp: 1769480740419
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-libraries-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 3158c2bff04b44785e424718edc39910f45ea2e57f2714b330df43bf3f558338
-  md5: daf6f46c2ef26cefed9991472a42550c
-  depends:
-  - python
-  - ros-kilted-ament-cmake-core
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 21720
-  timestamp: 1769481079120
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 35b8649e41fccf6b3d8d1bfc247ac3aaf5b48bc7cc4ebb249cb8540a0e1e078a
-  md5: 95553d5e0b7febbdd97efacc95ce613f
+  size: 21744
+  timestamp: 1775547168742
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: fa45a1f5487c5ce70ebb6fe3aadd2bab834ebc5cdba03521a422d4cdfce9c366
+  md5: 3b098af2a935e2a506167cf30240ffaf
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-lint-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22466
-  timestamp: 1769481317856
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: bca56ffa45dc7575b9f3ccd3e9612275779f93980b3f54b00308fbdf17fad72c
-  md5: 95f0eae10c2cefd329e1762f85c7a674
+  size: 22320
+  timestamp: 1775547573322
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-lint-cmake-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 15050a01a4320a4acf28575e6dc1d289556a5d1958dcb436fa22826de6df0262
+  md5: e625844fb3fcfe95a7666d33cd56c314
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-lint-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22453
-  timestamp: 1769481643818
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 0887f0c8752693120e2a6223fb8d79587bc3b2885114af9007afb5830334ae25
-  md5: 9a52a42e2ec48222ed221b6e2f53af74
+  size: 22462
+  timestamp: 1775547765186
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 19bcac83bd5099ea9c2cba71ba6e0434834db12f1717236ac69728debe39a2df
+  md5: da51ebb254b53e4da9a79e5bc73793e4
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-pep257
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23131
-  timestamp: 1769481530853
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 7f8bba1f4ca48804664e2f21590b9236a6fd25ce868c9be1de73558db8f93aa4
-  md5: f781a9ea909631aa9cf63d5e17e765e9
+  size: 23127
+  timestamp: 1775547834487
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pep257-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: b2774dca23f41909e4f4d8affa1d757d51bb45c78b4bfccc5a74803e29f6583d
+  md5: 7bd44750bb3d48fa8f96244e82cc1dd2
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-pep257
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 23206
-  timestamp: 1769481873044
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 3619d742f876b2d70029ce84382faeb5ab20c714154a830761a9d01ee3da6912
-  md5: 8e96b311d0505cb58d9eee8b51ab44b3
+  size: 23235
+  timestamp: 1775547980176
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: c96a78e6e18786301836386d8ad4a46380a2730f01252e0468730d8b6b279a07
+  md5: 8b1b563f8f96b821bd9f1011b2cff3ec
   depends:
   - pytest
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24915
-  timestamp: 1769480918140
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pytest-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 11f8505a16706d2816463ce86577821a81d9f9f3bd8f947e22c8a845b8cff8ef
-  md5: 8cf4ccb0b4d6e147872806bd539f3162
+  size: 24879
+  timestamp: 1775547095042
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-pytest-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: ed08882f82aae3c1bac088b4bb5018fec2d4558cf5bb12cc6c4c8435fcaa4ebf
+  md5: 3d765849a07b7eee961e472fb8d1c8c9
   depends:
   - pytest
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 24940
-  timestamp: 1769481241270
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 6c026590141a204404ef1d29048a0b3dd942b8336e2b6321f493659ada980791
-  md5: 92fe94f74cc22d28c2c7499a16207597
+  size: 24967
+  timestamp: 1775547361468
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-python-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 773b02bef57e16ee0f97ec1c507929c2b76d168ef79d5a10bf56ee80b37a8f87
+  md5: 2932843f2dadd2ceb84222e9536ab852
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24233
-  timestamp: 1769480730766
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-python-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: f9a9db39935e0bc30b59e36ab8090c08be7385ed8013c1a4609d8a00eda06a80
-  md5: 33e08aaa71fb3d62247667626558435c
+  size: 24116
+  timestamp: 1775546903019
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-python-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 3cd6405dde297b2e4a7008d22d5d59b4e69d58a27e13bce8dd377d17d9962bed
+  md5: 807831cdb332381ffef6b996e6ee242b
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 24264
-  timestamp: 1769481058568
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 68cbacba669307e3e4d6779d25a48e3204ba51965f4098a6dc26d8aed16607cc
-  md5: ffb557307b62a1afa4ba895ac1744383
+  size: 24276
+  timestamp: 1775547156110
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: 227801e80779eaa81a7f2af2c2282e8c85ba7184236a868165530a8a807d31a9
+  md5: 79d96d4ae3ab11dad2657d819d35e258
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -37451,20 +36878,19 @@ packages:
   - ros-kilted-ament-cmake-ros-core
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 31437
-  timestamp: 1769484283079
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h61f2ce4_15.conda
-  sha256: cb424b81b9d8354866d54b971586e57233edef1997a9c45ea6da3ccd1f1b0425
-  md5: 93b226d83251d93fd084761ba5f9f222
+  size: 31528
+  timestamp: 1775550474145
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-0.14.7-np2py312h61f2ce4_17.conda
+  sha256: 544e2d4b6931a85d57375340ea8935c14ef6c1e9b82ad9e05c19abec4ad492e4
+  md5: 60190591b42310a453d208da0c487139
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -37474,339 +36900,325 @@ packages:
   - ros-kilted-ament-cmake-ros-core
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 31402
-  timestamp: 1769484434833
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 9365320bc946d43aeafee521d188299fdebdfabca0918b2e8ce9e461138ebd26
-  md5: 7c52656bd8d4222e34f38df6391b469b
+  size: 31565
+  timestamp: 1775550311622
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: 8d3b4a40844d9792b636220e6269309be03539763ec1b78526f1869f78a9cb04
+  md5: f31bc898c6fa860e878f886b17b239c6
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26949
-  timestamp: 1769481907394
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h61f2ce4_15.conda
-  sha256: b18d6c09b28c3ab379b6eb5aa65a19d0ee87de79e725bf7dc6de6b3a2fe1cc62
-  md5: a98aaed835bf92e8e3400d7409b9e8fc
+  size: 27027
+  timestamp: 1775548192666
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-ros-core-0.14.7-np2py312h61f2ce4_17.conda
+  sha256: 24fba3c4045b7fa29bd0b8998b5e835e555567c3402ce00fd32743e0229cf006
+  md5: a8d5717140e276c268456c63f0d6108f
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26900
-  timestamp: 1769482242933
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 82515e1e547fe97d8a2bc828384f32423f6c0dc5b061ad5d8aab5740437df286
-  md5: 89f796d6e2f2749f814b35c0f0668287
+  size: 27111
+  timestamp: 1775548270462
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: c28bf7f3343ab0af8ff573f110fad6f02871c741dd2d1426384e643bfea5f508
+  md5: f6fd85bcdae11c1691408ed13a70be85
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-include-directories
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23932
-  timestamp: 1769480816925
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-target-dependencies-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: dde75776e83d29114cfdc80a68c3f58b5ac7671b1fe6a11f38e815b3475c184a
-  md5: 3a7493407362bcfc5ef89cf1559973b4
+  size: 23847
+  timestamp: 1775546994581
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-target-dependencies-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: 19125bd94cfae2fdd316f4146e80a30573817ecaf5a9f52d5784bbf2690a614f
+  md5: e3ef6eea043bb5826fc5eaefe9ac58c9
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-include-directories
   - ros-kilted-ament-cmake-libraries
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23948
-  timestamp: 1769481147043
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 5a3b6c9413ec8763f1d99438cf3e53ffb54a26ca4334952f836195006b9a4583
-  md5: 37278ec25dd247b4ce3d9d3a0f07407c
+  size: 24000
+  timestamp: 1775547242123
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-test-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 091fc3fa4dd74c35712a021e84fb23e74ddfe0ce04c071c60b951232b9d40d36
+  md5: 83490826e62b7bffbb03665a99eb3632
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36128
-  timestamp: 1769480803209
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-test-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: da42e7890b1da2effbabc443c12cde4857e5f8cff88cf59c8efca2efd9e434f9
-  md5: d16163f3da3d62745fd9899c60b3978c
+  size: 36013
+  timestamp: 1775546979031
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-test-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: fd90b3d1bc2d1d4dff4dbf282dcfd8907924635d4382c6037b9a7f4e0a243281
+  md5: 7876d30fb467271cf6d3c46430976deb
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 36114
-  timestamp: 1769481134489
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d66b90aeae700f4789c6d4e7e058694b8f34f21bfe24a73a61e229e197588755
-  md5: 1ce82ab15d9f893241772b41d4d13b28
+  size: 36170
+  timestamp: 1775547227348
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 6502415382293742485580397cde9a9cab9f133433a4a301da92b80b4ff59bf1
+  md5: a5d1a9f59731460718c2a0d90d6e2262
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-uncrustify
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23696
-  timestamp: 1769481527634
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 8f925cf594a27517fc354e7fa97935224614e7ddccead4cf9309b6b34b8f2d87
-  md5: 4a158232737e40e4d796e2cce0af0064
+  size: 23670
+  timestamp: 1775547828596
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-uncrustify-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 37c3f0c3a3842842daba2bf00d8cd2b7ec098c590b47934bba468e41a524b80c
+  md5: 6694c345b9a256ae083ce60fb5de6e40
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-uncrustify
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 23777
-  timestamp: 1769481866612
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.4-np2py312h2ed9cc7_15.conda
-  sha256: 8dba01c60fdbf70d91eeeac51e838eb206ab384f8284003d4708e86c74e420a0
-  md5: e743c926d8767a3477132e2a9734aa95
+  size: 23834
+  timestamp: 1775547975462
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-version-2.7.5-np2py312h2ed9cc7_17.conda
+  sha256: 524023fa68f02ef3c2a0f8498eafed79b5113709f69b4711164d10bf9effa5f8
+  md5: 06cc56e859ed55e54b1dc6e75742a29c
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 21841
-  timestamp: 1769480730458
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-version-2.7.4-np2py312h61f2ce4_15.conda
-  sha256: 9ed2902de272d16ac115ebd18d6ca3373aa9fea708e6fc7d7174a55f6e685b3c
-  md5: 43f6e6e62a1766d0ae81a8cf85918cf3
+  size: 21746
+  timestamp: 1775546902592
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-version-2.7.5-np2py312h61f2ce4_17.conda
+  sha256: ef565cee5d9d81f63f5904f5ce08826e0d3b82945aac4d048f4e5d491ae11db8
+  md5: e0199e9314f9732d1ace12e366d7a8e5
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 21870
-  timestamp: 1769481018823
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 9c6f6d5ecef33ea31d3e3205ff2ffd14011e359214934cb066eff80c4a057d6a
-  md5: 6b77831d9bf6b347bcaf8b2a61c43572
+  size: 21909
+  timestamp: 1775547154553
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: db4d020e444fc0d4d0cd43b69b8047a35bd95da22e9c2e54601b1c7a7e27cb40
+  md5: 2bd3c75df8f994f09ce8eac421daadd6
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 23145
-  timestamp: 1769481508877
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: c2ddf55c9499b84c70405def271df79ca9f396f399f068629c185b3f4d0c7587
-  md5: 8eee7a5ffdf55d82867de8a7bddc6a36
+  size: 23121
+  timestamp: 1775547814591
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cmake-xmllint-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: c9feaeb04a016a3fe01d8392223c179692fda33218a6495afcf7395f94e69e1f
+  md5: f5b82e24c96ffa08b4d2020267a74e28
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-ament-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 23170
-  timestamp: 1769481852496
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 6aa31473a87dae773d64ce2f539c31a7d58c7d4f0a6b5fd25aab5d8bb82d2343
-  md5: 9b784da5ac4e74a0a5e5da2d01b0c14a
+  size: 23216
+  timestamp: 1775547962060
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-copyright-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 6be8a9e348235ff3db82b875f9c1af84f5a90f8a2fdc89cab76c0568b86472b3
+  md5: c879dd54d1c623e068838d1fcf0edf29
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 66724
-  timestamp: 1769480992745
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-copyright-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: d736dd8035ce19a163fa1221d4d4e58bbf40b22af8e843aafa87580d8e169f08
-  md5: 502a6e440d8511e20c44e4c6d8dd7764
+  size: 66487
+  timestamp: 1775547176258
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-copyright-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 7e1dbd1f72477a8add2d40a42ca678d292838cf5bba38acc42a23f332a605c54
+  md5: 73b2ccfa7e9a14a64a8d1211dc611ca1
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 66705
-  timestamp: 1769481306020
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d0a3ed65f89d81bb9380be164f9192755bf31ef20baca9a21edd00a47aef50bc
-  md5: adf590ff0763679a66e1990e4af26e49
+  size: 66600
+  timestamp: 1775547416897
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cppcheck-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 2b4a2c9b7228b791bbf9d457e5b78694ae621b01866da7d390a0411a67b9005f
+  md5: 30afffcee4dae3d3841f57d64f9b9638
   depends:
   - cppcheck
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30333
-  timestamp: 1769481347590
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cppcheck-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 15f24c2beeb17077ce6ebb043ef352dd7749c3e4f09223410a8ae3966b84f002
-  md5: fad263f4c0790dea23b98d9940a6496a
+  size: 30042
+  timestamp: 1775547606835
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cppcheck-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 0a2fa4a4e0555389b96a1236ef811fb5bd024f2d04527b3d92e9abc8808ca3d3
+  md5: b027066b03895626942f12dd502612d0
   depends:
   - cppcheck
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30307
-  timestamp: 1769481669910
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 26784f92d828c4f12fc7864b2a9fefd61bf8a20e451e2f26a09ae2d7df8ae9e1
-  md5: f63e2c7f509af8911e0c127c9b5fbcf4
+  size: 30165
+  timestamp: 1775547796364
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-cpplint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: ef17a6393abd54a6766981e84cabc97c772c4c8d3d68a041e89d9f24bd9a1623
+  md5: 172668d4570336154c26c6eac0a3e30b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 169476
-  timestamp: 1769481219523
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cpplint-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: e733b6cb30c3b898207bec62a129035d06a10c163861b06e07dea49b825e84e0
-  md5: 3b8b2f313c63941214292082aa37ef58
+  size: 169222
+  timestamp: 1775547490817
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-cpplint-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 48855930fb922b24331e2c1604683ee9d92f8a4f51c859a6af3c6ddab94117e3
+  md5: 8c830e39682fb0056636484b5d826f52
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 169457
-  timestamp: 1769481551590
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: c34f8ba11875bb03bbcdc95271b8889cf0914d43d5b1f1e3910b35ec6fedaa55
-  md5: 1c8b4dff520b9d84f1624f103ce1c494
+  size: 169372
+  timestamp: 1775547676719
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-flake8-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 31e3af40a3db2a246e0dfa349b55371b3b1a2fed0c0ad9a8b7d0690b12013f22
+  md5: 06bb8ec21556f91b76da9c6dac4ce3f1
   depends:
   - flake8
   - flake8-builtins
@@ -37817,20 +37229,19 @@ packages:
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28444
-  timestamp: 1769480790211
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-flake8-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 070e830d4f79f79d333bf939e04bec866b0112ff6f161eee53b6d502b6ea757c
-  md5: c0f597d48780936ec9105ef12be0d73b
+  size: 28208
+  timestamp: 1775546964948
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-flake8-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 6da4fc60c0d3849d459caa15aa352c6bf59c8c1ed281d4a38a623414511c3f0d
+  md5: a448743376337c2599443b1658c44d5a
   depends:
   - flake8
   - flake8-builtins
@@ -37841,184 +37252,177 @@ packages:
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 28452
-  timestamp: 1769481119862
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.2-np2py312h2ed9cc7_15.conda
-  sha256: 8214ed7ae705dbfb85e556b327e5e7f9ab05cd742fc842656d101d3e5222c64c
-  md5: 13c6c302922f1aa14cd9d683bb7dc851
+  size: 28354
+  timestamp: 1775547213182
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-cpp-1.11.3-np2py312h2ed9cc7_17.conda
+  sha256: c8ced08dfa7caccbcd2468a173c4c326003ffcb7c178771ae882f4e9d7542ef9
+  md5: 53b094689fbead2a33c6c47a16cd9b17
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 52338
+  timestamp: 1775548543053
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-cpp-1.11.3-np2py312h61f2ce4_17.conda
+  sha256: 6cc23473649615683022bac0eccf407acd959ce94c5cc060d2d4f2ff929feb54
+  md5: 82d3804a16b24e2ac567f97dccd969d4
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 51561
+  timestamp: 1775548504695
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.3-np2py312h2ed9cc7_17.conda
+  sha256: 35de5c6172510ad551a2bfcf06c7ff383c490db24c54c7bf06208494b1fe4846
+  md5: 268e9a1947ab9a19b88e2831b988e0ef
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 30502
+  timestamp: 1775547588121
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-python-1.11.3-np2py312h61f2ce4_17.conda
+  sha256: 21a7360a115b2570a95eb756429262888562c4de4c1a1de1dbada14506da81ac
+  md5: f2fba9341358daa35f9b89b492616b99
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 30623
+  timestamp: 1775547779077
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 73cfcf49b46619773eed9a439d8263efcc16595f9deaba304e9227fa3dee074f
+  md5: 47593ea1b76419873cb9969967f11a8b
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 47318
-  timestamp: 1769482249098
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-cpp-1.11.2-np2py312h61f2ce4_15.conda
-  sha256: 703e081c11669111206014efe3e768a7e7dac2fb409ae77d4d646989cdbdce40
-  md5: 37f3e02667409ca160a62f224c024d58
+  size: 17450
+  timestamp: 1775546890246
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 6a08a8275e949e9641a2002db74098ec2f8d1056acea837f9b6cadac89cbe546
+  md5: 9825a59b668ceeffa7288e582fde7bec
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  license: Apache-2.0
-  size: 46772
-  timestamp: 1769482472734
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-index-python-1.11.2-np2py312h2ed9cc7_15.conda
-  sha256: f22dcb480a960217c725d72535312cfea3c9ec62a23b720fcbe882bd91d13e90
-  md5: 2701b3d22fe007869f2175d981684992
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 30782
-  timestamp: 1769481335293
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-index-python-1.11.2-np2py312h61f2ce4_15.conda
-  sha256: 9c7a9112d66998e27d53825a62f749f925444e8a24d331ee72051f89686dd18b
-  md5: 67235a84cec18123de26f59d62241b8b
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 30753
-  timestamp: 1769481657595
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 5be09a96a230b4ab934049c347b6b631f2e124576ce131fbc9385f24d3aca378
-  md5: 24fbc34aafec03038079daae6bbb73a3
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 17707
-  timestamp: 1769480717597
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 0ba2ed22b13b4c41161f161da1a4eceb8404d8e62d31352687db80a99f2653ef
-  md5: b887c7379cf8bf716ec740f0945cf9b0
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 17736
-  timestamp: 1769481043680
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: d34a706b4158bf666742b623cc1b298ccc3e850e1e0136aca002fb1c710f9b5c
-  md5: 3fb4801466c1988de38f04e2de7fb6c3
+  size: 17607
+  timestamp: 1775547142040
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-auto-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: cb2a6e8dcd4c8476fae8ea97106cbde9a410857ff1633164ee3f774a2c1e1736
+  md5: a9eab95a94e7080cf158107d985f92d3
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22063
-  timestamp: 1769480914604
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-auto-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 177cdcef725c32accdacce93913f5059aa10808f601ae68b3482f63b724cb45f
-  md5: c698d383270875f5675c5b8e480b984b
+  size: 21989
+  timestamp: 1775547090680
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-auto-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: c929160a0117ef290f284f2e27b2167314e6e225e3ca75540b5fc143cdb4b5ca
+  md5: afd249e51e93afe8900920b87b11fe77
   depends:
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ament-cmake-test
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22102
-  timestamp: 1769481238040
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: b21aed41fcb1024bfa29102cb3e5df70a364a31bdf9d2a0e7292949ce68527b7
-  md5: 7d6e6de3c4a18b3ec840ca232a0216dd
+  size: 22132
+  timestamp: 1775547354154
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: a8bab22294f560aafc499fbd556440499b27a05690c507dba99215d9e010b7fe
+  md5: 7dc9e9e1b85536dbd9bcc2cb4f0269cc
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 39882
-  timestamp: 1769481189235
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 6558e50e76da470cf7f00f90b0ee4fefe77a5445d13a347aa788fdf05075d7bb
-  md5: 079cfae52177e7f6a384c3b84007c73e
+  size: 39643
+  timestamp: 1775547417198
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-cmake-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 8e3af6adf6dd8521b17fd2e9f5ca4ad37b39515fbe6dad86fc89b9bb6be03312
+  md5: 801f89d9a047f3314c7d0b64035f392f
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 39914
-  timestamp: 1769481521599
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: eedce33897daded79f153386167e2763474f461e06e85602b37a6502a5fba6ce
-  md5: 4dd9f0a045be6382ad31521ab231c62e
+  size: 39771
+  timestamp: 1775547639906
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-lint-common-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: d617f5f510f0697c29e51f1404686067356b7bc43a580bd44615468f865c8f93
+  md5: 7f9e9dbe5d97482a8e25d69dc64d309a
   depends:
   - python
   - ros-kilted-ament-cmake-copyright
@@ -38031,20 +37435,19 @@ packages:
   - ros-kilted-ament-cmake-uncrustify
   - ros-kilted-ament-cmake-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22365
-  timestamp: 1769481566436
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-common-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: b6ac7b89dc470b10be6111cca9655de82b96893763b8bd5c2dd0702f163a530f
-  md5: 3c86a1c9566d4c0c677d6e9f954fed2d
+  size: 22309
+  timestamp: 1775547879574
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-lint-common-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: f50b2b73f3c877d440efe685b7ee7aa6243e38b49c76a187a14b3deefecbf887
+  md5: 95576ae0c210d365807139e7cfa8d5ec
   depends:
   - python
   - ros-kilted-ament-cmake-copyright
@@ -38057,304 +37460,296 @@ packages:
   - ros-kilted-ament-cmake-uncrustify
   - ros-kilted-ament-cmake-xmllint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22353
-  timestamp: 1769481931845
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_15.conda
-  sha256: 291b9dffcdf7d046dc5795c10818f44fa25eafd47b3cd8c7cc56a4669ce36dfb
-  md5: de16418e1ed797ebf75f6f241d610a65
+  size: 22475
+  timestamp: 1775548019645
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-package-0.17.2-np2py312h2ed9cc7_17.conda
+  sha256: b029632cc4dcb017e9bd8d703e5940a5ecd99e13158ebd10550c175841f9cc85
+  md5: 1f69c3912d148bd88796a514f5d6d20c
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - setuptools
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 43016
-  timestamp: 1769480640155
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-package-0.17.2-np2py312h61f2ce4_15.conda
-  sha256: 665c4c64f4daa3c2a157de8b70189cdc150af8d7a7d6c60aa13d4db41e0e6067
-  md5: 8e619c0582cd259d028f0646d85ceaeb
+  size: 42836
+  timestamp: 1775546815797
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-package-0.17.2-np2py312h61f2ce4_17.conda
+  sha256: a1fd3b7212be136ecbed346175c91d558153cd776bf3fc030433391965b368a4
+  md5: 3ea5ae36fd11d379ffae7cca86ba9e26
   depends:
   - importlib-metadata
   - importlib_resources
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - setuptools
-  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 43028
-  timestamp: 1769480922835
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: fa4e7940159bd4d2ac094a9835f78d3a3678829c305032600afc3a97f0334ad9
-  md5: 6d421e449affa3f6635e389940526c79
+  size: 42963
+  timestamp: 1775547071959
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-pep257-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: a2c45dbc197d8d8a51874eddc0e77a125fb1a2d0ed2383392e7af09af73a2964
+  md5: 4242fa902fde572cceb9611964098b8a
   depends:
   - pydocstyle
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 27110
-  timestamp: 1769480887391
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-pep257-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: ea66e32adcfbaf2616a9f631ea5ec31c3cddf8a72261a0f00a4467a77c170340
-  md5: e2c2600d80edf9c339e7b661fd5c9239
+  size: 26851
+  timestamp: 1775547063829
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-pep257-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 6b54e7b52d93e49742e2cbf7d3834e5219e665043c0a1334753b87aa0c363138
+  md5: b1bbddc026e933d1be65821a70d9ddca
   depends:
   - pydocstyle
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 27126
-  timestamp: 1769481212032
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: 3dcbbd0614e17959ce1ad3a23201ccbc21620000f53d0cf0055a5e143d4cc2ab
-  md5: bae1ca96a3fd4c9807d220fd18098533
+  size: 27015
+  timestamp: 1775547316894
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-uncrustify-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: e486f97892f4d24fc8b20019a619da91c6ae5b2aa00175a711a7321c509fce4a
+  md5: 1de29a953846b07315a3a21f20f1e6fc
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-uncrustify-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 68547
-  timestamp: 1769481342533
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-uncrustify-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: 1869bd8ab621bf2f7c5c9d708dcc178fc45b6bb9618e254af64bbb04a595e115
-  md5: 0fd53337989be4c258ccb3e743c0a461
+  size: 68343
+  timestamp: 1775547596599
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-uncrustify-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: 19759994b38066348dc363f4b7d61c5ef69b29403f29d2318cef7d92ceaa7ea6
+  md5: 119f45dcfe75f33616b0a29da05ae66f
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-uncrustify-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 68534
-  timestamp: 1769481664903
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_15.conda
-  sha256: b99e3734c6aa2805a18e680c2b9c45cd92c24086fdb736f507a1d8d7d18c5358
-  md5: 296f4f1296d72f5b1c66ee54a297ed30
+  size: 68435
+  timestamp: 1775547790038
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ament-xmllint-0.19.2-np2py312h2ed9cc7_17.conda
+  sha256: 4b1ecf3874ccedfba66c7c7122c7e8759c3b9ab21daa612eb94a7a616a8692d9
+  md5: b84f7ed7b7c5081fba854c6213ef2c4d
   depends:
   - libxml2
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28160
-  timestamp: 1769481086986
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-xmllint-0.19.2-np2py312h61f2ce4_15.conda
-  sha256: d54ba58f5f4cedeb58c6c567dfeca8c1fdb9816dbd036a7020aa979619dc42dc
-  md5: ccf8965b4b44fd0d3d80bc67e01c34de
+  size: 27933
+  timestamp: 1775547316530
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ament-xmllint-0.19.2-np2py312h61f2ce4_17.conda
+  sha256: af84d6a2ef54010d1525cda9142739ed3fe3adbd6c85a8a961fa9b9dd5f9f4c2
+  md5: e51e115fc2072ac7cd16c3d33ef133b2
   depends:
   - libxml2
   - python
   - ros-kilted-ament-lint
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 28156
-  timestamp: 1769481416777
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h2ed9cc7_15.conda
-  sha256: eb7b497cadbd59eb1fa68cb444b70309a1c5c7a34135cdd6a912211f3e818c23
-  md5: ea5d749796380f56d2489c135ebc1110
+  size: 28041
+  timestamp: 1775547504413
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-angles-1.16.1-np2py312h2ed9cc7_17.conda
+  sha256: 945fcd53b3e1ebbd706f28eed340f175e7404b9a044b3acdafba1191bae7f5cc
+  md5: 232ea0ac9a3018c0cf49c2c73c37a78b
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 34329
-  timestamp: 1769481234764
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h61f2ce4_15.conda
-  sha256: f63e2d3d83c98f44a70f36433f5903b8fbeacaaeef99dd54b6520e05316def20
-  md5: dbd67178e3c256d044e221f904649c1b
+  size: 34272
+  timestamp: 1775547442293
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-angles-1.16.1-np2py312h61f2ce4_17.conda
+  sha256: 74a3d2a8def47fe986285969adccf4db1d0c980124106f91532ed5a44e8b16c9
+  md5: cb700d76a77edd4811ee1996ccdd8cde
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 34275
-  timestamp: 1769481553465
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h2ed9cc7_15.conda
-  sha256: 90a6f651a999caf6183084601ca584b806dd7c3de3c840a264867ed334d33ada
-  md5: 6c4a9edae876f635bceea975e9ec07e0
+  size: 34357
+  timestamp: 1775547670133
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-backward-ros-1.0.8-np2py312h2ed9cc7_17.conda
+  sha256: 938454475b5496dc787944cd78f40eb75cbb32c5c45001c58fce819418935312
+  md5: cbd72560cc7ef75404ea13ccf1066585
   depends:
   - elfutils
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - elfutils >=0.194,<0.195.0a0
   - python_abi 3.12.* *_cp312
+  - elfutils >=0.194,<0.195.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: MIT
-  size: 333719
-  timestamp: 1769480849784
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h61f2ce4_15.conda
-  sha256: 771ad89e2eaac5e2c747d74ed36c4bfe6a1a893f95b15616113bb3bbb73e37a9
-  md5: 2a08bdf9be1715dbf7f09bc7528bc66b
+  size: 333579
+  timestamp: 1775547025050
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-backward-ros-1.0.8-np2py312h61f2ce4_17.conda
+  sha256: d9ae1fb673527015bf7abbbf301f1b42aa380b7eece50f0ece52c255804e050b
+  md5: fd7827f816b62821a0f10e982af9cec9
   depends:
   - elfutils
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - elfutils >=0.194,<0.195.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - elfutils >=0.194,<0.195.0a0
   license: MIT
-  size: 323385
-  timestamp: 1769481169504
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 2893e4a553c73351b790ec5934f6005e0b140c40c002c620afcc8b774f03b13f
-  md5: effaba6a72597d712d64c30f257418b8
+  size: 323413
+  timestamp: 1775547271522
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-builtin-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: d981b1b6eaff61c9d7f65e42554f38849681ebbf2e308f573a06a040278800f9
+  md5: 8992399be2191fa178ebeaa69b5e3857
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 78376
-  timestamp: 1769482959329
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-builtin-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: aed5d7a884f832245658397cb56d82a3a896bde449370bb5bcb3a768720745be
-  md5: 70ca389833ad493b9002acecce4fc5f6
+  size: 80442
+  timestamp: 1775549166535
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-builtin-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 277ef0cbd8ce660f35427c5d98d52d6d22afbd06b93ccc8df9b86f93950d9817
+  md5: 70514492a417770033574838f57ca195
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 82139
-  timestamp: 1769483235524
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_15.conda
-  sha256: f964517a49f200e28eff5a8519703c36493d79c0655608ced57b83b169cb90c6
-  md5: e76de5f7262b15e1585e75c2bf8f6611
+  size: 83984
+  timestamp: 1775549164374
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-class-loader-2.8.1-np2py312h2ed9cc7_17.conda
+  sha256: 7a798f855659b0050152b405fa8c6d246e11995598e63a6e48aafb693dffa32a
+  md5: a5cf7fe5ae40e3f361952cb44ca77972
   depends:
   - console_bridge
   - python
   - ros-kilted-console-bridge-vendor
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - console_bridge >=1.0.2,<1.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 74996
-  timestamp: 1769484350402
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-class-loader-2.8.1-np2py312h61f2ce4_15.conda
-  sha256: c9524fd57eb821fea7836371852ea5ef7ab12b541f1a060fc6994db55a165286
-  md5: 7f677efa67db8829ad6c479b8a20e8d1
+  size: 75039
+  timestamp: 1775550536242
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-class-loader-2.8.1-np2py312h61f2ce4_17.conda
+  sha256: 7cc612a89c9ba61f7a8ed1daf87d6901d8fcae18505433f892438a14df518e9b
+  md5: bcbe7a9ffb0c50d1a6289388712287bc
   depends:
   - console_bridge
   - python
   - ros-kilted-console-bridge-vendor
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - console_bridge >=1.0.2,<1.1.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 81044
-  timestamp: 1769484513537
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: ce9736083f5f7f3071771574dd0ef91302ef7ea56620778d0921864bd9726e71
-  md5: e37d071e458e1a4b70b1058d2aa1040f
+  size: 81240
+  timestamp: 1775550378872
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-common-interfaces-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 5c3b766b1ef9427ae995195d5aa355b1b2e6ad41f954f2ed81d5cd5d3b4b1e08
+  md5: d7b7d4aeb87f4227fe590092ed7eddca
   depends:
   - python
   - ros-kilted-actionlib-msgs
@@ -38370,20 +37765,19 @@ packages:
   - ros-kilted-stereo-msgs
   - ros-kilted-trajectory-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26736
-  timestamp: 1769484184350
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-common-interfaces-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 53cb6ddeeaf921d078af3e8afc87e3570e0b5d1c6a2ceee8ad84600e8b556d66
-  md5: 2669be9fdea0314d866a581f4b52bd68
+  size: 26863
+  timestamp: 1775550386515
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-common-interfaces-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: cf5542ceb0123a099f28274d95d931d379601f85fe04f0e11a89099c0388b3e6
+  md5: 625a33c902bac308d9bbd316f05474cd
   depends:
   - python
   - ros-kilted-actionlib-msgs
@@ -38399,90 +37793,88 @@ packages:
   - ros-kilted-stereo-msgs
   - ros-kilted-trajectory-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26746
-  timestamp: 1769484357681
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 084236f8ccd20c061818e907af5e1d2e08e0101124ec6d715a1966fba7071bdb
-  md5: 5f59e671702d5f717fafefb12c2ac857
+  size: 26927
+  timestamp: 1775550216794
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-composition-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 6e6eca5e8568eac94dee89cc825e01ace62fc02e82a00468e60bcac31cbf8834
+  md5: 8440bc2ca424bee4bb9aa5aca768c1bb
   depends:
   - python
   - ros-kilted-rcl-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 224241
-  timestamp: 1769483409226
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-composition-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: 1d54a14c20875d9288c6a200dd863dde130f1bdc59129bda7ed11ab5aa3441d9
-  md5: 92d9557aea06184dbb1e4bf5d34b50b0
+  size: 227468
+  timestamp: 1775549583148
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-composition-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 1f95a5043cda4e60ed94d9723a2ef1312578d4f6cecd8243a26162b64a197a55
+  md5: 2e2a50241764a2fca50aa8df3f2cdd09
   depends:
   - python
   - ros-kilted-rcl-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 229856
-  timestamp: 1769483680997
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_15.conda
-  sha256: a3ac7fc473e86bf0bc60e0a7800c08ed24253f091692d842ab4d239d145b3f99
-  md5: 03e0f3f9baf49a76546419538cff2ef2
+  size: 233244
+  timestamp: 1775549595452
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h2ed9cc7_17.conda
+  sha256: 8439ef0bcd0dd46541af67edd1dac97fb70b3217574a711ac394efa693270356
+  md5: 68658a292a3ce8d7850af77895e693f2
   depends:
   - console_bridge
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27851
-  timestamp: 1769482324658
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h61f2ce4_15.conda
-  sha256: 8636a375d2488f3c2226f953755c1cffea0306d60f3d08ecafa0098d78e3af8e
-  md5: dec6a549f2d27bdc0275a238133ab21f
+  size: 27870
+  timestamp: 1775548606197
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-console-bridge-vendor-1.8.0-np2py312h61f2ce4_17.conda
+  sha256: 911f492abb8592850a6a1c17a8093919ec63a6cd20ec21b337d394c10e41216b
+  md5: 2e11b54b908b62aab4cbbc6391a9954f
   depends:
   - console_bridge
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - console_bridge >=1.0.2,<1.1.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27838
-  timestamp: 1769482547054
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.7.0-np2py312h2ed9cc7_15.conda
-  sha256: 49ea5350ffb1888978fc2686283480b8f7d9598dea965294c50c8a615f019edf
-  md5: bcec99fc72a7fcb5997b0835f36082d0
+  size: 27978
+  timestamp: 1775548576398
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-msgs-6.8.0-np2py312h2ed9cc7_17.conda
+  sha256: e528cb981b23906d7786f0e1ac048704ea7bc20ea1b56c5ccf76c03c7c9c7fec
+  md5: d308ea713b309eab0d8345c01359b6b1
   depends:
   - python
   - ros-kilted-action-msgs
@@ -38494,20 +37886,19 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 1539952
-  timestamp: 1769483771340
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.7.0-np2py312h61f2ce4_15.conda
-  sha256: 342856bee198788811bd3ed410c97adf10ccbfcc9e75e37fa888325103ebfb90
-  md5: 624d8ff2f2ddc6f4caca0ae5738297b9
+  size: 1604561
+  timestamp: 1775549932462
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-msgs-6.8.0-np2py312h61f2ce4_17.conda
+  sha256: 32ad7edd226f0402fd33bac627eecd74f395df580edc4fb22ee842ad965ce25b
+  md5: f7453817f8d420daa4e32958390794d8
   depends:
   - python
   - ros-kilted-action-msgs
@@ -38519,20 +37910,20 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
   - ros-kilted-trajectory-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 1546329
-  timestamp: 1769484029957
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.8.3-np2py312h2c89a96_15.conda
-  sha256: d989a1b0c796eb691b97e720658f9f149e4f4cc41cd59632a4567aa17a6e67e4
-  md5: 3188985085fe58846fe3fdf0e6c7c389
+  size: 1608466
+  timestamp: 1775549884077
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-control-toolbox-5.8.3-np2py312h2c89a96_17.conda
+  sha256: c91ba15d00074270ab32b24bc416f7e06c3431ec5ffc969a29ed6521dcd4c0fc
+  md5: 0b32dc3b37b9bde402fd5d5e3b02eae4
   depends:
+  - cpp-expected
   - eigen
   - python
   - ros-kilted-backward-ros
@@ -38545,24 +37936,26 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
+  - ros-kilted-rsl
   - ros-kilted-tf2
   - ros-kilted-tf2-geometry-msgs
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 278871
-  timestamp: 1769486300923
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.8.3-np2py312h8b5252a_15.conda
-  sha256: a93028ee7959bae70a0e169eb1a9f4e788339ba7bef328429cee7dc045313109
-  md5: 291101933ea79e4d909cac81eed642fd
+  size: 279100
+  timestamp: 1775602843933
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-control-toolbox-5.8.3-np2py312h8b5252a_17.conda
+  sha256: 3663b9c84e796d157c2a4b77dc1bbad5a602b2f19a320c5b477ebdc301c3bd1e
+  md5: d592c4f4db36c025bbaafdfd3a21b4bd
   depends:
+  - cpp-expected
   - eigen
   - python
   - ros-kilted-backward-ros
@@ -38575,62 +37968,64 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
+  - ros-kilted-rsl
   - ros-kilted-tf2
   - ros-kilted-tf2-geometry-msgs
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 276425
-  timestamp: 1769486231854
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.11.3-np2py312h2c89a96_15.conda
-  sha256: d004112bf9ae72fa7e25b8144a9d3c8c40448887eaddca7fbafed0c1cf4c7b96
-  md5: 5b860e76e50868730a72a527090c5ca9
+  size: 277127
+  timestamp: 1775610470389
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-interface-5.12.0-np2py312h2c89a96_17.conda
+  sha256: f71f1649bc58a966ed9edead90dad57d0a7c2ba84255b049aab876940a75424f
+  md5: 85d7d551e6aa2220a681430f632a2c44
   depends:
   - python
   - ros-kilted-hardware-interface
   - ros-kilted-rclcpp-lifecycle
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - libstdcxx >=14
   - fmt >=12.1.0,<12.2.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 133121
-  timestamp: 1769486505833
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.11.3-np2py312h8b5252a_15.conda
-  sha256: 0427a58bf0e734749d8358ad57c092340b836fb64dc3b2bf606372727d2fb052
-  md5: 6bee68ca7f131f07ed495589b3f566b1
+  size: 133238
+  timestamp: 1775603152285
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-interface-5.12.0-np2py312h8b5252a_17.conda
+  sha256: ad49a86473208138635364cf7151d0d2020b25256705a9f1d6f337f632458432
+  md5: 21acb6a5d9234f94da67caaff5c1f866
   depends:
   - python
   - ros-kilted-hardware-interface
   - ros-kilted-rclcpp-lifecycle
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 131417
-  timestamp: 1769486414356
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.11.3-np2py312h2c89a96_15.conda
-  sha256: 0189204782548d40b0299f836f111523d7a9d1c03eeccb6072322034074300ba
-  md5: fd0a5cf8f600e8dae6d4d35eaa702841
+  size: 131774
+  timestamp: 1775610718579
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-5.12.0-np2py312h2c89a96_18.conda
+  sha256: ef4517fac73929d51219d18e0cea46076aa8a0cd2ccba22190e9e27ebdd6862d
+  md5: 2f6430ac8f5ee2c19c01ece96abe4bbb
   depends:
+  - filelock
   - fmt
   - python
   - pyyaml
@@ -38654,22 +38049,22 @@ packages:
   - ros-kilted-ros2param
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 676439
-  timestamp: 1769487245125
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.11.3-np2py312h8b5252a_15.conda
-  sha256: 2186bf60a3b09ce90dcb992cd2aedbb8357568a555b3ed3858681a5f7b00d78d
-  md5: de54be29f4d47fb4d1ca53d5b3f3900c
+  size: 679500
+  timestamp: 1776749305044
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-5.12.0-np2py312h8b5252a_18.conda
+  sha256: a8e618ce6b6362917e6695ede81c80f6c20d3724dee8e11d30871842eb2ec1d6
+  md5: 52a65a713d33e736793de893b68fad69
   depends:
+  - filelock
   - fmt
   - python
   - pyyaml
@@ -38693,19 +38088,19 @@ packages:
   - ros-kilted-ros2param
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 641648
-  timestamp: 1769486992713
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.11.3-np2py312h2ed9cc7_15.conda
-  sha256: 656db275c8454020cd1f88b8830823a63b29a6ccf89b934623155b8a882c6051
-  md5: 4c885720954413f8e17614c740c5bb2a
+  size: 643333
+  timestamp: 1776749475574
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-controller-manager-msgs-5.12.0-np2py312h2ed9cc7_17.conda
+  sha256: 36278ec6f52a8907d51900a9d93b4acc00da57ce895b72c0920d4333f8e190b3
+  md5: 37a4e7b27f121e9ef59a19cd740a15fa
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -38713,20 +38108,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 573055
-  timestamp: 1769483364545
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.11.3-np2py312h61f2ce4_15.conda
-  sha256: ff95d85cd7ffc7d9169cd9d0257868d4d5186143dc45276ba0c4db7214d4b23d
-  md5: c7393e7c8e715e75066c490cc9c6db91
+  size: 580339
+  timestamp: 1775549538549
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-controller-manager-msgs-5.12.0-np2py312h61f2ce4_17.conda
+  sha256: 34bd0cd7c53d8a8c8899cdb20bc3c0e9482cd1f55c8d2683d027cb72accf8cf3
+  md5: 9f057cf066d4142a8877a8053c336175
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -38734,18 +38128,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 579483
-  timestamp: 1769483650251
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_15.conda
-  sha256: bf6529b3a78493f3b034ba54fda08a3a99962be45706bec4fa04a0ea326f8940
-  md5: 8876184e5c17a515fd29f828a5fa6205
+  size: 586786
+  timestamp: 1775549556304
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-cyclonedds-0.10.5-np2py312h2ed9cc7_17.conda
+  sha256: 6361bc98d6dc314c715637a61f7357c6a8af3ce2f4e1c8b9c68e39f3368191e5
+  md5: d07e8e7e1e81062eedfd722ca3d892e3
   depends:
   - openssl
   - python
@@ -38753,20 +38147,20 @@ packages:
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-iceoryx-posh
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - openssl >=3.6.0,<4.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - openssl >=3.6.1,<4.0a0
   license: EPL-2.0 OR BSD-3-Clause
-  size: 1198745
-  timestamp: 1769481018679
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-cyclonedds-0.10.5-np2py312h61f2ce4_15.conda
-  sha256: 033f108be2d0ec42904c5c26acf3e820f8931a7bbb96b75fd057b5d6042d1515
-  md5: 3bff44aa6488632b2d23450d4bf6b049
+  size: 1198633
+  timestamp: 1775547228076
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-cyclonedds-0.10.5-np2py312h61f2ce4_17.conda
+  sha256: 82b56f4d2e38ffec714c9feac477b4f8976fe4d10f55465875d5010e9e54e1df
+  md5: b68583c79bdc298c93ae63f2ff213186
   depends:
   - openssl
   - python
@@ -38774,20 +38168,19 @@ packages:
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-iceoryx-posh
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - openssl >=3.6.0,<4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - openssl >=3.6.1,<4.0a0
+  - python_abi 3.12.* *_cp312
   license: EPL-2.0 OR BSD-3-Clause
-  size: 1262120
-  timestamp: 1769481346837
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: c0c59bd84116eb45371262b67a60b9f9d556295321a942622a55e7ad9acf3e6e
-  md5: f06410148f6797ebb284297157dea6cf
+  size: 1262160
+  timestamp: 1775547443134
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 774368d747e2b6c6bb8fb8d53edcc078041f501dbb13c87afc4acf3584798592
+  md5: 8628f2e9f515f209de0eb36f3a583732
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -38795,20 +38188,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 208495
-  timestamp: 1769483495945
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 526f94571ba8ae55b74ebfadd7a3f868234a2776bfd9ef4df9d930d10bd11c4f
-  md5: 09b4fdfdd260b4e56f5139a3b3deda36
+  size: 212290
+  timestamp: 1775549669603
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 784f5fc960d2a835bfddf1f6ae4195a7eb9499b7c8480d3d2ecd000c7a7f46f2
+  md5: 5e95216d3c62cbf3498fb906e4c775d9
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -38816,19 +38208,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 213619
-  timestamp: 1769483764695
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2ed9cc7_15.conda
-  sha256: c421ef73b6d2fe2eece4ab4be1a33591fbce4a942b637f263750a0ffea47bc77
-  md5: 70f5d336c33347d4abf032676115f295
+  size: 217475
+  timestamp: 1775549660467
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-diagnostic-updater-4.3.6-np2py312h2ed9cc7_17.conda
+  sha256: 57e743be0a3d060f5a4dc3314866a0e9f072e68fe9abd4528468ba546c483c96
+  md5: 14b4f207317e5a83e09eefcf1a85a7ab
   depends:
   - python
   - ros-kilted-diagnostic-msgs
@@ -38836,20 +38227,19 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 186171
-  timestamp: 1769485584679
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h61f2ce4_15.conda
-  sha256: de8fc4e79512777d728d8b3972ae8b3218afdb96d7749c10f916059eef1492be
-  md5: 2bdf0bbaeca124647baa786a6ca71387
+  size: 186459
+  timestamp: 1775551986252
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-diagnostic-updater-4.3.6-np2py312h61f2ce4_17.conda
+  sha256: 0c011d63cfcbb1d3ca1faa6a57f38f27f854ac872a635a61abe087cbd1d8614d
+  md5: 5795d4a597cb34ec1f00ccec215e11a5
   depends:
   - python
   - ros-kilted-diagnostic-msgs
@@ -38857,50 +38247,49 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 188143
-  timestamp: 1769485617257
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2ed9cc7_15.conda
-  sha256: 256b543d968d73054046a64a0c635ac92a85fc2a0dba4f415f69c54eb4ab2155
-  md5: 39a499c653da2b140c2d998d0fabc5c9
+  size: 188657
+  timestamp: 1775551481510
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h2ed9cc7_17.conda
+  sha256: 144c93f43ddefc0647086860a4d28c8ffa3a898e78168a4417ee63262bbcd281
+  md5: 440c29d737367f5cc6087c16e83ca581
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23609
-  timestamp: 1769481536453
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h61f2ce4_15.conda
-  sha256: c3cce986aaf8bac6afaeb3c116765829cfd7145fb872342be74e375912f5451f
-  md5: 6995b43b549a5df4436002e9c4dbe7df
+  size: 23491
+  timestamp: 1775547842117
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigen3-cmake-module-0.4.0-np2py312h61f2ce4_17.conda
+  sha256: 5888b2ed77ca8a3d26986546123b557ab90451c751aa8a93705537f39e332c55
+  md5: 9b5ca06470eca0c93f1a35f79cdbc93b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23589
-  timestamp: 1769481878867
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigenpy-3.12.0-np2py312h2e7a0af_15.conda
-  sha256: 3e50134089fbfec8f093857491c27cf01475b6c38278f0b4936681f303d1da8b
-  md5: 601a872af8b920e1cda2ecd1c31c1ffa
+  size: 23682
+  timestamp: 1775547992775
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-eigenpy-3.12.0-np2py312h23fe623_17.conda
+  sha256: 036e48160f39804abee500f73fa8dcb781bad518f4c5c8c46fa588932dc0765f
+  md5: 0c92318ee81ec3e877d8227cf9e8b9c2
   depends:
   - eigen
   - eigenpy >=3.12.0,<3.12.1a0
@@ -38909,20 +38298,21 @@ packages:
   - numpy
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - scipy
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libboost >=1.88.0,<1.89.0a0
-  - graphviz >=14.1.2,<15.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libboost-python >=1.88.0,<1.89.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - graphviz >=14.1.2,<15.0a0
   license: BSD-3-Clause
-  size: 21474
-  timestamp: 1773155922013
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigenpy-3.12.0-np2py312h3e490f4_15.conda
-  sha256: 9d1a67fd70514a104b7137da154ae24114bc8fd699dd79c2461b647cdb3bb824
-  md5: 6da4ec62a36b4ceceb5b84c9c945307f
+  size: 21750
+  timestamp: 1775546890021
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-eigenpy-3.12.0-np2py312ha1f14ce_17.conda
+  sha256: 7fdd60a1f7ad1feeaea74521223bcbdcdddc651b9fe62ecb3474c3f11e1e8091
+  md5: c67919b2f4fb538518d70ba022086eda
   depends:
   - eigen
   - eigenpy >=3.12.0,<3.12.1a0
@@ -38931,174 +38321,171 @@ packages:
   - numpy
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - scipy
-  - libboost >=1.88.0,<1.89.0a0
   - libboost-python >=1.88.0,<1.89.0a0
-  - numpy >=1.23,<3
   - graphviz >=14.1.2,<15.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 22512
-  timestamp: 1773156099002
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.3-np2py312h2ed9cc7_15.conda
-  sha256: f2ac2aa71ac7fcd45c22c805488745626defd9315f1446196eb788e1f873599b
-  md5: 8c47ecf373bd16953e7429b203bf0bf3
+  size: 22773
+  timestamp: 1775547143503
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastcdr-2.3.5-np2py312h2ed9cc7_17.conda
+  sha256: 07cb8eb1a61140e12b295668670b3079ea017be518d9c5c70385ff512bf4d412
+  md5: 30eb82f50f361d1cb06900301cf29325
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 89685
-  timestamp: 1769481202273
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastcdr-2.3.3-np2py312h61f2ce4_15.conda
-  sha256: b363ff0dd81e333f8525ae717377e6df7be8e7a0a4f855618b6aa694a186eedf
-  md5: 1f39931c30cf248673762712b8e2a333
+  size: 89534
+  timestamp: 1775547413501
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastcdr-2.3.5-np2py312h61f2ce4_17.conda
+  sha256: cf31e7dbd7b0e00462a5073324c72aebdb9a59c43960e0f34222c78627b7180d
+  md5: 8c1d36ddc69d3f634051c9a7a2536dcf
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 86634
-  timestamp: 1769481522397
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_15.conda
-  sha256: 89fcfa57d1d394d7188575f702324f47f968f39048a559de16240c4c57ff98da
-  md5: fbada3c49201f5057e5a681470609bfe
+  size: 86618
+  timestamp: 1775547640481
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-fastdds-3.2.3-np2py312h2ed9cc7_17.conda
+  sha256: 58582fb1a847919a02d326d55530e3463f0796128a333b0510ef89307a41343e
+  md5: 332aff327eb1e7c656a0de6ace58f6b4
   depends:
   - openssl
   - python
   - ros-kilted-fastcdr
   - ros-kilted-foonathan-memory-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
-  - openssl >=3.6.0,<4.0a0
+  - openssl >=3.6.1,<4.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 5031625
-  timestamp: 1769481881152
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastdds-3.2.3-np2py312h61f2ce4_15.conda
-  sha256: ad8ad7fa9d10a8ab2b2a37ce4228175abc078160ff35caeeceb02345dc5b169e
-  md5: f7ac37292b0eee3d14b9606fc0031642
+  size: 5049573
+  timestamp: 1775548161639
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-fastdds-3.2.3-np2py312h61f2ce4_17.conda
+  sha256: 5b4441327592e456d9f6efb25418f78b59d3b42303579a339c88e1fe6b856c92
+  md5: 93321602e3cb6e0e26456a0b94764a10
   depends:
   - openssl
   - python
   - ros-kilted-fastcdr
   - ros-kilted-foonathan-memory-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
   - libstdcxx >=14
   - libgcc >=14
-  - openssl >=3.6.0,<4.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - openssl >=3.6.1,<4.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 4835985
-  timestamp: 1769482197594
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h2ed9cc7_15.conda
-  sha256: d906748f04c50923cb563c0114507af328b5a253d7ab869c7205f0b985cd9ec2
-  md5: f219c9f0da1fdb6bb5f505d8f612b634
+  size: 4849168
+  timestamp: 1775548241928
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-filters-2.2.2-np2py312h2ed9cc7_17.conda
+  sha256: c2e0e477e987c10c769a5d6ba9ad5788c110e86cb5d1d77c19508ed257ec353f
+  md5: d0dd9dcd20df5dbd05adc2174efd59c0
   depends:
   - libboost-devel
   - python
   - ros-kilted-pluginlib
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - libboost >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 130171
-  timestamp: 1769485098727
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h61f2ce4_15.conda
-  sha256: 58f62841bfe3fe17d692a9032f592741037aa86bfa685cbb0a6932948c17588b
-  md5: 68198dd25429954f27a335716b1292ee
+  size: 130345
+  timestamp: 1775551284962
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-filters-2.2.2-np2py312h61f2ce4_17.conda
+  sha256: 75449ffe88023bdef0e3d8807f2bd88a12d3406e23763d8b85a2bc5eede30b4f
+  md5: 255639374a78417661f96eb2d852705f
   depends:
   - libboost-devel
   - python
   - ros-kilted-pluginlib
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libboost >=1.88.0,<1.89.0a0
   license: BSD-3-Clause
-  size: 132024
-  timestamp: 1769485214026
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_15.conda
-  sha256: 1736822350a45983ff0feb652ef02d5b9cc5eb096e0811d0156a3bfae8a711f0
-  md5: 193c26baeb2d6a32dde1ee345aca7610
+  size: 132352
+  timestamp: 1775551029550
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 18be30095916b7994944b89ff892c4d939935c7c8d8993e916a62e30b9e67bbb
+  md5: a8009c5e726b5bcb7e7e60da83de61f3
   depends:
   - foonathan-memory
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - foonathan-memory >=0.7.3,<0.7.4.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR Zlib
-  size: 19577
-  timestamp: 1769481587716
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h61f2ce4_15.conda
-  sha256: 44514fdef0fba34626550f9755527015d09c5b8392a6268ff0f486033da1cf28
-  md5: d1c63c794dff132d2c7f172a6a493193
+  size: 19363
+  timestamp: 1775547899377
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-foonathan-memory-vendor-1.3.1-np2py312h61f2ce4_17.conda
+  sha256: 7c900396d0e6921f25ea4210b6968a4a1f965a8829e1ced1aaf7a6d2f0e7ddbb
+  md5: 4aa39cf2d3b87bd913b1ead409b08467
   depends:
   - foonathan-memory
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - cmake
   - libstdcxx >=14
   - libgcc >=14
-  - foonathan-memory >=0.7.3,<0.7.4.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - foonathan-memory >=0.7.3,<0.7.4.0a0
   license: Apache-2.0 OR Zlib
-  size: 19581
-  timestamp: 1769481955403
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.6.0-np2py312h2c89a96_15.conda
-  sha256: 23c8b660c4b2caf5465a4e2ead4df801faff721f2c8e5e081c4572c9e84f392a
-  md5: 589f89c16e0738c7b68b2ae62f0c1f4b
+  size: 19497
+  timestamp: 1775548044811
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-0.7.1-np2py312h2c89a96_17.conda
+  sha256: 582992a10a5341c702d742584681776ea328d358a4ee0151238697e6a194f858
+  md5: 885f6883c762f2437c15e4855b0776e1
   depends:
   - fmt
   - python
@@ -39111,21 +38498,20 @@ packages:
   - ros-kilted-rsl
   - ros-kilted-tcb-span
   - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - fmt >=12.1.0,<12.2.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49252
-  timestamp: 1769485557129
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.6.0-np2py312h8b5252a_15.conda
-  sha256: b6855071504da83d6754544557773c2d9b37cff515aaa61257ed93440819e8fa
-  md5: 99bf503eaaba144e71d251ed82d3d376
+  size: 48830
+  timestamp: 1775551969203
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-0.7.1-np2py312h8b5252a_17.conda
+  sha256: 3fcfb373111f0d243d5f28af3e66452d8d10098859240d283e7eb436fc236e51
+  md5: b3f0aa51e32120c57cb5ebc5eae2312d
   depends:
   - fmt
   - python
@@ -39138,95 +38524,91 @@ packages:
   - ros-kilted-rsl
   - ros-kilted-tcb-span
   - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 48921
-  timestamp: 1769485591811
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.6.0-np2py312h2ed9cc7_15.conda
-  sha256: 4ad69cc021b6cbf4d0e7a770c37b3983ad37924c77c4f0002b57f99df1be53ad
-  md5: d370a310139c75a444b74fda7aeb297b
+  size: 48753
+  timestamp: 1775551463235
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-generate-parameter-library-py-0.7.1-np2py312h2ed9cc7_17.conda
+  sha256: cee171f122748ad98a63d20f9ba8825b7f1f7b3c5937557b639e145d6d1ed658
+  md5: 928e3af7f0d6b86602801e777834b615
   depends:
   - jinja2
   - python
   - pyyaml
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typeguard
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 71190
-  timestamp: 1769481109852
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.6.0-np2py312h61f2ce4_15.conda
-  sha256: 3f63db24f1e8ea5f92ea87fa8be1cfa8250f776c9fd6fc322baa4656b76f2039
-  md5: 32c330a98a9943e1bbdf3bac866b98e0
+  size: 72450
+  timestamp: 1775546895137
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-generate-parameter-library-py-0.7.1-np2py312h61f2ce4_17.conda
+  sha256: f5aab07ab6020da2ddaa2273478ace777a8abae085765f3702d05c5334429df5
+  md5: e50acd1405670753af6126aa4d6e07a0
   depends:
   - jinja2
   - python
   - pyyaml
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typeguard
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 71198
-  timestamp: 1769481443297
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 955954f1e6e3886cec3534504c77416f3b9a9be830bf3e8196170729865cd23a
-  md5: 7b5983f9f0138e75f1fcd7469bd3907e
+  size: 72625
+  timestamp: 1775547145041
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 859dc87ad45729d28cf0bb292aeea3b1a0324a41d43bc3b01bf4f88fedb5d042
+  md5: 3692013ff016bfa6193c88ea6c6faa8b
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 377527
-  timestamp: 1769483425900
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 66f112a699702996b3a5c6dedb20f4c69b300694b8abfd26e1fb7d2367bdd469
-  md5: c3fc078a4446cf7ba804223e0cc09080
+  size: 385780
+  timestamp: 1775549600944
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 4b44af5265e4741e133014d96f5e48f5f290c2190f07a3eac602cd69fb5df4ca
+  md5: d8cb71ab96405e1f2642dce44318bef4
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 385626
-  timestamp: 1769483694799
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 9c89eb8f6a7b9d2562e078f8be4b688c241aca98c824a2fc05c5589c63d55d9a
-  md5: da7a102c23c7a9d214fc9a3b4e30e536
+  size: 394111
+  timestamp: 1775549610423
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-geometry2-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 0bd0659b41f7dd9ea8c0f00366083cb9ec1f0ec826fc12b755dd0c219b57b28c
+  md5: fa4e55fbd21bcf2524707bf01b72e1a5
   depends:
   - python
   - ros-kilted-ros-workspace
@@ -39241,20 +38623,19 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-sensor-msgs
   - ros-kilted-tf2-tools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 22574
-  timestamp: 1769486474530
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry2-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: bea7ae66827daae42c45fa812dbe35bbdae896e32e413b7c60aaacf1f7799161
-  md5: 1617de2fd39d19f44352212c610292a1
+  size: 22488
+  timestamp: 1775603117216
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-geometry2-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: c1796f3c7ca65a50d8914a23240117c094982ca55116c9aff8f424bf64c17c93
+  md5: 1a6055e7b7c810642b45d1094ba52d60
   depends:
   - python
   - ros-kilted-ros-workspace
@@ -39269,122 +38650,117 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-sensor-msgs
   - ros-kilted-tf2-tools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 22566
-  timestamp: 1769486379956
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-  sha256: f4ab267e542b25a8e7598d3d35f7b905a2b7c63a3c666308f7a16758ac9c8e64
-  md5: 0e6d9f0c42003a4c1765e4b96eed7f11
+  size: 22646
+  timestamp: 1775610683412
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gmock-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+  sha256: 3ecca7351a6432c10f97b7fec4271e7b0b46ec147fcad3e2958f99b39db32f12
+  md5: fb860d8d5f7637bebbd4f1a30f145ca0
   depends:
   - python
   - ros-kilted-gtest-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 122615
-  timestamp: 1769480803310
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gmock-vendor-1.15.1-np2py312h61f2ce4_15.conda
-  sha256: 4fa22879d04eb3a98d9bbe2489a8eac6625469460168bf540ac90a331961916e
-  md5: 271c3a843f043d3f87054d154fdda655
+  size: 122361
+  timestamp: 1775546975636
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gmock-vendor-1.15.1-np2py312h61f2ce4_17.conda
+  sha256: c98f199e911b2e332b5b84935e13984a35e728ed3eb3facdb58026f4d0d8fe5b
+  md5: 7b29633f22e0a077ba93df2f9f37019f
   depends:
   - python
   - ros-kilted-gtest-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 122623
-  timestamp: 1769481132520
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_15.conda
-  sha256: 4af8d537e396af6c3ef9f17971ba8d819763150735acc12a460a31b7c456a52a
-  md5: 9b40cc926acd4b3e7fdfd76ee9e78751
+  size: 122528
+  timestamp: 1775547229437
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gtest-vendor-1.15.1-np2py312h2ed9cc7_17.conda
+  sha256: 6c663a85eba955ca0c6d8327e546e03319037c2c546b72cd89a8ae70d2e4148b
+  md5: 4fee7e3a43a8c5f6e4ccacc273e6cf4a
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 208999
-  timestamp: 1769480737380
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gtest-vendor-1.15.1-np2py312h61f2ce4_15.conda
-  sha256: 684de7c40960f9e406f6dcc2ae6f4081bc1932101ddae0e87da76312829ca013
-  md5: 1931e6567903cdeab38e4c72fbe12a12
+  size: 208755
+  timestamp: 1775546910580
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gtest-vendor-1.15.1-np2py312h61f2ce4_17.conda
+  sha256: 3b336913928614c79ec80db37c64ef74570ace4440237c90ee13e9d44843d983
+  md5: fb4439332897653f65b9902d14aa8279
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 208988
-  timestamp: 1769481076071
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h2ed9cc7_15.conda
-  sha256: ef32b772aba43252550702240548c68549d435ae6dc568bee2850daf0ce3804f
-  md5: 4ca1de716774d02e8d764b23b5ced62d
+  size: 208924
+  timestamp: 1775547165411
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-cmake-vendor-0.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 3c5705e538b7b773f5cc7bbd99ffa39815cd1b00fc991803cceb931ac1011828
+  md5: c83816f0cb942b149548e74b220a6009
   depends:
   - gz-cmake4
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - libgz-cmake4 >=4.2.0,<5.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libgz-cmake4 >=4.2.0,<5.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   size: 24230
-  timestamp: 1769481592450
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.2.2-np2py312h61f2ce4_15.conda
-  sha256: 826faa9ac9776e9699444cd96f01e6ea45b0664d8801c514a107d13c5f53fd79
-  md5: 46be9976f1dec044176b880e8bdf3c59
+  timestamp: 1775547904216
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-cmake-vendor-0.3.3-np2py312h61f2ce4_17.conda
+  sha256: dfc6fc49d37d2a020f8cdd915808a62c33f55d2f9c49100eab2558735f930cbe
+  md5: 11f5aa64ed92ac29c5860804a384e1d1
   depends:
   - gz-cmake4
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - libgz-cmake4 >=4.2.0,<5.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 24193
-  timestamp: 1769481960109
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.5-np2py312h2ed9cc7_15.conda
-  sha256: edafed041ba1ed697d8c3891cde28e6cdb468dcb3e661f5507020f4d4af556f9
-  md5: 27cf7bb1e09ee0dd58ee83a486bf451f
+  size: 24345
+  timestamp: 1775548050001
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-math-vendor-0.2.6-np2py312h2ed9cc7_17.conda
+  sha256: e1e005db7e145a27875430f28e0bbefb1b0fbb18ed0fb74bf2264806b229eb59
+  md5: 5aff8a94a03c4ecb53e837556481fce2
   depends:
   - eigen
   - gz-math8
@@ -39392,21 +38768,20 @@ packages:
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-gz-utils-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - libstdcxx >=14
   - libgz-math8 >=8.2.0,<9.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28116
-  timestamp: 1769482372304
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.5-np2py312h61f2ce4_15.conda
-  sha256: 595741efb5e2a0eda77ac7b78c091bfc60970a9bef8920cb41e089fc9c2369fe
-  md5: 9c4ade98d843e0b370db60e7a4eb8d51
+  size: 28311
+  timestamp: 1775548647662
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-math-vendor-0.2.6-np2py312h61f2ce4_17.conda
+  sha256: 49c4df1a99e80729d63ce2edf43d4e613cdcbb66183160062d9c471415181eb0
+  md5: f198a84b2b9b4c148f32aa10f2e5378a
   depends:
   - eigen
   - gz-math8
@@ -39414,99 +38789,97 @@ packages:
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-gz-utils-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libgz-math8 >=8.2.0,<9.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 28101
-  timestamp: 1769482601480
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2ed9cc7_15.conda
-  sha256: 13cae4b2248080bb8cefea90aeb5407f4c0e0cd69a91b85b08af6d7649c45f5d
-  md5: bd7aaf6f4a480335dcae9162a0674d22
+  size: 28360
+  timestamp: 1775548617949
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h2ed9cc7_17.conda
+  sha256: 106dac5d19f8cd9c71ca0978e8eb5a5c774c685cde4bf941288c488d4557d855
+  md5: b672fc1ff7872e9c8125f998a9da298b
   depends:
   - gz-tools2
   - python
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - ruby
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libgz-tools >=2.0.3,<3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27691
-  timestamp: 1769481880821
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h61f2ce4_15.conda
-  sha256: d17a337494f0ddda72d6ab404fd8bfa64cbed63a76f08bf780ee9063aac5145a
-  md5: 398df768cdb3292ac8d11d0c0cadff94
+  size: 27628
+  timestamp: 1775548163039
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-tools-vendor-0.1.3-np2py312h61f2ce4_17.conda
+  sha256: d939f71f07d82d0929873380ade1e877d0775ac616bd078a2211b436a1e776fa
+  md5: 0a63901bba117da51fea6ee33e4c94a1
   depends:
   - gz-tools2
   - python
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - ruby
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libgz-tools >=2.0.3,<3.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - libgz-tools >=2.0.3,<3.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 27466
-  timestamp: 1769482197919
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2ed9cc7_15.conda
-  sha256: 09838ed0db4d902e02e66e9cf7d28ef739afcab6758cd790c89d99379f527629
-  md5: 2e30389f4d874ca34277e1b5a1860df2
+  size: 27658
+  timestamp: 1775548242034
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h2ed9cc7_17.conda
+  sha256: 696a2b3d1da5667bc78fbc2d0a0526009af22f5785ad83736b4d2f45c64592ab
+  md5: 91b31d52b4df6a3d9c54d3b0a6422cc2
   depends:
   - gz-utils3
   - python
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgz-utils3 >=3.1.1,<4.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - libgz-utils3 >=3.1.1,<4.0a0
   license: Apache-2.0
-  size: 26306
-  timestamp: 1769482282660
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h61f2ce4_15.conda
-  sha256: 4944ed71aeb34aaa33953b24709a345a080a13b83967cf3331bd843023701c28
-  md5: 57f26f34b41cb669fd3a5eee76376c70
+  size: 26294
+  timestamp: 1775548572213
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-gz-utils-vendor-0.2.2-np2py312h61f2ce4_17.conda
+  sha256: 3356418759f0131b511644fab34d338c82012a3baef2b3a8aef1b4df8fb98abd
+  md5: b09e2a3cd4163b8f77c937fee4c5f7eb
   depends:
   - gz-utils3
   - python
   - ros-kilted-gz-cmake-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - libgz-utils3 >=3.1.1,<4.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 26268
-  timestamp: 1769482510844
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.11.3-np2py312h2c89a96_15.conda
-  sha256: 7528859d407afb155de2fcdbcc6813f1b36cd18d0b2e796c5bab480242c2d718
-  md5: 8b05b87731486df8fefafa844be249f0
+  size: 26348
+  timestamp: 1775548539801
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hardware-interface-5.12.0-np2py312h2c89a96_17.conda
+  sha256: 30a67b99682d5ea3f2f31c665ea64ed4d5c65908a8b3f7f1060c3a57d8ae5734
+  md5: 81234b1e0def98dcc020409c160f6cfd
   depends:
   - fmt
   - python
@@ -39524,21 +38897,20 @@ packages:
   - ros-kilted-sdformat-urdf
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
-  - fmt >=12.1.0,<12.2.0a0
   - numpy >=1.23,<3
+  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 515592
-  timestamp: 1769486173046
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.11.3-np2py312h8b5252a_15.conda
-  sha256: a3bee00fec11b32ac262ca6b2122568b2cbf7a4c505cfca295dbd85d7c743325
-  md5: ef40226b47f9fe390224f7c076c18a5d
+  size: 519161
+  timestamp: 1775602700259
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hardware-interface-5.12.0-np2py312h8b5252a_17.conda
+  sha256: d84acfa93fcd5ef7985252774536c38a772400724e98cf4cc0d9fbaca391a57a
+  md5: ea3a8445b7aa73e3b96f9a74210d9bab
   depends:
   - fmt
   - python
@@ -39556,20 +38928,19 @@ packages:
   - ros-kilted-sdformat-urdf
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 498420
-  timestamp: 1769486119527
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hpp-fcl-3.0.2-np2py312h60381d3_15.conda
-  sha256: cc52bd2a0805bd8e6c53193081d9b40a833ece9604e41c9994917e9c0bee68d4
-  md5: f8cdc5fe755f22d2d5ff4d65d09eb6dc
+  size: 502484
+  timestamp: 1775610341732
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-hpp-fcl-3.0.2-np2py312h60381d3_17.conda
+  sha256: 2e8ad274c08ec7dd9d4ed51e445c11dc965c99d7eca1c090b5826c5e8e92b671
+  md5: 2607b3c33889219c1edac55b034d013c
   depends:
   - assimp
   - eigen
@@ -39580,20 +38951,20 @@ packages:
   - python
   - ros-kilted-eigenpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - graphviz >=14.1.2,<15.0a0
-  - libboost >=1.88.0,<1.89.0a0
-  - assimp >=5.4.3,<5.4.4.0a0
-  - libboost-python >=1.88.0,<1.89.0a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - python_abi 3.12.* *_cp312
+  - libboost >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
+  - libboost-python >=1.88.0,<1.89.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - graphviz >=14.1.2,<15.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 19376
-  timestamp: 1773155940859
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hpp-fcl-3.0.2-np2py312hd7e41bc_15.conda
-  sha256: 623d7315022b49ccfcc1a98841a830941090b97fb0d59ecf9560815ec65ca177
-  md5: 9b1a228ebf3c7d3a771a1d1cd3ca54cd
+  size: 19383
+  timestamp: 1775546980542
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-hpp-fcl-3.0.2-np2py312hd7e41bc_17.conda
+  sha256: cba7c254cbc824668723454f2622fdba36b53a7bf3c1832d1352db09bda6b6db
+  md5: f9e41285b8c6bbd5d7159ee1e9c399d1
   depends:
   - assimp
   - eigen
@@ -39604,121 +38975,119 @@ packages:
   - python
   - ros-kilted-eigenpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - ros2-distro-mutex 0.14.* kilted_*
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - graphviz >=14.1.2,<15.0a0
-  - libboost-python >=1.88.0,<1.89.0a0
   - libboost >=1.88.0,<1.89.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - assimp >=5.4.3,<5.4.4.0a0
+  - python_abi 3.12.* *_cp312
+  - libboost-python >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 19419
-  timestamp: 1773156120529
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: d6bc356cd3195e23e63cb7d04ef0bbc85268019fee7d33103faa20df7db17be3
-  md5: 87accfd0d206e736a061491dedf49b27
+  size: 19355
+  timestamp: 1775547235465
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 13a706979570883418a83c27b1ecdb6a72db8c368a12ce848cc4e02ed7d7bb02
+  md5: a218e50d1b6919d3efa3a718b8c84e5e
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 93164
-  timestamp: 1769480901521
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h61f2ce4_15.conda
-  sha256: 67331747bbb85241b4842e23e8da7ddb4102888e20fb5ee5b228b5ba2d132a0b
-  md5: d171e5cf1e7019d5ac29788de4f31d6b
+  size: 93027
+  timestamp: 1775547078762
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-binding-c-2.0.5-np2py312h61f2ce4_17.conda
+  sha256: 630bf619a094b9cfc078d7da074a65a563e464d0bf4587d5c9ed7f055604b0af
+  md5: 7a04953738fe6d30754a7a3dc1a988b6
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 91043
-  timestamp: 1769481222359
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: 5ca890a864bbcf7c9f4794fc5e23bffe388694b41f80000080388547b537a42d
-  md5: 6aa3efbaf985ab261e58e59367a20c0e
+  size: 91095
+  timestamp: 1775547333971
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 40b220c18f37c63074b1cd3d9f6da9fa58125adce78040dfadac46e5ecbb8a48
+  md5: 5c07a23e589224a315c4f33b26407b8c
   depends:
   - libacl
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libacl >=2.3.2,<2.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 263978
-  timestamp: 1769480753737
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h61f2ce4_15.conda
-  sha256: 6279cca6d37bc69cf399b74df720f8c32469a8c92d7769bd63debf6f057ee929
-  md5: c665da498f7001ea3c2dbb21f3c1ba63
+  size: 263867
+  timestamp: 1775546927423
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-hoofs-2.0.5-np2py312h61f2ce4_17.conda
+  sha256: f19105cbb7913df30b0b6689fb26e42a316cca54d2539ee7da79ee2816c008f6
+  md5: fd7876a1f15ee8e942d5768745348e1c
   depends:
   - libacl
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - libacl >=2.3.2,<2.4.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 264275
-  timestamp: 1769481047177
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_15.conda
-  sha256: 569b69c0636f1f57c264dd2a1df8fac2659378f35b5a7f1b19e0373c10c045bc
-  md5: 9b7c315b79be4964dc28388344b03808
+  size: 264286
+  timestamp: 1775547177378
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-iceoryx-posh-2.0.5-np2py312h2ed9cc7_17.conda
+  sha256: 87525acc1d392d94638c1d1abd00c387f32d5f3055498123061f69d1df53659e
+  md5: c66292daa624d8c63bca49cd675c4cdf
   depends:
   - python
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 574060
-  timestamp: 1769480806728
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-posh-2.0.5-np2py312h61f2ce4_15.conda
-  sha256: 2a1327bfcfc36783d76fe20a2c0d1fa78668d9058d1d6b8ab3b95b75219b3f3a
-  md5: 5c51eeaea7889fd9823925ce918e451e
+  size: 573973
+  timestamp: 1775546979949
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-iceoryx-posh-2.0.5-np2py312h61f2ce4_17.conda
+  sha256: 4b60ff4dcc14e9f0a1772f6d82f9ef786eed143476c3db7e2e70d73ff1a5085d
+  md5: 42aaef431c51cc2765ae344f2b5ce63b
   depends:
   - python
   - ros-kilted-iceoryx-hoofs
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 577452
-  timestamp: 1769481135910
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.3-np2py312h2ed9cc7_15.conda
-  sha256: 3e667ed9df95b2895d6764f69ed2614239229766076ede1f0e026197f18f20ce
-  md5: 3898a6a67242b5ac13e5a35d0a984a47
+  size: 577537
+  timestamp: 1775547235085
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-image-transport-6.1.3-np2py312h2ed9cc7_17.conda
+  sha256: 8aaeb950ccd214caa8afeb2bd97a3c824ff0708dbafa7edeeaf395242da224d8
+  md5: 81eb0a4419814a3a840f270fdc58b2b5
   depends:
   - python
   - ros-kilted-message-filters
@@ -39727,20 +39096,19 @@ packages:
   - ros-kilted-rclcpp-components
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 580041
-  timestamp: 1769485606482
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.3-np2py312h61f2ce4_15.conda
-  sha256: 13646324a40d1469594d16ee0fa5b28420a39e64d505183520d849d6c1b02f2f
-  md5: caeb463ad483ee0605b158adf4af1745
+  size: 580302
+  timestamp: 1775552170089
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-image-transport-6.1.3-np2py312h61f2ce4_17.conda
+  sha256: 0136c1167488d3d4fe0a54a817539ce981b721273e58c3639a7db42da5fe39bd
+  md5: cc093e1463132740b5b7f7949745ecee
   depends:
   - python
   - ros-kilted-message-filters
@@ -39749,18 +39117,18 @@ packages:
   - ros-kilted-rclcpp-components
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 582882
-  timestamp: 1769485633805
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 58dd23fa6664ab6e482e675c44046e26ea3701e1e4063ec29bc93465651aec28
-  md5: 18f4e79f7024a59f47264302e8ec7d19
+  size: 583373
+  timestamp: 1775551626397
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-interactive-markers-2.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 99d5f493891e4ca6b22218dabae53daa76985ac4bd34e8e34ebd23b667ae4327
+  md5: c5446858990a12ff79a361aba4f9bf7e
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -39774,20 +39142,19 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-geometry-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 305681
-  timestamp: 1769486173540
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.1-np2py312h61f2ce4_15.conda
-  sha256: 638c6cedf3f45a06ac965f2183a8f59bdf5d14e43b18b558edd194088acded72
-  md5: 8b728b1aa2f6dd34a6b86b412c0fef71
+  size: 305995
+  timestamp: 1775602809876
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-interactive-markers-2.7.1-np2py312h61f2ce4_17.conda
+  sha256: 17dcffa017d990a3c2c6d1de48364285a454dee7f47548c521276dd4e4368de5
+  md5: efad21ef0df9cec3a4986c3671d02bc2
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -39801,19 +39168,18 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-geometry-msgs
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 305588
-  timestamp: 1769486120185
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.11.3-np2py312h2c89a96_15.conda
-  sha256: 1d07b772ee2e922bd55655125831871c85a208ba38bed7a2fec4aa14fc72f4c9
-  md5: 63e3c0f00f79e838cfa630a231098ba6
+  size: 306030
+  timestamp: 1775610435206
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-limits-5.12.0-np2py312h2c89a96_17.conda
+  sha256: 6f77955f2386856bc5373f34d6f84b96d18637e1e5f9614699cf1bc88a81ab8e
+  md5: 595cd4ebdf1f8cf24b9d2c924e6e9b06
   depends:
   - fmt
   - python
@@ -39825,21 +39191,20 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-trajectory-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - fmt >=12.1.0,<12.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 140255
-  timestamp: 1769485893122
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.11.3-np2py312h8b5252a_15.conda
-  sha256: 0114e56837cc4170aa334d7f1e086cedf52813098980624198241e49e614d6c5
-  md5: 52393003122fc5b2f6196567b90e3adb
+  size: 140691
+  timestamp: 1775602428090
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-limits-5.12.0-np2py312h8b5252a_17.conda
+  sha256: a4d7a66efc6b4abcc018d7d85017b2e10f6b97770b6dc63df0bab16603d1b6d4
+  md5: f1dec0e224716a1f5d7713de2306b024
   depends:
   - fmt
   - python
@@ -39851,19 +39216,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-trajectory-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - fmt >=12.1.0,<12.2.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - fmt >=12.1.0,<12.2.0a0
   license: Apache-2.0
-  size: 140389
-  timestamp: 1769485863830
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.12.0-np2py312h2ed9cc7_15.conda
-  sha256: 9f150e50105d0c762846328798b5da0ae34804a8dec3d3b3fb2a16edce08670a
-  md5: eb352a0d09b63bee586a0053fd4cbbe0
+  size: 140705
+  timestamp: 1775602620480
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-state-broadcaster-5.13.1-np2py312h2ed9cc7_17.conda
+  sha256: ee7aaee61de90c5ad51dc85996bdd95f89afcdcc796f9a34bd906e5ca928ddd0
+  md5: c1ea3ae647ed2090e79ca8f2347458cf
   depends:
   - python
   - ros-kilted-backward-ros
@@ -39878,20 +39243,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 189993
-  timestamp: 1769487843550
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.12.0-np2py312h61f2ce4_15.conda
-  sha256: 9241be30011d578e34864f8c997064238ab5ad3e76bda2ca5722d7d419ddebc5
-  md5: 869db90d92f4ab0bdcdfb0c9fc1a5328
+  size: 190043
+  timestamp: 1775604378259
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-state-broadcaster-5.13.1-np2py312h61f2ce4_17.conda
+  sha256: 15fd2ad1f594d7d6051765352f409c09dc870847a30c0972a940722e64b48bbf
+  md5: 16a0ce3ee18a9d20a517b101c2ee5085
   depends:
   - python
   - ros-kilted-backward-ros
@@ -39906,20 +39270,20 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 187213
-  timestamp: 1769487534562
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.12.0-np2py312h2ed9cc7_15.conda
-  sha256: b0f9c828bafc0fbf819b88f805ae0e0fa3e5c0330a65278a7f85f911ed7cb2bb
-  md5: adb4cfc8f74473e44cb6ff468dd4e273
+  size: 187482
+  timestamp: 1775611681384
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-joint-trajectory-controller-5.13.1-np2py312h2ed9cc7_17.conda
+  sha256: ac4ff484619ba5f6140253b98cdf9dbacdda83c132ef84dbc3740912e892dbac
+  md5: fa5535fb0ead9afcd794034b1556290b
   depends:
+  - cpp-expected
   - python
   - ros-kilted-angles
   - ros-kilted-backward-ros
@@ -39935,23 +39299,23 @@ packages:
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
   - ros-kilted-rsl
-  - ros-kilted-tl-expected
   - ros-kilted-trajectory-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 442892
-  timestamp: 1769487668468
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.12.0-np2py312h61f2ce4_15.conda
-  sha256: 287502fe094f5012426f5baed0897855be87a2eb16ed92880aadd2a830a003ed
-  md5: 4e60603da87eb773c7aecfcf051466d8
+  size: 443095
+  timestamp: 1775604526927
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-joint-trajectory-controller-5.13.1-np2py312h61f2ce4_17.conda
+  sha256: 4c271255d7ff9145cf647bba4a68718b50998a28560569b7468c6f88921746cb
+  md5: 5f3149899c6f40e694a8d02c5297120a
   depends:
+  - cpp-expected
   - python
   - ros-kilted-angles
   - ros-kilted-backward-ros
@@ -39967,22 +39331,20 @@ packages:
   - ros-kilted-realtime-tools
   - ros-kilted-ros-workspace
   - ros-kilted-rsl
-  - ros-kilted-tl-expected
   - ros-kilted-trajectory-msgs
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 426183
-  timestamp: 1769487381982
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h2ed9cc7_15.conda
-  sha256: 2c989d3626950083099a32b7a122951899fb0c03c8a9fba7408694a4f5c8cd5c
-  md5: 62d03c5017443654ae8bce3d2425bb7f
+  size: 427361
+  timestamp: 1775611795851
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-kdl-parser-2.12.1-np2py312h2ed9cc7_17.conda
+  sha256: 85016552429c4f2a99c2d1ead6fc4808de2491511c39194a46c570432ea34139
+  md5: b88ad0003c15d7fe2be7cf4358ff9f56
   depends:
   - python
   - ros-kilted-orocos-kdl-vendor
@@ -39990,20 +39352,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-urdf
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 48049
-  timestamp: 1769484835065
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h61f2ce4_15.conda
-  sha256: 69cad2fa1a356cd214a94ea3db35c6994e9d15873ec8758350bf37b305627ad3
-  md5: 54db32a4c3e12cdf929980ea97256789
+  size: 48138
+  timestamp: 1775551027586
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-kdl-parser-2.12.1-np2py312h61f2ce4_17.conda
+  sha256: 4313d5264187effcab0f5ffa59fa046cab20df7ca12f22301b706a1cddded421
+  md5: 12e2351024ab93a2872f475930fd12ea
   depends:
   - python
   - ros-kilted-orocos-kdl-vendor
@@ -40011,50 +39372,49 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-urdf
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49114
-  timestamp: 1769484988669
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h2ed9cc7_15.conda
-  sha256: 2cccc962056ed952f44d7f2fb953e823ad0d54159be9d4581d9e43fa087101da
-  md5: 70ed642bef8963bc485d0208ea490e41
+  size: 49245
+  timestamp: 1775550807784
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-keyboard-handler-0.4.0-np2py312h2ed9cc7_17.conda
+  sha256: a3e533638fbc01a0856045b5226a223e4f065fc13bf7ce6030e2055d4de62e0c
+  md5: d04bd46c5dc0a227f6640e2c0f704238
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 56187
-  timestamp: 1769481903430
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-keyboard-handler-0.4.0-np2py312h61f2ce4_15.conda
-  sha256: 1ec1ac08e95f74a0062d21e0fc3a532f44fc121a7477effef41d1e5d4dca19b7
-  md5: 4f95cc0bdbc80741f9999bdec12ed61c
+  size: 56308
+  timestamp: 1775548192114
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-keyboard-handler-0.4.0-np2py312h61f2ce4_17.conda
+  sha256: c2e9153848eefa896b18478a183006b31b12e4a07c7a94b5911ff997acf14df1
+  md5: 922f16855f4f7c0f4fe3959fa855585f
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 57550
-  timestamp: 1769482236573
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.2-np2py312h2ed9cc7_15.conda
-  sha256: 7f4f7b19254c1a731c641d96880228ec88526e52b3d662389aea11acabc4fcb5
-  md5: 7a96b65bb6941d77dca5748ae74c90d9
+  size: 57720
+  timestamp: 1775548277338
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-laser-geometry-2.10.2-np2py312h2ed9cc7_17.conda
+  sha256: c56eba4780c5404bb5a28a8266a58dce00f6263f60230f167bcbc285b7027851
+  md5: eff64a93d21a2540d56e7bef2dde1769
   depends:
   - eigen
   - numpy
@@ -40066,19 +39426,19 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-sensor-msgs-py
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 62978
-  timestamp: 1769485063856
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.2-np2py312h61f2ce4_15.conda
-  sha256: 19fe3d61f8409902921e5741de65335898165fa1d05626f8f20cb573c98400b5
-  md5: 00ce46bc4fbe3d933f3e7fc8dfdf4a17
+  size: 63204
+  timestamp: 1775551281278
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-laser-geometry-2.10.2-np2py312h61f2ce4_17.conda
+  sha256: c8ca34cf7d387825333c4482b9b2dd04ea88a30660df9ecc3508520ace29da97
+  md5: e9cfc52ba69995261195c9cf5371ff29
   depends:
   - eigen
   - numpy
@@ -40090,19 +39450,18 @@ packages:
   - ros-kilted-sensor-msgs
   - ros-kilted-sensor-msgs-py
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 61240
-  timestamp: 1769485182258
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: c0b5e1a112944d36268d9ab3db7dc1a9238a8cab6a9cc4c59c6cc8d476a33e78
-  md5: 7fb99992549f0640473fa9b7bbbba794
+  size: 62716
+  timestamp: 1775551024820
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: b42a44c643b3641bfe94cd2f76226b7e3e57b42c9e720e2e2ae39434b8cc107e
+  md5: 3aa35e4726162bc26f90975de9309c77
   depends:
   - lark-parser
   - python
@@ -40110,19 +39469,19 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 246546
-  timestamp: 1769481477621
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-3.8.7-np2py312h61f2ce4_15.conda
-  sha256: 40956071a3c7b39434dc84fd265389baa247dffe041595206a02225f7085c00c
-  md5: 80e325fab0a1137a1435984e7071a6b4
+  size: 246343
+  timestamp: 1775547783769
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-3.8.7-np2py312h61f2ce4_17.conda
+  sha256: 57680eacce3f7242294aead8d70f603c3a759313156dcc70a5aded7382d3ad3c
+  md5: 4e607373c744f3790cf4267a8a51d0f0
   depends:
   - lark-parser
   - python
@@ -40130,18 +39489,18 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 246509
-  timestamp: 1769481808416
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: f4659895fba4f36d92f4e212aae219dff8e6eeb9b311ad3e25c459488c162aa6
-  md5: dfa7476220a6cc2342cd4f4042971be8
+  size: 246461
+  timestamp: 1775547926674
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-ros-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: 8056010714a6909e4eb1fe3f9bf1aa33e76c337bd66b8913fc43c821778ba5ea
+  md5: 5c398b0ef2f36c95e0a8a4d8fdf82d8c
   depends:
   - python
   - pyyaml
@@ -40152,19 +39511,19 @@ packages:
   - ros-kilted-osrf-pycommon
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 113950
-  timestamp: 1769485079708
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-ros-0.28.5-np2py312h61f2ce4_15.conda
-  sha256: 6284358fc10ef19aa8699522416d710d1f560cd7ceab425ac561538ce6d196af
-  md5: 445ad4f175176399f6f38b54266b85ac
+  size: 113717
+  timestamp: 1775551285595
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-ros-0.28.5-np2py312h61f2ce4_17.conda
+  sha256: 59237a4bd418bafb8dae2b81febed8ad7cd4c32de451aaee067261cb5a5bab9f
+  md5: afdd4f92fa76d1f0f93e2ed08bd71ae7
   depends:
   - python
   - pyyaml
@@ -40175,18 +39534,18 @@ packages:
   - ros-kilted-osrf-pycommon
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 113975
-  timestamp: 1769485195012
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: a4c5ed0028dcfb16fe5b517c34d8c88676b894daefa7cb6d78a8355fbc565f9f
-  md5: bdf5e16e25065a12a22f16ba4565cb66
+  size: 113825
+  timestamp: 1775551028592
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: 1e5738b8d7c24c2d87c8bd6825710944608cab8efa49a0f1266b5fde9c6af4e5
+  md5: 1914d6f860062d17c05a2cfce3eb712f
   depends:
   - pytest
   - python
@@ -40196,20 +39555,19 @@ packages:
   - ros-kilted-launch-yaml
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 116466
-  timestamp: 1769481581278
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-3.8.7-np2py312h61f2ce4_15.conda
-  sha256: a6e5ad926e1589b28dc022e2733d8d1abe12a505a5922e5eedc7911f19fd1dfa
-  md5: 0ea0451dbc246f4bc14ad4330fa2a1c9
+  size: 116270
+  timestamp: 1775547891466
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-3.8.7-np2py312h61f2ce4_17.conda
+  sha256: 74605f6a91f4850d59a31ca93ad52a1c00079d7ec78ea03c35a24bc0c1617491
+  md5: c5628be23d9473dd7dbe473569a15a23
   depends:
   - pytest
   - python
@@ -40219,55 +39577,53 @@ packages:
   - ros-kilted-launch-yaml
   - ros-kilted-osrf-pycommon
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 116458
-  timestamp: 1769481945917
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 8beed9ea270008e803cba496bbd012f14705ef28cfc686bcf88786fd6558a689
-  md5: 7b39b4bc8a2c2f655178f74f3e51c0ec
+  size: 116296
+  timestamp: 1775548032116
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: 9b811ba8f257e31b3152ceec5517d7e02447077899c3755fc284c2c2eeffa43e
+  md5: 72a377657eb3124f6980d53b0ae6bcd3
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-launch-testing
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27126
-  timestamp: 1769481902408
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h61f2ce4_15.conda
-  sha256: 54809ee88a7185e60a493b9dfb768a0d776f0f6e57f6cda78d59a9329a66aeaf
-  md5: d88cc02e28dbfacb7c52de90688f87f5
+  size: 27160
+  timestamp: 1775548186030
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ament-cmake-3.8.7-np2py312h61f2ce4_17.conda
+  sha256: b3f9f3a181839cf6529e05bde1274174b71cfe95f5d3d686db82bacea263328c
+  md5: e5140d7e1ef0aff814ecc58fd94726ee
   depends:
   - python
   - ros-kilted-ament-cmake-test
   - ros-kilted-launch-testing
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 27152
-  timestamp: 1769482234870
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: a1f443e5544e76bae64c2f2b50323273449dfd79274ff08aed31d2e7566d6637
-  md5: 39c0644d25137f437194fee55cae014b
+  size: 27273
+  timestamp: 1775548264412
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-testing-ros-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: d131bf0bdfc26eccc83adbecb21f6a711f184a3763ac0c80218b581a5b663768
+  md5: 827ad125a189dec847eb0f0262ed0b4b
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -40276,20 +39632,19 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 56488
-  timestamp: 1769485252596
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ros-0.28.5-np2py312h61f2ce4_15.conda
-  sha256: 98ade1db00e8c3afbcbf3d1e79551bb25f9b1754cee7a8999b658a72cf85c1b9
-  md5: 945a458178bb679eec73d0526fe603f4
+  size: 56409
+  timestamp: 1775551548581
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-testing-ros-0.28.5-np2py312h61f2ce4_17.conda
+  sha256: 788e92c4457293e0ee6500a5b0dda2e85c92bcb5078396fd8118b59d088fbb7f
+  md5: b6a3de558895d9d4d929699914cc3310
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -40298,159 +39653,154 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-rmw-test-fixture-implementation
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 56273
-  timestamp: 1769485340821
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 5221cbff29742434f8a66e3998b6de659695a2d38425cdf48016140f8ced82a7
-  md5: 2125582063f53979f6b5d714db3bb25a
+  size: 56455
+  timestamp: 1775551180150
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-xml-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: cf6a2a0c3cd4616cd3015f7e47eeffabefb60b59370f92cb9303f52b1242f305
+  md5: 3db629d5df25d129e137b5d7ef1a3208
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25866
-  timestamp: 1769481528051
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-xml-3.8.7-np2py312h61f2ce4_15.conda
-  sha256: e3040cd1ce2572d146170b9e17f6f7833990b65c8060e891b393d19e2233cd65
-  md5: be1674094f805e74bc000df3580b874e
+  size: 25629
+  timestamp: 1775547832174
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-xml-3.8.7-np2py312h61f2ce4_17.conda
+  sha256: 28ab4b072b114952f3c0ad6d80efb7430584e2a3537b820412dedf5dcde570c7
+  md5: 06ecf9d0a2f26c227beca9f2c78b8dbf
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25878
-  timestamp: 1769481870309
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_15.conda
-  sha256: 2885602164eaeb1bd6efc372376819df4563f5e53e9457a9500147998d0b28d4
-  md5: b2dbd5802d0bdb3f22ef0875b16e0619
+  size: 25786
+  timestamp: 1775547982978
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-launch-yaml-3.8.7-np2py312h2ed9cc7_17.conda
+  sha256: da1f5b713ba19aa6193de145dc35ab1bc529851b1d3d260c4818a7573c07d437
+  md5: 4c80531dff12163fe6cd5527692c53cd
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 26472
-  timestamp: 1769481521692
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-yaml-3.8.7-np2py312h61f2ce4_15.conda
-  sha256: 5ff86e6323e03bb17513eaa9c4eb839ee0bcde5989ec3b444d1e74d5bb91746f
-  md5: f3ca5a630d66327bea2e07f3ce4032ba
+  size: 26190
+  timestamp: 1775547825048
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-launch-yaml-3.8.7-np2py312h61f2ce4_17.conda
+  sha256: c2a264b2bd2d90b3b7584ecf8e12a8ada353bc84f05c52766a571e71624a49ae
+  md5: f421cad551461d04d08039832716981a
   depends:
   - python
   - ros-kilted-launch
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26438
-  timestamp: 1769481862378
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 249558284c3e32a5b3fc6aa4237af2f138d97266ccf691ef14968dc0c3466acb
-  md5: fbba2cb34fa2ee17f49fa0ccd9670948
+  size: 26357
+  timestamp: 1775547974145
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libcurl-vendor-3.7.1-np2py312h2ed9cc7_17.conda
+  sha256: a6f1522c18bdaac9a84ad0353ad96d8d730600bafc7e9e8899667fce51cfdfd0
+  md5: e33ff8eb1c6b6e3bb71ca8b8245649b3
   depends:
   - libcurl
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libcurl >=8.18.0,<9.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libcurl >=8.19.0,<9.0a0
   license: Apache-2.0 OR MIT
-  size: 23986
-  timestamp: 1769481216622
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.1-np2py312h61f2ce4_15.conda
-  sha256: dcd4d5729ac1d4023b6daa5dfae972d6f3dbffcc3f865c6b16b699361a38d017
-  md5: cf6e456eca9d8eb2b5364ef7eaca3427
+  size: 23952
+  timestamp: 1775547435452
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libcurl-vendor-3.7.1-np2py312h61f2ce4_17.conda
+  sha256: 5ead37f55123621008a8ee679042b8bdb753e10ce091bb37a8a5348b6dad6782
+  md5: 879fd4045e5965fb625c3a1949fa4807
   depends:
   - libcurl
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libcurl >=8.18.0,<9.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 23994
-  timestamp: 1769481551899
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 512fc923a5ed4f4e171c40930090f7d6a0613e89b7d52d632c8dfaee43b600c5
-  md5: 6f0641f3fd74e70bd649a05dfd8e7498
+  size: 24087
+  timestamp: 1775547669880
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-liblz4-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 47de5f710c3ffd3e9f7db3ce5fed9d74b14856905b0b457f92540fc527a7f974
+  md5: 981079b1681c5bc2c73a62c9beaa4629
   depends:
   - lz4
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause OR GPL-2.0-only
-  size: 24274
-  timestamp: 1769481219371
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-liblz4-vendor-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 88a4a4cc7b43dde521339d17ae8fd8b7cfa2019f418c003d4c73fd25adcdccea
-  md5: 60c6ec710f8f924e08b36b1ba042a868
+  size: 24270
+  timestamp: 1775547412956
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-liblz4-vendor-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: c4d1fa935ed16f438e3271f41c2f39b1a24205f0e8ca573558e4a341527d190e
+  md5: f06c1700aec03fb37cd7c5a79182afa7
   depends:
   - lz4
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause OR GPL-2.0-only
-  size: 24263
-  timestamp: 1769481557012
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_15.conda
-  sha256: d47f3cd0ffcd25e15ac65123c1d5a7a8d6aa3f6b214a036a1465429705546cfd
-  md5: 1dfcc8620055acd1210102130295d4b5
+  size: 24382
+  timestamp: 1775547640720
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libstatistics-collector-2.0.1-np2py312h2ed9cc7_17.conda
+  sha256: 52b287e9bd7438299cf8ae2a6f7a50981f7d4d5755c81a5e1e86fe5996678ac8
+  md5: 4e8c759027a4aace9e41f1702f9541ea
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40459,20 +39809,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-statistics-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 58336
-  timestamp: 1769484793834
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libstatistics-collector-2.0.1-np2py312h61f2ce4_15.conda
-  sha256: 33fa7de20a41c419cd60735e5505a1f96ca101648d90887d322d5ab24b6ce51a
-  md5: 4fad22da32c6553c44910090758f9734
+  size: 58630
+  timestamp: 1775550984587
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libstatistics-collector-2.0.1-np2py312h61f2ce4_17.conda
+  sha256: 9c7b1f467f9b424adc725fc54c6d81fb96079ab6f7253001bde97d8eb1f9809b
+  md5: e3032ddd4e461c2e890c2b4f47557132
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40481,92 +39830,92 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-statistics-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 57634
-  timestamp: 1769484924356
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 21dcc6c0a7c7ae9b8f490ccf6481e3bccde746507663e14f69543bf1d49ed0a2
-  md5: b2fa6413d09e8921170f0cfff78f9d2a
+  size: 58115
+  timestamp: 1775550759067
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-libyaml-vendor-1.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 419e2cba8585ad2c86ab4f602f0fe19153c5062cfd7b8fafd4a02d86fc69d0d1
+  md5: bf2bf710206d324708e7579fb3cf7908
   depends:
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   - yaml >=0.2.5,<0.3.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR MIT
-  size: 29756
-  timestamp: 1769482319912
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libyaml-vendor-1.7.1-np2py312h61f2ce4_15.conda
-  sha256: 0be2bc3191a72ad4a24486b5684a7b6a1367465cd26c8690aa3679a38a6b0596
-  md5: 35f604b7008bf39f9c0d38e200a9416a
+  size: 29841
+  timestamp: 1775548600537
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-libyaml-vendor-1.7.1-np2py312h61f2ce4_17.conda
+  sha256: 5bf5c1cd4a141f558680c9c32877a216cd8e6d8c93e4c042012ff704b2960a3c
+  md5: 40816cd41e83337122e69e422e5beaa8
   depends:
   - pkg-config
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - yaml >=0.2.5,<0.3.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR MIT
-  size: 29732
-  timestamp: 1769482542076
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: e0a0023e6743b4e8866d0289a82ccae9f9a7e0b8b39e5bbd188192198300b72a
-  md5: c48e5749478f5bc0bc1086a611df19ca
+  size: 29866
+  timestamp: 1775548570724
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 7a4582125f61223c5e21ee609007c715c4c7d7a9df4c21ba83394ca53f1b6557
+  md5: d3d5b0255c46ffc6e82b2b55e6a1d252
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 266413
-  timestamp: 1769483120685
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-lifecycle-msgs-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: 758b1c0bd99249f2cdcf924d44f982019ebfde77b001f08951ea245bb78ab029
-  md5: fdb42853913125a65b676e30dd71ac25
+  size: 271654
+  timestamp: 1775549324355
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-lifecycle-msgs-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: df839028ad33d42e87ba8ff0eef66c654044c5193b1548ebee6e114a5ba7ebab
+  md5: 98099072ba8791726067ca72566fa746
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 275607
-  timestamp: 1769483413744
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h2ed9cc7_15.conda
-  sha256: 73181b82da344ce80a3b3e519e548416bf8d2dae44bf0629131847bffcbfe3e7
-  md5: 9b791d2db8e3ab10a7d5f9a16ba999b0
+  size: 281044
+  timestamp: 1775549343857
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-map-msgs-2.5.0-np2py312h2ed9cc7_17.conda
+  sha256: 57bcfed3358bfa62d0afff8d93138c9db41d2c1b60b0a1a935eea3f75a73775b
+  md5: 9f66ed489bdc4e11f92f25edc00174b7
   depends:
   - python
   - ros-kilted-nav-msgs
@@ -40574,20 +39923,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 344308
-  timestamp: 1769483757825
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h61f2ce4_15.conda
-  sha256: af4392687df00bd6bbb8c1f587bf20a132c22dc2b22439bb2eacd00c78f7c40e
-  md5: 6bda5ae81c728220ad1f2e6c331b756a
+  size: 349476
+  timestamp: 1775549954683
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-map-msgs-2.5.0-np2py312h61f2ce4_17.conda
+  sha256: b37045e741ba623260d3608edf40023cb4b3bf61367c70565ae8b96e33f808e6
+  md5: 5aef3a02eacc59cbb539696f223a0ab4
   depends:
   - python
   - ros-kilted-nav-msgs
@@ -40595,56 +39943,53 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 353003
-  timestamp: 1769484011817
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 48fde9c7bcc0c0d3c76a808c0a23a6494e69bc24ec1830c066cfd05e5741d23b
-  md5: 3e2efa898c9b6136caaf208dda0a499a
+  size: 358307
+  timestamp: 1775549905420
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-mcap-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 1f14684133c9d2531cc54b07c076b14dd5b7616cc7638caf4d647248e0037058
+  md5: 3fa84f233ff6df4bd8e087ce3215a582
   depends:
   - python
   - ros-kilted-liblz4-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-zstd-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 172865
-  timestamp: 1769481332030
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mcap-vendor-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 8787f4aa8373113c0cadc8bb1ede55535a67fdae5675f90d30b07e41aa8527cc
-  md5: 10526a36c8478b6f7682b79f192f62dd
+  size: 172770
+  timestamp: 1775547612723
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-mcap-vendor-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 0a33539afa325199113033c706ca885e353c0765445641d108aae74cf879b471
+  md5: aa52403767fffe3f239c53debd6ed845
   depends:
   - python
   - ros-kilted-liblz4-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-zstd-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 168989
-  timestamp: 1769481657527
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.5-np2py312h2ed9cc7_15.conda
-  sha256: 6d304444e22067963097e0b1ee789e573db63fc8ee1c101ff63ca03237060ea5
-  md5: 0cb972a2cb8809c2d64bb54d2fe26e38
+  size: 169076
+  timestamp: 1775547776867
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-message-filters-7.1.6-np2py312h2ed9cc7_17.conda
+  sha256: e2efdf131d8be50d6575d586b07d2dde0a11d962b5a035a33fff59b60ed7698b
+  md5: 3eee707cb8653c8cac8743ba810f0b9f
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40653,19 +39998,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 88511
-  timestamp: 1769485264930
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.5-np2py312h61f2ce4_15.conda
-  sha256: 6b28f379109cbf3b82602e8926e6c71741aa0cfba8e25c7085a3a407bdaed46c
-  md5: 83dd10b7ccfa09482000fb6493c95cf4
+  size: 88883
+  timestamp: 1775551566159
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-message-filters-7.1.6-np2py312h61f2ce4_17.conda
+  sha256: 5aa3f2500b5729ba38815810c099f295ec2678660597e27dbcddeaae79cbb6a1
+  md5: 098cea5551e35a96f14fa51b5b25fe79
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40674,19 +40019,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 88629
-  timestamp: 1769485355839
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 9baafb16cd27b577a27b47479ace2f36e2e408270f05a0af30d38625266ee4ee
-  md5: 592ac5acfed8b5f5ee15138386b08bf4
+  size: 89142
+  timestamp: 1775551197543
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-nav-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 0b1031044b7f1d764ac79060c29b692f59c8eb5f0e2962795e3ba314b5e049b6
+  md5: 8ea2c2a6b8910af2b24882187843ad2f
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40694,20 +40038,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 314263
-  timestamp: 1769483551702
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-nav-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: a1a7aafdb7807dd1344c880613d4522b97d0553e0c3d0a7e9681fc5f450fd4d4
-  md5: 7b0412652377367bb0a1b6fd2877b234
+  size: 347128
+  timestamp: 1775549745861
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-nav-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 8cc861c185867c4d91929e870bfa213aaa1db5c4dec07070f3f1073d6c5853c6
+  md5: ded158868f6471596ba7135a259fdb67
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -40715,124 +40058,121 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 322523
-  timestamp: 1769483818841
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 80f3c188b131df59fbad7737f94befa0d20d815f2c7dfaaf17542782c666c11d
-  md5: 2eeef0396871b6c207cdf8d726c63bde
+  size: 356422
+  timestamp: 1775549726391
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_17.conda
+  sha256: a6ec486655a56c4efd47ca6e1d58eda48857d90413c9da73df7af8aac9efd3da
+  md5: b1169a1ab1659ebab87f14f0f6478184
   depends:
   - eigen
   - orocos-kdl
   - python
   - ros-kilted-eigen3-cmake-module
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - orocos-kdl >=1.5.3,<1.6.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - orocos-kdl >=1.5.3,<1.6.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 28183
-  timestamp: 1769481898374
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_15.conda
-  sha256: 7c4304d3f05b880f191c1587ec4658c9cfceb10f08bca9dae2f64f23509f56f3
-  md5: bf6de19980bec359d618a2f636c307a7
+  size: 28281
+  timestamp: 1775548187283
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_17.conda
+  sha256: e0547a09cc37095c3c5e7a29627fdd329d54586a05942407e2cd70f9d947d501
+  md5: 69e51e35361339b565477f5a8f5f8257
   depends:
   - eigen
   - orocos-kdl
   - python
   - ros-kilted-eigen3-cmake-module
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - orocos-kdl >=1.5.3,<1.6.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 28144
-  timestamp: 1769482223267
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osqp-vendor-0.2.0-np2py312h2ed9cc7_15.conda
-  sha256: 1f6cd352564fbf515ddf3b83657568c7f7b55f140794dfc3f2d8d5d38dfe93fa
-  md5: 079d533a5e2d2883adc6f602d047c6b0
+  size: 28400
+  timestamp: 1775548264355
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osqp-vendor-0.2.0-np2py312h2ed9cc7_17.conda
+  sha256: 5c747d55675498a345310ce2f46d7ded7d146e14a40e9736b6884b5fb7479b4a
+  md5: d4eb0fc85eeee5fb07ca72a2f43ff21e
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 121362
-  timestamp: 1769481894499
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osqp-vendor-0.2.0-np2py312h61f2ce4_15.conda
-  sha256: a976df7bec59451998118f5d47c334c3e0628b0cbed83a6e99b5e4227c585bca
-  md5: 1aa91d202b70269ce8f80d61415e30c0
+  size: 121432
+  timestamp: 1775548163211
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osqp-vendor-0.2.0-np2py312h61f2ce4_17.conda
+  sha256: fbd43dd9e45fcf29a61d52b26597f7b75542d50bd3fcbd3d1c73c689c9d82e90
+  md5: 37d4616d97366f2afbb4e226d496f659
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 117204
-  timestamp: 1769482215015
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_15.conda
-  sha256: 295abb1c2a9ffc09ccc5844f22d11840dbdeb09a2f2e8ba219978b466fbfe0eb
-  md5: 2b503d9cd73621c4db78888a7be981b4
+  size: 117395
+  timestamp: 1775548242254
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-osrf-pycommon-2.1.6-np2py312h2ed9cc7_17.conda
+  sha256: 7362a92d20dbc98b188679de3ad770364f7dcc07b9c012a4e0d2821a5a6f1dee
+  md5: 0583f472a24e2b0a8fd7b6f444521a9a
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 64789
-  timestamp: 1769480717674
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osrf-pycommon-2.1.6-np2py312h61f2ce4_15.conda
-  sha256: 62d44b6236afbd13f74d3cac3e2f47105572f7d09d5266a0b436c41a9c768b61
-  md5: 4d05e8374daa2d5d77c5f4a81d73ba2f
+  size: 64516
+  timestamp: 1775546889942
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-osrf-pycommon-2.1.6-np2py312h61f2ce4_17.conda
+  sha256: dfa92c36f8e4d115c62ba4256da5e39585275d5c05083fdae22ae0f3a6698d78
+  md5: 8aeedc027b477fc5ff453be9d386d5bc
   depends:
   - importlib-metadata
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 64748
-  timestamp: 1769481006732
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h2ed9cc7_15.conda
-  sha256: dc61c411d7a5133835b5e32d2e38b6a9e44d1ce68190fe046aa6305f6f4daaaa
-  md5: eac3e5797110cadda10918008cf124c8
+  size: 64685
+  timestamp: 1775547141743
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-2.7.0-np2py312h2ed9cc7_17.conda
+  sha256: d76afedce9f1b74eb30253a7fccb2793891983841420d3f70cfdf3b24d918441
+  md5: 04d9b893926fdf61ca2cc5dd10589b24
   depends:
   - libboost-devel
   - python
@@ -40841,21 +40181,20 @@ packages:
   - ros-kilted-rclcpp-lifecycle
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
+  - libboost >=1.88.0,<1.89.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - libboost >=1.88.0,<1.89.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: MIT
-  size: 171661
-  timestamp: 1769485271243
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h61f2ce4_15.conda
-  sha256: 032edf9c92997d3db49d5999046b2f6ad7173e774160dec438181ae8a890f1dc
-  md5: 7ec5a4742fe97e4346858e441626d629
+  size: 171975
+  timestamp: 1775551575440
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-2.7.0-np2py312h61f2ce4_17.conda
+  sha256: 91823dbc1d19c555ce90611465d64e07200444d8d60fcfc270a3b5ff83347206
+  md5: 392aa054f5ca1ade9691fd5ce17fc51e
   depends:
   - libboost-devel
   - python
@@ -40864,56 +40203,54 @@ packages:
   - ros-kilted-rclcpp-lifecycle
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - numpy >=1.23,<3
   - libboost >=1.88.0,<1.89.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
   license: MIT
-  size: 170120
-  timestamp: 1769485367392
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-  sha256: 5320a2cc761f90171cca74c0ace0c6206c34c9df0b859940724364c8761c6199
-  md5: 6196547053d4f5edbf34f535f650e4fe
+  size: 170698
+  timestamp: 1775551206678
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+  sha256: 9b8254c6965161fb13f4463b27d53c5991bccde9630b26d72113e699174af159
+  md5: 15210e76750e3ca5dc62b6beff819fe0
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
-  size: 124981
-  timestamp: 1769483352158
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h61f2ce4_15.conda
-  sha256: 0373368fc08f6f56baf514b468787acd9e4b03cc2b3eba913e450267c7126efb
-  md5: c44eb269e4a9ddc3f2f50e53fa5f4e91
+  size: 127571
+  timestamp: 1775549523532
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pal-statistics-msgs-2.7.0-np2py312h61f2ce4_17.conda
+  sha256: 5b64f9e140a61c228a1c18535c0ad95f6093670e8c0b976371ecf3eb4f6b95a7
+  md5: 19da7692fad06e8af29698e398a1fc38
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: MIT
-  size: 129132
-  timestamp: 1769483638193
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.6.0-np2py312h2c89a96_15.conda
-  sha256: 57ec488432339ce50eb607fedcaaaea894f25f6359d9c04a4e5d6a13dbbacff9
-  md5: 7b777665d55d9f9d0431861369f3b9ad
+  size: 133188
+  timestamp: 1775549543137
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-parameter-traits-0.7.1-np2py312h2c89a96_17.conda
+  sha256: 21fcf82dbfba12b457307df2fba6308a5314196a97bdbf624e1ce8c321e754e7
+  md5: 3b376b934b9ba170a1fac53d8fae7960
   depends:
   - fmt
   - python
@@ -40922,20 +40259,20 @@ packages:
   - ros-kilted-rsl
   - ros-kilted-tcb-span
   - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49607
-  timestamp: 1769485235695
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.6.0-np2py312h8b5252a_15.conda
-  sha256: 6ca16d688f80c0b67f738127386b79f5f54d9d5d3cba81372530f701b2b2f533
-  md5: f82b3800facda945e0b1a8aef61044b3
+  size: 49278
+  timestamp: 1775551529665
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-parameter-traits-0.7.1-np2py312h8b5252a_17.conda
+  sha256: bd88367ad1e62a7076f4317f7e3955bbf900c3f1695a8315cbf333e4101cea2d
+  md5: 9998227282093c0d7db5b1cb9c810e55
   depends:
   - fmt
   - python
@@ -40944,20 +40281,19 @@ packages:
   - ros-kilted-rsl
   - ros-kilted-tcb-span
   - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 49323
-  timestamp: 1769485319861
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pinocchio-3.9.0-np2py312hfc2d069_15.conda
-  sha256: dbb409bef1ce867ada709b81ff26b736c88f45e1b6afd2ffa1b9b6f50fee5cdf
-  md5: ba2d5290bbba6445263d9d094ad2f821
+  size: 49163
+  timestamp: 1775551157287
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pinocchio-3.9.0-np2py312h402d539_17.conda
+  sha256: 4feb4164c818425113dda9b49d69362e49a709a67f0a9a1f43637dc6404f90c7
+  md5: 5955a28058bfe1e76be45c6969e2047a
   depends:
   - eigen
   - libboost-devel
@@ -40970,19 +40306,20 @@ packages:
   - ros-kilted-ros-environment
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - graphviz >=14.1.2,<15.0a0
-  - libboost >=1.88.0,<1.89.0a0
   - libboost-python >=1.88.0,<1.89.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
   license: BSD-2-Clause
-  size: 21578
-  timestamp: 1773155943775
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pinocchio-3.9.0-np2py312h66a98ff_15.conda
-  sha256: 7048fdb4fd505233fa0f32c8fab5c5c18eee66e5e6a6859fc9ef4fe3234681c7
-  md5: 08ad5b57e418a30d50ce4badaf20a7a4
+  size: 21715
+  timestamp: 1775548723979
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pinocchio-3.9.0-np2py312h2f67575_17.conda
+  sha256: 6bfa8fc926884cba64292a078c50ba4bb6455842b36abb590146a5f00292be42
+  md5: ea9fa2a0934b5226a6526a4a3d747095
   depends:
   - eigen
   - libboost-devel
@@ -40995,19 +40332,20 @@ packages:
   - ros-kilted-ros-environment
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
   - libboost-python >=1.88.0,<1.89.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libboost >=1.88.0,<1.89.0a0
   - numpy >=1.23,<3
+  - libboost >=1.88.0,<1.89.0a0
   - graphviz >=14.1.2,<15.0a0
   license: BSD-2-Clause
-  size: 21604
-  timestamp: 1773156126563
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_15.conda
-  sha256: 61cf7b8002f5db4f0b349a855ca9ea8e5d92bc1929fcd495ef4257a642c36f46
-  md5: 377ef9fb44bbdb73a1f43b0df07e86f1
+  size: 21668
+  timestamp: 1775548708129
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pluginlib-5.6.2-np2py312h2ed9cc7_17.conda
+  sha256: c29229e8787efcbae0cf0ee72061696adb1fe26b8d1a55f2c85e0f6c64146a42
+  md5: 0049d3b99bd76199372fe39b8899943d
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41016,20 +40354,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 142080
-  timestamp: 1769484532531
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pluginlib-5.6.2-np2py312h61f2ce4_15.conda
-  sha256: c15644a0454d0603f15238ac0860aee5218799518f8cb5eff9811348ea5d317c
-  md5: be978f9baf2d953924fd59db962655d1
+  size: 142143
+  timestamp: 1775550717693
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pluginlib-5.6.2-np2py312h61f2ce4_17.conda
+  sha256: d896590ea7f74236897ec70b6bc6e273b10e2e3dde7c6562cbed112dae74d2ec
+  md5: c80330af73ceb7fa70f0db53cfef745a
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41038,18 +40375,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 143063
-  timestamp: 1769484675294
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.6-np2py312h2ed9cc7_15.conda
-  sha256: 24f5b7b4a60af4b0c1a1f96930fab038b9d6a0bc48bc78d24899960fba5c41e0
-  md5: 02593f72c4e4a735be221fa84618365c
+  size: 143256
+  timestamp: 1775550524194
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-point-cloud-transport-5.1.6-np2py312h2ed9cc7_17.conda
+  sha256: f6fb491fa879d1082c4927c4d536bfe22fb229ac328129d3e594477a0e935f56
+  md5: 0f5b10f6911a225076da2b0d855cb695
   depends:
   - python
   - ros-kilted-message-filters
@@ -41060,20 +40397,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 459767
-  timestamp: 1769485555677
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.6-np2py312h61f2ce4_15.conda
-  sha256: fac7a993e0603f831653468a1fada5d7a7fa07e8fff1ab22ab4bf2b2878212f0
-  md5: 662fd1368a720038363775eac33d9f06
+  size: 460056
+  timestamp: 1775552125637
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-point-cloud-transport-5.1.6-np2py312h61f2ce4_17.conda
+  sha256: 532e2e0c04c80c77951a67060405a895840f6c192699e476af3bc6230a2d39d1
+  md5: 7d32e4bb4e8ef9192f1da828159efe3a
   depends:
   - python
   - ros-kilted-message-filters
@@ -41084,91 +40420,90 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 460042
-  timestamp: 1769485592694
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2ed9cc7_15.conda
-  sha256: 9e8b1e0ab9d8a03617d0941b12b4ca64b1843a70c67c8176cdb401e44c7fdd4e
-  md5: cc19316d8594ec61d055ae8a3f9c253e
+  size: 460479
+  timestamp: 1775551594244
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-pybind11-vendor-3.2.0-np2py312h2ed9cc7_17.conda
+  sha256: 88f9fce5879cdf17904e5aa37691e9e111a7f49cd1a351801c9276c16498d986
+  md5: 3c754da727d228d3f522c35a6bbbbbf9
   depends:
   - pybind11
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 23215
-  timestamp: 1769481216249
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h61f2ce4_15.conda
-  sha256: be50a2bcf5fef8eb2b0af9af3093f2f4d3e338b015e1d6c53247864c1b9244c7
-  md5: b66116e81cff1c32a57b89d44caefe7c
+  size: 23187
+  timestamp: 1775547427011
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-pybind11-vendor-3.2.0-np2py312h61f2ce4_17.conda
+  sha256: 835d8fa2d89ce183acfcac511294c79d555f0ce17515b14df6c3b79620ce1d53
+  md5: 88211c3ae62c047f5010602341d04cba
   depends:
   - pybind11
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 23223
-  timestamp: 1769481537544
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_15.conda
-  sha256: cc8e99c5a35358fc7aa4a1781a1796a4909553b3ba343e6392d2c43aafa98c02
-  md5: 0d63f3bb135e3814c53c57470ce7fdc4
+  size: 23353
+  timestamp: 1775547653301
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 3c9ff5e35e36103a86e363551d9a6e85220cdc5b438d5de04a5128fab84bd4c4
+  md5: 94ccb328eb0d4b8e2fa5f8205c7a7028
   depends:
   - python
   - python-orocos-kdl
   - ros-kilted-orocos-kdl-vendor
   - ros-kilted-pybind11-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python-orocos-kdl >=1.5.3,<1.6.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 27672
-  timestamp: 1769482300114
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_15.conda
-  sha256: 2dcfbc94ce49d329ae00b5719dc8916337a57c4fe8d23456bd1e24edb30ef3cd
-  md5: dcffa4b05e1ce1aca4036fe31c4afea3
+  size: 27648
+  timestamp: 1775548585166
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-python-orocos-kdl-vendor-0.7.1-np2py312h61f2ce4_17.conda
+  sha256: 2da7777525d2a9292f0580872fb34446006b802034f063b922d644886fa722ca
+  md5: 9c9da54dbab7547a29ecd079856b1b9e
   depends:
   - python
   - python-orocos-kdl
   - ros-kilted-orocos-kdl-vendor
   - ros-kilted-pybind11-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python-orocos-kdl >=1.5.3,<1.6.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python-orocos-kdl >=1.5.3,<1.6.0a0
   license: Apache-2.0 OR LGPL-2.1-or-later
-  size: 27629
-  timestamp: 1769482525214
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 6577e8d0d079e86e530a5db952aadb0ec7b60bc8d730d2d731df4bff44cfe84b
-  md5: 9d6eb9bbad1b93d07dbeacf98f7a6e4e
+  size: 27804
+  timestamp: 1775548556929
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: d4cd6431a7e5b52a2e6c9722af06bebcf2524b91fb1a831d13a62ad5719800a2
+  md5: be5ba045cf2767c6fa53b5c191031862
   depends:
   - python
   - ros-kilted-libyaml-vendor
@@ -41184,24 +40519,23 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-tracetools
   - ros-kilted-type-description-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - yaml-cpp >=0.8.0,<0.9.0a0
   - yaml >=0.2.5,<0.3.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
   license: Apache-2.0
-  size: 200044
-  timestamp: 1769484624231
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-10.1.4-np2py312h61f2ce4_15.conda
-  sha256: ff5372a61791c535d6d3b433e935b8f7d8378ac00d61bd2bd82f1459f7860f9f
-  md5: 67c3d67091019cd605a291d378b48511
+  size: 200334
+  timestamp: 1775550822899
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-10.1.4-np2py312h61f2ce4_17.conda
+  sha256: 2375342f63c97d567358234f8e57c7b6868198972972353b7dbd5c191d81b254
+  md5: 50e9b42168355e10a1a9fd43c84fb3b6
   depends:
   - python
   - ros-kilted-libyaml-vendor
@@ -41217,23 +40551,22 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-tracetools
   - ros-kilted-type-description-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - yaml >=0.2.5,<0.3.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
   - yaml-cpp >=0.8.0,<0.9.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   license: Apache-2.0
-  size: 205711
-  timestamp: 1769484769576
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: acbdde105959c58ceb99133a4dd8c864dc60a181da04ebd16cac7fad19befb4b
-  md5: 584a41c8567d1be94797b3c521ec57ed
+  size: 206208
+  timestamp: 1775550611650
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-action-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: b75dc8b0e3a14c52e5a8bcff4d5f7945e81b87a61814ebde85de204b9136c759
+  md5: 4a4b91d8c5c295c109308c0c201021bd
   depends:
   - python
   - ros-kilted-action-msgs
@@ -41242,19 +40575,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 82129
-  timestamp: 1769484819573
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-action-10.1.4-np2py312h61f2ce4_15.conda
-  sha256: 821ea35c7fd90c9e5bab92f4471aec2b42fa9925fd9e26a36a6386e31f30831f
-  md5: a5a5b26a23b1f0d9048b75bc9422dcaa
+  size: 82345
+  timestamp: 1775551009861
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-action-10.1.4-np2py312h61f2ce4_17.conda
+  sha256: efadcf4a0b55114759f06c3368e85ba6b8a25e3cee5ab111792988a927634a0e
+  md5: 32bbc92698c14756b541bbc4cc95e01c
   depends:
   - python
   - ros-kilted-action-msgs
@@ -41263,56 +40596,53 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 82795
-  timestamp: 1769484960943
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: ffe83f46a46661a6e7cef9da910972bee13e772ff235695991885d18bb179e38
-  md5: 704dfdbec340e3566ef6239dc7ccd392
+  size: 83196
+  timestamp: 1775550787086
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 434e4750e1ba3eb848ac1ff35be4605280d36f8eec9bef68a396f3130c5eae08
+  md5: 75ee05e0642e9aa048af36aace07a2b9
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 569744
-  timestamp: 1769483208393
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: 881476f8ea69e284a2ae19aab321ba407ddbbc07237b41570c7d89a5b411fdc5
-  md5: b9a7125a521f9a3ddfc6313c99bfe95b
+  size: 579256
+  timestamp: 1775549396880
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 93433a79df5b2f74c26f63d362f3ec172c7a83d33a99681105b353e720ac4e4a
+  md5: de0f2020b0ad3265552ad094d7623dc0
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 579957
-  timestamp: 1769483508836
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 05b635f7f2348fbee5cbe38938ede7e4e8e429f3bf1c85be9dd0bba385dc3551
-  md5: e41fada8061b5488f0db4b106a7be1fc
+  size: 589082
+  timestamp: 1775549417408
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: 7cbc04159e70060bda857c6f96acd6aeed1960cd604bc43ec7dfea4631b6fd8e
+  md5: 66fd4fab184105526d2610766ae4fbb9
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -41322,20 +40652,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 59110
-  timestamp: 1769484813191
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h61f2ce4_15.conda
-  sha256: d88430f5a2a39bef2693204c586a6e9ca0b56aec78b62aa9598fab312e183747
-  md5: ed1b82fe16b80bee9f389236ce850c0d
+  size: 59311
+  timestamp: 1775551002127
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-lifecycle-10.1.4-np2py312h61f2ce4_17.conda
+  sha256: f0cd948fd3f5125af8e7d99c96a22344033f7ffd9e829ea446e72117af61874f
+  md5: 241d20e7514ed63c5cae72efe1f4d5ec
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -41345,53 +40674,51 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 59870
-  timestamp: 1769484953734
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_15.conda
-  sha256: b692debf6902b771da30ff6c69f5999a620337edba67f86df89e5b675781e668
-  md5: 6151236963f5fdba874bf8b65ca90f0b
+  size: 60279
+  timestamp: 1775550778977
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h2ed9cc7_17.conda
+  sha256: 57a1b52c2f82998630cadcfd8be1819db48c84ab599fc3e932a6161dd1cb83d0
+  md5: a17c398dd42fdcf020bfc0182cae5d68
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36345
-  timestamp: 1769484328026
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h61f2ce4_15.conda
-  sha256: fa68fab81ef45373484f89da7dd681fb7facc315034b666715beed67ce20bb19
-  md5: f1b95ab2a7cc3b0dac2b4e39894cc7fc
+  size: 36538
+  timestamp: 1775550515508
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-interface-3.2.4-np2py312h61f2ce4_17.conda
+  sha256: 6f44996adf794b1eedb8863d0207cc8dd18ffea2e57430ecb335cbd958b6eea6
+  md5: 19703dac16c4c395290d7a304e1353d9
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36733
-  timestamp: 1769484490918
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_15.conda
-  sha256: d6ef0e91e15e1157193ab7dae817049c2e7d04b7518529d05e98d00f58376f60
-  md5: bc68717512d2355becf7d4e1e296db04
+  size: 37026
+  timestamp: 1775550354533
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312h918b84f_17.conda
+  sha256: b638a3b6db149e5ddbea5c0361621fc468a2678b5b9c23df37c4dec6145441a4
+  md5: 41cb4c19a429564ca2ec865d6d7c8d10
   depends:
   - fmt
   - python
@@ -41400,22 +40727,22 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - fmt >=12.1.0,<12.2.0a0
   - python_abi 3.12.* *_cp312
   - spdlog >=1.17.0,<1.18.0a0
-  - fmt >=12.1.0,<12.2.0a0
   license: Apache-2.0
-  size: 47114
-  timestamp: 1769484516374
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312ha677571_15.conda
-  sha256: 8308dd3cc0f411fee066d63e2e3cf8dc069697cf9bc3bb4d6febd3d0e4e3c8c3
-  md5: 57181f96149026b855f81fb19863dc2b
+  size: 47230
+  timestamp: 1775550700155
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-logging-spdlog-3.2.4-np2py312ha677571_17.conda
+  sha256: fc9d6e55841f74996f2eea5e126a03dff89e88a76c6805eaa88f6ac211d3787f
+  md5: 6f662671e45e00b78b3081f5d3a26000
   depends:
   - fmt
   - python
@@ -41424,67 +40751,66 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-spdlog-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   - fmt >=12.1.0,<12.2.0a0
-  - numpy >=1.23,<3
   - spdlog >=1.17.0,<1.18.0a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 48749
-  timestamp: 1769484656209
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_15.conda
-  sha256: 7c5e3d0c52c6e1c97ab1cba8d46fee35cc51697d3f7c64fbc6da1b997664bca0
-  md5: a73fd025b9e44fae030af213d9e2dfa2
+  size: 48984
+  timestamp: 1775550510845
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h2ed9cc7_17.conda
+  sha256: c8e1992763fa9a678b4cdfebb25041b2ba56c228ca1327095c8c15b8e0a2ac9a
+  md5: 0696ef97c78d29480ef095719ab33955
   depends:
   - python
   - ros-kilted-libyaml-vendor
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - yaml >=0.2.5,<0.3.0a0
+  - python_abi 3.12.* *_cp312
   - yaml-cpp >=0.8.0,<0.9.0a0
   - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   license: Apache-2.0
-  size: 52289
-  timestamp: 1769484343134
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h61f2ce4_15.conda
-  sha256: c8a5a76a2c0cd921534835e7e7e3da3e7670a669a63fecbd9709947005238567
-  md5: e11a87cd1286ee38589bf3904c394cb3
+  size: 52381
+  timestamp: 1775550528231
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcl-yaml-param-parser-10.1.4-np2py312h61f2ce4_17.conda
+  sha256: c93e9a708e238e4fac69966060b95facf4db94129db45fd2ac71ebcbf2b06a5e
+  md5: 69bbd4cc6bffe237894512af5a0c8175
   depends:
   - python
   - ros-kilted-libyaml-vendor
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml
   - yaml-cpp
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - yaml >=0.2.5,<0.3.0a0
   - yaml-cpp >=0.8.0,<0.9.0a0
   - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
   license: Apache-2.0
-  size: 53835
-  timestamp: 1769484507157
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 72db52619bd11a4190975c48c59ec47e0998df36bc626b5b680f35f559ef156b
-  md5: c10c35415c38e18fb2399a487e3a07f5
+  size: 54042
+  timestamp: 1775550366981
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 9b8583541811febca2fa0d41f42e45ad25fe392ba228363c4b59d57093eb72d6
+  md5: ac64994df47fd8fced41ff2682db8b77
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41506,20 +40832,19 @@ packages:
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-statistics-msgs
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 1084988
-  timestamp: 1769484860233
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-29.5.6-np2py312h61f2ce4_15.conda
-  sha256: bf1b0b572017c71cec8663a3ea6b4e2a8c7d08e818538fee73bd8eaa7730dcdb
-  md5: 8f1fa4da6b627cdbc3e2e337aad5f2ca
+  size: 1085475
+  timestamp: 1775551058360
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-29.5.7-np2py312h61f2ce4_17.conda
+  sha256: 492ccb8cdb0e108616ca817f596983ac4e9664c19096594a50f24c47b56f7e82
+  md5: 6c2c7b3b4fee6c7131bae4510906c444
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41541,18 +40866,18 @@ packages:
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-statistics-msgs
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 1045552
-  timestamp: 1769485020075
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 939f8d99c30817c02e8d82c7c16cf0c8bc850feee67fb6cf553e4e7ab87ff51f
-  md5: a5702a5f3a1f8fb7b7f6e15ba3c1993f
+  size: 1045691
+  timestamp: 1775550846582
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-action-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 2b81b7b55c8def56241188fbd165f46bbfe46a531882ed8c54f707f158399922
+  md5: 40329a7692568cc0f23599e5bfeda6bd
   depends:
   - python
   - ros-kilted-action-msgs
@@ -41562,20 +40887,19 @@ packages:
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 153998
-  timestamp: 1769485100965
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-action-29.5.6-np2py312h61f2ce4_15.conda
-  sha256: f724c52cf8c62127b7962ef13c44bb37a458a35e7a3431d583890174c1a89c5a
-  md5: 45f16e33279d6ca56d03d01bb205d72e
+  size: 154287
+  timestamp: 1775551308759
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-action-29.5.7-np2py312h61f2ce4_17.conda
+  sha256: f30d9606a9fd424e43f2556864a11e3e911592703fc8a64e686d711f429d68bb
+  md5: d0911f82bb9864d6581e0f6f856f0825
   depends:
   - python
   - ros-kilted-action-msgs
@@ -41585,18 +40909,18 @@ packages:
   - ros-kilted-rcpputils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 153800
-  timestamp: 1769485214274
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: c8277da67e139dea2f196ba318f99fd3ae6c422328118dd6aec10bbdebc3720c
-  md5: afa4b993e1382ef577778c57baaaa137
+  size: 154302
+  timestamp: 1775551051253
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-components-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: a469253ff935d1905ec64fc9845913c68eb0b3b50e0bdc3ff4e7ba55aa1298e1
+  md5: ebb001f9dc892c6d62842d8d3d3750b6
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41604,20 +40928,19 @@ packages:
   - ros-kilted-composition-interfaces
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 141025
-  timestamp: 1769485052378
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-components-29.5.6-np2py312h61f2ce4_15.conda
-  sha256: 758157c5d30764afa7d312fbee6a60b61ef5e460db285a26eeb913ba74b38331
-  md5: ff48398d3fd6ed5a2c219155abff100c
+  size: 141269
+  timestamp: 1775551261492
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-components-29.5.7-np2py312h61f2ce4_17.conda
+  sha256: cc11804a1984354c052eb3f1e876f88f227d7ae863d491cdd5a94d38e2e99c39
+  md5: 09a487a9b42ab23965bc29a5ab897d18
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -41625,18 +40948,18 @@ packages:
   - ros-kilted-composition-interfaces
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 142592
-  timestamp: 1769485170207
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h2ed9cc7_15.conda
-  sha256: 914dfbbee3e4e44deb535e3ec29478553412b76dbd84679919bff960ad36dec8
-  md5: faa66dec5c22e4004a9af2f523c7b444
+  size: 143057
+  timestamp: 1775550999729
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h2ed9cc7_17.conda
+  sha256: 5928d14cbfc313aa90a66cdde3287de6e2225ec150112a84173b859c8b7f67af
+  md5: 101d46ffd7bcb3ee77fb4601802825d8
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -41648,20 +40971,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 131333
-  timestamp: 1769485085949
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-lifecycle-29.5.6-np2py312h61f2ce4_15.conda
-  sha256: 3dd7f8114f7d131a07f8340398c3aa78f072b86ab38bc70d929dc47f7a3e3e90
-  md5: 6932d0e64bc87c30a364dcf6156b6da7
+  size: 131619
+  timestamp: 1775551293442
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclcpp-lifecycle-29.5.7-np2py312h61f2ce4_17.conda
+  sha256: 3e930198b2aec4fbb383a2e5d33fadbe86a904348340c095304238eadec84f69
+  md5: 24db9bccf60266c08bf7a36386500518
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -41673,18 +40995,18 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 128329
-  timestamp: 1769485200932
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.4-np2py312h2ed9cc7_15.conda
-  sha256: da2abeb563108b8dd6f588b3ca4a239cb74d9912c9d2d08efc05b555008add89
-  md5: b20289f32f2f92314a1ee616cb03781d
+  size: 128775
+  timestamp: 1775551035798
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rclpy-9.1.5-np2py312h2ed9cc7_17.conda
+  sha256: b819df2a1429c40abd027cabd3bc890789fbac6dfb19b83973d73b13afab1412
+  md5: d7fc439036a1c8bc19d655e4d7761e84
   depends:
   - python
   - pyyaml
@@ -41707,21 +41029,20 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-type-description-interfaces
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typing_extensions
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 779858
-  timestamp: 1769484959352
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclpy-9.1.4-np2py312h61f2ce4_15.conda
-  sha256: 06fef75ca871ec83f5494ddbb299336770928dbefc2ebd7c90e79cd5c1c7f9dd
-  md5: e87b555a7502caf7d7503b1ab90fa762
+  size: 796548
+  timestamp: 1775551161512
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rclpy-9.1.5-np2py312h61f2ce4_17.conda
+  sha256: 6ba7b5d7a23bda238dc28d0aec095b84cf69d13ecaacd9d7c3f89222cd3716a0
+  md5: 08398519bc34e5eaa2608a6ee0292872
   depends:
   - python
   - pyyaml
@@ -41744,87 +41065,83 @@ packages:
   - ros-kilted-service-msgs
   - ros-kilted-type-description-interfaces
   - ros-kilted-unique-identifier-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - typing_extensions
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 728395
-  timestamp: 1769485095622
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_15.conda
-  sha256: 1199b772ff5753fe14531cb408f5145a2e74a39363b3e43ffa5ca2c8f6b69ce3
-  md5: b6eafb50b1183cd3e259a9aea7523d9d
+  size: 744573
+  timestamp: 1775550923614
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcpputils-2.13.5-np2py312h2ed9cc7_17.conda
+  sha256: 226c1e61f1139fd9cb4999dd95177351ab1ec4895dfb4e01da19a0b7a2f66769
+  md5: 56d73c532cab2355082342ceb3cdc366
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 81193
-  timestamp: 1769482395135
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcpputils-2.13.5-np2py312h61f2ce4_15.conda
-  sha256: 2d3067c93814b805265ccb551f6f603174b52feaf676c889bb8fc3a1d023f960
-  md5: af827a00e48d27a69f9179bc8bcdb501
+  size: 81174
+  timestamp: 1775548674166
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcpputils-2.13.5-np2py312h61f2ce4_17.conda
+  sha256: b250d78e6b89b59d898224c92ad1b3f976a3d38785f791fc7428657477f29441
+  md5: 2c07d748e43dbd65a8d80a24131fd77e
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 81476
-  timestamp: 1769482623395
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.9-np2py312h2ed9cc7_15.conda
-  sha256: 79916bd06076c2de5fa417745a86aaf5286af8606999f677639a7f97a4f71d12
-  md5: 5bb98f92311be2e928276b25d1f321c7
+  size: 81697
+  timestamp: 1775548646993
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rcutils-6.9.10-np2py312h2ed9cc7_17.conda
+  sha256: 166534d5280affede23a0b39e78eb3d409b30dc5dc2f8d533067481da061d976
+  md5: 527943fb7c09036851b13b1c5b34b080
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 124639
-  timestamp: 1769482302421
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcutils-6.9.9-np2py312h61f2ce4_15.conda
-  sha256: 31008db40e2144f9dbd5f30e727f6323fd000573631c08163de9647c62ae1335
-  md5: ccba4bcce5ff9303ceb8d02825d7cc39
+  size: 124801
+  timestamp: 1775548585370
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rcutils-6.9.10-np2py312h61f2ce4_17.conda
+  sha256: d47b0e2f812a6d0b19d8c861532a25e143592723a1e46c5ad8b96d10ad046896
+  md5: f48454f17769cd4df0463f40d6b8aee5
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 128663
-  timestamp: 1769482527137
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.7.1-np2py312h31007e0_15.conda
-  sha256: b76721023df00831db2e931afef61d76faab2c1dbbb82d42058ab58e0230f609
-  md5: 6424463e2b230bb289092fe16ff467f4
+  size: 129059
+  timestamp: 1775548555826
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-realtime-tools-4.7.1-np2py312h31007e0_17.conda
+  sha256: a72a55e5cd51e2009214d8183a8a7565512704232ceff04776019d2ab0bd19f9
+  md5: 314737757dad569e6a93623e5f40849a
   depends:
   - libboost-devel
   - libcap
@@ -41833,22 +41150,21 @@ packages:
   - ros-kilted-rclcpp
   - ros-kilted-rclcpp-action
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libcap >=2.77,<2.78.0a0
   - libboost >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 66591
-  timestamp: 1769485257534
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.7.1-np2py312hbd2122f_15.conda
-  sha256: 052e45453abdd86981ce67ca56d7d6796ad933cc730763259b8f3f6be5dec887
-  md5: 1f7886b0a9fd554e9384a8905ddc14c4
+  size: 66717
+  timestamp: 1775551555616
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-realtime-tools-4.7.1-np2py312hbd2122f_17.conda
+  sha256: ca8aa3014e8ec5788ad1ae852c6a9c74c9a6a4e6d13951109d8679ee1b150032
+  md5: aa92b99f71d5194b6aec94c823fcf928
   depends:
   - libboost-devel
   - libcap
@@ -41857,135 +41173,129 @@ packages:
   - ros-kilted-rclcpp
   - ros-kilted-rclcpp-action
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - numpy >=1.23,<3
   - libboost >=1.88.0,<1.89.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libcap >=2.77,<2.78.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 68947
-  timestamp: 1769485346238
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.1-np2py312h2ed9cc7_15.conda
-  sha256: c81b7aa94322b7c583922049516eb3e4befc0e5213e0b5f5ec12bdfff686c5ea
-  md5: aa924dad09accff173795836eb9c567b
+  size: 69355
+  timestamp: 1775551186828
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-resource-retriever-3.7.1-np2py312h2ed9cc7_17.conda
+  sha256: 2f4638b52f4797296cae956aa642e4f849910ee650983b93b51d13954be35efa
+  md5: 6728e27b90202f5f2cbfa9c5e6b21323
   depends:
   - python
   - ros-kilted-ament-index-cpp
   - ros-kilted-ament-index-python
   - ros-kilted-libcurl-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 56823
-  timestamp: 1769484328475
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.1-np2py312h61f2ce4_15.conda
-  sha256: a8c72e03c143aaa3acd7ca1361ccea380ebd50b61fb8654b032ff0476608fbdc
-  md5: 79ab3e302f1ff22d69dcaa3b44cc47bf
+  size: 56856
+  timestamp: 1775550518064
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-resource-retriever-3.7.1-np2py312h61f2ce4_17.conda
+  sha256: 1ed28c69306c29a1d78e3b2f37547daa4fec882c247cbe97ff9e695e8139e2bf
+  md5: bebbb569504d9fd600eee0b5a762c19a
   depends:
   - python
   - ros-kilted-ament-index-cpp
   - ros-kilted-ament-index-python
   - ros-kilted-libcurl-vendor
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 56841
-  timestamp: 1769484489885
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 89a7e4fe2c32f21e41e1a503ae8f75060e332aa4b2d261add38c2b19b64bd5a3
-  md5: bcc42e809b01f1d371f81106cf6b2bf4
+  size: 57033
+  timestamp: 1775550354132
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: aa5afa08cdb4efd1cd8e03bd62631a9760ac09fdf88c6804551242dc0921718e
+  md5: ee530185c3b6b4feea576655de014ee5
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 96661
-  timestamp: 1769482511168
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-7.8.2-np2py312h61f2ce4_15.conda
-  sha256: 587d41b98f63b7be649698b3092ecdff45053823b3b5cb4ad9849aa3bd5f5068
-  md5: 2ff1523edc9c79739aff46881af99f5d
+  size: 96716
+  timestamp: 1775548790186
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-7.8.2-np2py312h61f2ce4_17.conda
+  sha256: 0eafa046d965e5d5407ddd60594567958de1a0070cba808a6b2f724947adbbd2
+  md5: 2e1421133ff3769fe4db5871eeb8bb73
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 97550
-  timestamp: 1769482751022
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: e74882e6de4a6bc78353cda16db14c6e47fd17d14721b64d8d2bd96641bd6904
-  md5: 4bac28b5915c3333607428786da0698d
+  size: 97768
+  timestamp: 1775548767029
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: a668aebdb2f93d38ab678258074a53ecb69cc714a3ab93d906d2e4f655135500
+  md5: 6a9eb0ef2fca1a3d080b77a3987ae3fc
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rmw-connextdds-common
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 30747
-  timestamp: 1769483562613
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-1.1.1-np2py312h61f2ce4_15.conda
-  sha256: 039e63906d7c8f26be23db37f66cfd4f677b3f0649c807eeadae02a2b40bf923
-  md5: fbd5b797e88ad618064978c7e6e6457d
+  size: 30913
+  timestamp: 1775549732574
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-1.1.1-np2py312h61f2ce4_17.conda
+  sha256: b928f70d78fe4223b43f866472d1c916f1aba6b5904e69b786cab7c3a0cbeacd
+  md5: 0a73f460e0f1d4eddaa9c1310a8942db
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rmw-connextdds-common
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 30652
-  timestamp: 1769483817575
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: c6773670b92bccc97676ff7a7385adc1b54fda17f123d472bd0e2c029aefb4a7
-  md5: 8a4144962bfe997fcd2b55ac1f4ec68c
+  size: 30958
+  timestamp: 1775549712603
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: a8a983d684406b89e4a52b184c74cfaefc22ca6db2cbebb01d09dbb56f44616f
+  md5: a47e0b8b2d0418febc69ec23a32d0ea5
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42004,19 +41314,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-rti-connext-dds-cmake-module
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 53981
-  timestamp: 1769483386926
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h61f2ce4_15.conda
-  sha256: 7e684697ca28d86d0c8298af8f5ec2620d91d9427a107986b8899db1af6a9215
-  md5: 2c057cf01adf04bb39c231896c11de1a
+  size: 54168
+  timestamp: 1775549557040
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-connextdds-common-1.1.1-np2py312h61f2ce4_17.conda
+  sha256: 5f87bc17cda9458d31db3dc229c5cb90f8cac6ad2f5cb1977863c1626feab44e
+  md5: 3c3d09396a53f8cab4682615dfe70083
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42035,18 +41345,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-rti-connext-dds-cmake-module
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 53900
-  timestamp: 1769483658742
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_15.conda
-  sha256: 97a959a21ee2d8af1e368c053a81d5a457d42d4b6e4f01d3012b9fee8d60b471
-  md5: a67fbabb64d831fe3181ff9e99212fea
+  size: 54208
+  timestamp: 1775549571679
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h2ed9cc7_17.conda
+  sha256: d5f88d022d81e3f960c34084b447dbde460cab41724588023d7a72464f16cba4
+  md5: 451053acfc9eef08b21b7c14fd605fb9
   depends:
   - python
   - ros-kilted-cyclonedds
@@ -42061,20 +41371,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 260986
-  timestamp: 1769483391935
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h61f2ce4_15.conda
-  sha256: 54a1cae2189bb4d5c62ed705861caff096a67eb1f6db3189311bfe81b24179e7
-  md5: d6be41da033cfcc3328057143d7e33fc
+  size: 261296
+  timestamp: 1775549564080
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-cyclonedds-cpp-4.0.2-np2py312h61f2ce4_17.conda
+  sha256: 711475c925f3fb5e7fd4000a58e757183fe9d17586b4f7011eb3f1188c25dc08
+  md5: 1118797b0d6863bfa574eb3b30a7cf3f
   depends:
   - python
   - ros-kilted-cyclonedds
@@ -42089,19 +41398,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 258849
-  timestamp: 1769483664758
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_15.conda
-  sha256: 95cbcb0757439e2c21b7aec33ed7b3ff71865db97135be8ba3410157af0f8545
-  md5: ab06959a37278f17ce39dc71971d337d
+  size: 259211
+  timestamp: 1775549577818
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-dds-common-5.0.0-np2py312h2ed9cc7_17.conda
+  sha256: fde5b85c5e0f77d066705eaf97aa1e40ca910ab74f4d6571b874b7c4afc0204d
+  md5: b933f8ce3f5007bccc53558ae848e514
   depends:
   - python
   - ros-kilted-rcpputils
@@ -42112,20 +41420,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 164613
-  timestamp: 1769483120714
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-dds-common-5.0.0-np2py312h61f2ce4_15.conda
-  sha256: ef6ef3c7f45bb028366a4c112734cc9a69a16e97c3258e9a555465fd030e3292
-  md5: 4df1474658715d4be36e632a17fa13d6
+  size: 168450
+  timestamp: 1775549324266
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-dds-common-5.0.0-np2py312h61f2ce4_17.conda
+  sha256: c505519514960a0a0fd0a08fb9f1a1e54c17cd3a585474fab78b8b474fb78e8b
+  md5: 5081803a4ab0fcf38f365540a043c20a
   depends:
   - python
   - ros-kilted-rcpputils
@@ -42136,18 +41443,18 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 165519
-  timestamp: 1769483436889
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 1cf4f63119d38c97ca6f5e0b9293a6c57259e8a80a067664b4817c708d0ede3e
-  md5: 4010a448c3314064b57cccdcf28524f5
+  size: 169670
+  timestamp: 1775549344274
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 24a5c493dc79e190b7dd7a28cbf7e230bbf789b3d17510575159b8da0a3a19f6
+  md5: f2fd0784a7c2e4f34c241e4081da6814
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42166,20 +41473,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 154349
-  timestamp: 1769483537019
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h61f2ce4_15.conda
-  sha256: c8319bd70f6af32d0766533f72cf57ce1ba261776e643ec5f04717c04967a844
-  md5: c5213c2a4413a359efe3a251302a3406
+  size: 154573
+  timestamp: 1775549706343
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-cpp-9.3.3-np2py312h61f2ce4_17.conda
+  sha256: fc0daa5f9928728d3da270530e6224e59c9d02486d3659985cdf2421d21d063c
+  md5: cbeb44891e2c8b85b0293f161b88717d
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42198,19 +41504,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 159705
-  timestamp: 1769483795692
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 19c353e3f95cd5593ebca60dc72e0be4055396a413e7db81873eaacd72752c7b
-  md5: 2999db357fff33f6b8d3a7a7c5ce5d61
+  size: 160046
+  timestamp: 1775549691629
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: ad1be05b64f46fa8c5ca26a852b5339e02b29c695be543c00768e63c47977a65
+  md5: 459cc020fdf64943c389b93c5839d1a5
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42226,20 +41531,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 176875
-  timestamp: 1769483498087
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h61f2ce4_15.conda
-  sha256: f52f8cede5aea4ef6f03e056c9dc2b29ff662363c50594dc0b05167db8005b8f
-  md5: 1788dfaa7eda2ec38b26ece310d170b8
+  size: 177083
+  timestamp: 1775549669958
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-dynamic-cpp-9.3.3-np2py312h61f2ce4_17.conda
+  sha256: 369ba6d5046036c26ad71eb575f9bbce7d308d105ddfa4cfff0b1f3845428534
+  md5: ca01274c937e8bc046dc41c13150fde3
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42255,19 +41559,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 177228
-  timestamp: 1769483762869
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_15.conda
-  sha256: c8efbe9096379aff7cc8828f9aec5632fa436222e222d68f6fc336eab8fc1405
-  md5: 6d720f18474f9f5312ed105101353296
+  size: 177567
+  timestamp: 1775549662118
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 04f70d066722d7dafc1b5d355aaf6bfa0b3f36b81c3a344413d1e338d03b6982
+  md5: 51f7087e37401fef93f0e351c6513a50
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42283,20 +41586,19 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 231805
-  timestamp: 1769483338194
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h61f2ce4_15.conda
-  sha256: 552feea02e5c44940d50d4e12ee92dad69af66628ddc967ce48f7ba8edfc03fe
-  md5: 27626218114e3b359ef188680bb692c7
+  size: 231956
+  timestamp: 1775549508545
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-fastrtps-shared-cpp-9.3.3-np2py312h61f2ce4_17.conda
+  sha256: f66987d0c6ce430be000c7fc37a7e9fc2a1b06af312734e2bb6554a3dfa29952
+  md5: acb89b34b904aae4ef7ebfb8f7dbec8b
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42312,18 +41614,18 @@ packages:
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
   - ros-kilted-tracetools
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 225543
-  timestamp: 1769483620022
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_15.conda
-  sha256: 8a7e656091bcedd378e9c1baacbbfaa03983bc134e263802f1e1948190879d52
-  md5: 12f2f5b4e7685a2654e4b06963eed3ea
+  size: 225867
+  timestamp: 1775549527309
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-3.0.6-np2py312h2ed9cc7_17.conda
+  sha256: a666e50b2717cad68d317c7696fe3e854cd60a354b5602d621abda6e126866c1
+  md5: 01831e174d4af43b5e6772d4113f9227
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -42335,20 +41637,19 @@ packages:
   - ros-kilted-rmw-fastrtps-dynamic-cpp
   - ros-kilted-rmw-implementation-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 53323
-  timestamp: 1769483757605
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-3.0.6-np2py312h61f2ce4_15.conda
-  sha256: da7dace313af37c5b29f438134c815d98bd004e8d917e44bcc942596a2ae3aa7
-  md5: 993b03d7d709a7ebb0b0f76a63eb0126
+  size: 53518
+  timestamp: 1775549916490
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-3.0.6-np2py312h61f2ce4_17.conda
+  sha256: b33262f8c0ef8bdcfb6fbdd96727a5257d52fb43a3b18a43464a6a10fb35ac21
+  md5: d8d30600baf701a42a222d0eebfd217e
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -42360,124 +41661,119 @@ packages:
   - ros-kilted-rmw-fastrtps-dynamic-cpp
   - ros-kilted-rmw-implementation-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 54934
-  timestamp: 1769484011975
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 40d46154aae64f3baa1120ca18327eebaf2f8b188246e2cbb150a2f0e059d1eb
-  md5: 69758cdc840841f7d14d9f73853157d2
+  size: 55254
+  timestamp: 1775549868504
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 0cc7571a93c5a2696586bcea1362041d82f3c828cb21cde5a76a8fe489011aab
+  md5: 76366ebbcf061a54ee8c5e07a36a0d5f
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 29440
-  timestamp: 1769482245508
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h61f2ce4_15.conda
-  sha256: 5fe41d997f4c2cd23cc706351b90c6f7f167207983f9a35842ce7e26f2652401
-  md5: d2957d1b491d7b45aefbc36a56718856
+  size: 29634
+  timestamp: 1775548538232
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-implementation-cmake-7.8.2-np2py312h61f2ce4_17.conda
+  sha256: b9a59b0b2b92c4ddfed34bf6a15949deada4df5a2d8f3caab323b3732cf8265d
+  md5: 47016bc19ce397846d5737fd6789f248
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 29436
-  timestamp: 1769482468554
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_15.conda
-  sha256: e50f857408f10c1c86d298cbebfebab855f5cf11c0d5a4fd36b29556c333748b
-  md5: b3594ee9039c5a35c6e2774c3538d9a1
+  size: 29678
+  timestamp: 1775548499425
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-security-common-7.8.2-np2py312h2ed9cc7_17.conda
+  sha256: d57ede0c3f3939da996c3ad686f3cea41b8d8bdb35b7638a05da6d8c1528db93
+  md5: 69816448129cca4818d879fef6f5cc81
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51115
-  timestamp: 1769482626707
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-security-common-7.8.2-np2py312h61f2ce4_15.conda
-  sha256: 31510212583719626c7f091ab8e96489e0fe1fdd1572313b17e1f2ef354ecaef
-  md5: 65a6111d16527f433918b19d2005348d
+  size: 51251
+  timestamp: 1775548884853
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-security-common-7.8.2-np2py312h61f2ce4_17.conda
+  sha256: fb0ea3d8ad6ba4615ea6bc6ced0ac0150028104872c4442c275b5f62c6305ab6
+  md5: ddf5838ef59e4c9d1d3afe901ef26802
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 50702
-  timestamp: 1769482905405
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: c89feb8bfd6424bfee97c79b9cc7eb34e23184a53ad817d728344935aea84c7e
-  md5: 431c216708bd3e1860a429ed57064845
+  size: 50908
+  timestamp: 1775548864393
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: b0e766b073287e203e934e2b52ef47d06b4362c7a46e88382f7f9bf25c62d96e
+  md5: cc14fbda21b165c9980c075fcd062d40
   depends:
   - python
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30538
-  timestamp: 1769482633737
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h61f2ce4_15.conda
-  sha256: 9c75c515f350c47fc7ff9901c11f86bdc7c6e0f3c01bf62b3c785d5774c04430
-  md5: 32627e4ca39d021a55e86b315a90e516
+  size: 30661
+  timestamp: 1775548892777
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-0.14.7-np2py312h61f2ce4_17.conda
+  sha256: 06aebd94833036ae75f06de8516fd8ba7fca932850e247466c86f06fbe2fbec5
+  md5: eebda3b0777cd389847e352d7340392f
   depends:
   - python
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30536
-  timestamp: 1769482912187
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_15.conda
-  sha256: 0dcbbb8f26e2aa026def344f0df6663eef3604dd94c6f95408297e61e1d0e06a
-  md5: a7dc858192bcfeaa7cdcf7eaef19c873
+  size: 30751
+  timestamp: 1775548872519
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h2ed9cc7_17.conda
+  sha256: a6c0e2082a2f0b82b8e99c9a2723bb550e5f8ccffac1dbcd9194772d44bf0f70
+  md5: f47e870dfb282f8c597382b9ed2823c5
   depends:
   - python
   - ros-kilted-rcpputils
@@ -42486,20 +41782,19 @@ packages:
   - ros-kilted-rmw-test-fixture
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 52380
-  timestamp: 1769483950404
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h61f2ce4_15.conda
-  sha256: 92125e58b9a616b8a60b0ac7d86c987b849aaccad7f7faa9b85d6ead2935104c
-  md5: c3e6810dd22b3f8a9233ab7cc3afaf18
+  size: 52621
+  timestamp: 1775550152244
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rmw-test-fixture-implementation-0.14.7-np2py312h61f2ce4_17.conda
+  sha256: f8bbf313d61acf41630550896853946dd11abf5906f87e59325abab7be48e2d7
+  md5: 76e4abeaff06ac78989b84d343af7ff8
   depends:
   - python
   - ros-kilted-rcpputils
@@ -42508,19 +41803,18 @@ packages:
   - ros-kilted-rmw-test-fixture
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 54535
-  timestamp: 1769484189426
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.3-np2py312h2ed9cc7_15.conda
-  sha256: 0c6428c2c7201ca1dc0522b471f2ad50dc3b287a0e619035b7f877710ff8772c
-  md5: d40fb96937348156d831b9b59f1abacc
+  size: 54912
+  timestamp: 1775550040958
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-robot-state-publisher-3.4.3-np2py312h2ed9cc7_17.conda
+  sha256: 34a70df31f026b3119733dbda0355dd48c4468b9e586f4dafd92247624c50e52
+  md5: dad1d181a4f96a38fab80029b9d22c03
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -42535,20 +41829,19 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-ros
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 268252
-  timestamp: 1769485936495
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.3-np2py312h61f2ce4_15.conda
-  sha256: 1273e96e2932ff32d68178a4e44ca681c2d21b7b2c07b0dcaa5a7f2643b74da5
-  md5: 2aa6fc9453dd01e87aa6e2f46c2e972f
+  size: 268498
+  timestamp: 1775602470625
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-robot-state-publisher-3.4.3-np2py312h61f2ce4_17.conda
+  sha256: 72109ac1302cd29e7aaaa36d54dc59940e2c0c9ee42e78b072396751cf13c838
+  md5: cbce1477d5c85faf7950592f3ef5ecf8
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -42563,19 +41856,18 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-ros
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 266405
-  timestamp: 1769485911696
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h2ed9cc7_15.conda
-  sha256: 1beae3402c856bdc4ed77f3caf28ea06c09f42d7192023574ca3d7068d759ca7
-  md5: 92e28039658d97ff907e1989ad24efb5
+  size: 266811
+  timestamp: 1775602663614
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-base-0.12.0-np2py312h2ed9cc7_17.conda
+  sha256: 02759e8686aed0613636d8f451fc7b4b8630db6e422b3d60d4a217cf7a2f419f
+  md5: 25cbf8453ad7ddfe44064dc4fb44fac7
   depends:
   - python
   - ros-kilted-geometry2
@@ -42585,20 +41877,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 22456
-  timestamp: 1769492651079
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-base-0.12.0-np2py312h61f2ce4_15.conda
-  sha256: 0a7569088ddc1b647bfd53b5070f0e71577b56c875a7b7bd3d5a0841d18ac887
-  md5: 395e29e6b57f7f2960e36224a7226071
+  size: 22394
+  timestamp: 1775606922876
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-base-0.12.0-np2py312h61f2ce4_17.conda
+  sha256: 0ac74716efe6497e3de3eafa29be963d779b1f00a538da65cf5a4c74e4bc1651
+  md5: 5f126df2ce614751b86ab0772a12e06a
   depends:
   - python
   - ros-kilted-geometry2
@@ -42608,19 +41899,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2
   - ros-kilted-urdf
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 22432
-  timestamp: 1769489480850
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_15.conda
-  sha256: b76f984e83e66b996fe9963f60101dd0f4641179c796d247eead2639162e7e6f
-  md5: 5675090d8fde356787ea88e63cb29858
+  size: 22531
+  timestamp: 1775613875728
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-core-0.12.0-np2py312h2ed9cc7_17.conda
+  sha256: 2621c65e4d791f60c49bb6a44b34db129a3ed7291dcacfe277043153579f245e
+  md5: 65ac35c66b8422d83baed51c1d504e80
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42656,19 +41946,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sros2
   - ros-kilted-sros2-cmake
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23141
-  timestamp: 1769487744654
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-core-0.12.0-np2py312h61f2ce4_15.conda
-  sha256: 7d35cba5bd78c41ee0af9138e89d8abe49e0c410dd1246fd93220e61ef729406
-  md5: e8a9cacbdf44812690576a43ba1f3cf6
+  size: 23094
+  timestamp: 1775604330348
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-core-0.12.0-np2py312h61f2ce4_17.conda
+  sha256: 8b6b66ba65eeec2c18865a92ea8b3d0d23865273a96b343b9264f8276c51f859
+  md5: a74afe4019a75a4ec266611716b082e2
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -42704,78 +41994,76 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sros2
   - ros-kilted-sros2-cmake
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 23172
-  timestamp: 1769487467572
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_15.conda
-  sha256: fa07b737d84363ad94af7b67c5e25372d73c6f22fb830084c9a3122fb9b18b09
-  md5: 0b7b4a3be085491774335da001e7600e
+  size: 23195
+  timestamp: 1775611626574
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-environment-4.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 0a2b7df45929b66be4c99f1acd45bb64a40e146c6df57e32ce6bf23dab208fcf
+  md5: b9ffe9267430e19fc4e3e1dda15b2958
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 21431
-  timestamp: 1769480694236
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-environment-4.3.1-np2py312h61f2ce4_15.conda
-  sha256: 504542b92cc3af4924243c555a4414f7f1ba0710b0498cf5c630ec2a0e5b68a3
-  md5: 74e4c904d748d3966c3e803624eb442d
+  size: 21349
+  timestamp: 1775546867511
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-environment-4.3.1-np2py312h61f2ce4_17.conda
+  sha256: abd6d73de9dc7cb671a51fa0b6f1b55c0478bc0e21f0edaccb2f3130ade9b28c
+  md5: cb559a786212bc5d31409ef99c53d606
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 21416
-  timestamp: 1769480976823
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_15.conda
-  sha256: 88269c8ef716917c734961ed99107553a562576e92b4d2a886237f0951030333
-  md5: fde5bbdacf0191dbe4d72dded6025c64
+  size: 21472
+  timestamp: 1775547121998
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros-workspace-1.0.3-np2py312h2ed9cc7_17.conda
+  sha256: 723deebd9977c765fcfd7d4bd1cfcc69b2a67f44fca3051a650999e784874bf2
+  md5: 0dc4c839cefa2d96bee05a205ece9f5e
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 35511
-  timestamp: 1769480681564
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-workspace-1.0.3-np2py312h61f2ce4_15.conda
-  sha256: 528e695c49298f048f743b8cd72286c394a8784d6bed3c9ceaa7cafd2fd1a060
-  md5: 6275a65f4eb12dbff3e8f80e3fadbaa4
+  size: 35269
+  timestamp: 1775546853784
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros-workspace-1.0.3-np2py312h61f2ce4_17.conda
+  sha256: d6be9b6258de9905508f739739d4906d5eb703d496eca2ee060fbe1c77e25017
+  md5: 20236657dbf867c22889e0a1bd305656
   depends:
   - python
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 35474
-  timestamp: 1769480963173
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 019a522c85604fb61ea63555db41f0fc34728bbf3e02a16b9ab606d39b97c822
-  md5: 2540513e607e09f60f03e44e67d8cdb4
+  size: 35376
+  timestamp: 1775547109838
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2action-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 893b3fd899df270158f9fd81fce0cc45210322ab05be05970479b8139345a52d
+  md5: 2200b709455d17233145843ffe4cca2b
   depends:
   - python
   - ros-kilted-action-msgs
@@ -42785,19 +42073,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 56907
-  timestamp: 1769485926708
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2action-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: e3016cf290035f8fd199e2ab6869246648521d058524a57832a1f7f73fd12e60
-  md5: 39214cec4d9c9920eab98af34e65f336
+  size: 56751
+  timestamp: 1775602447842
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2action-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 2854ac8ece156c5da6069a6441d5bdc80fa834abb254598e5664bcd4dc8e6818
+  md5: ca01abb518d420276e1c721cc3dd446c
   depends:
   - python
   - ros-kilted-action-msgs
@@ -42807,19 +42095,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 56708
-  timestamp: 1769485910904
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 0f31f4cb0ca74ebfed34c6294c70f0009d9ddf1f6c584572665ac29ad59ddd9e
-  md5: 0d0c78a0f5a13c3f9f5ffd37a9c03002
+  size: 56873
+  timestamp: 1775602643997
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2bag-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: fc1dc46889a50126c4313f11d92216f9492655e4485a55b15db37866c3c3f19e
+  md5: d86647321eb6c9178a9359c8ff89800a
   depends:
   - python
   - pyyaml
@@ -42828,19 +42115,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosbag2-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 71709
-  timestamp: 1769491627218
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2bag-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: f1b969604117b1d57cd6da5da2dc56f22ffb5eb07b629ed61cf89eb5f4bff615
-  md5: 4d384a460981d6329959eacd47f1c155
+  size: 71678
+  timestamp: 1775605680175
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2bag-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 4627264ecb2ff3c246cb480a99e8e1b040977965ebb556e1112a60f7f85e406c
+  md5: 7547a1c62ec307ad99eefe06396ad4b1
   depends:
   - python
   - pyyaml
@@ -42849,18 +42136,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosbag2-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 71561
-  timestamp: 1769488556385
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 96d322ae56d1859214719aac84f757cfff1f0a015c7ea02768365859878dd8aa
-  md5: 26430602d162f840327bb0ce8c8ebe15
+  size: 71686
+  timestamp: 1775612849881
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 08fd099543e01a030d9a867d0fbe00b281cbbe537d4622e717663f5e1ff8e914
+  md5: 552f34df46237e24b74619ea30a92335
   depends:
   - argcomplete
   - packaging
@@ -42868,20 +42155,19 @@ packages:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 75285
-  timestamp: 1769485113379
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: 8c61e1cf30f6f12ee3e873310a32b8fbb2098200c6e14226cb8a1b8100fffb95
-  md5: d83ff84d1b26de223f498ab16dc62ab4
+  size: 76065
+  timestamp: 1775551322006
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: a56c489c1ac8a6c6def84ceb7d3456b5e7a982396e5b3e4365bad041eb0517c1
+  md5: 0974bd9d81d9ca07017453e3deb9a98b
   depends:
   - argcomplete
   - packaging
@@ -42889,19 +42175,18 @@ packages:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 75194
-  timestamp: 1769485224283
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_15.conda
-  sha256: c47f03a72653c920ce1093c8935a278736058dc260b83151cd5c9ac2fd425fb3
-  md5: 6e5b2a57d32332a87b3f6c381085c650
+  size: 76203
+  timestamp: 1775551062641
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h2ed9cc7_17.conda
+  sha256: 17e767b1d71c36d29bbd7118e5a02ab4a69af899513f030f157a93aa90213e66
+  md5: 6a353a72f30340a55d74834a92232aea
   depends:
   - python
   - ros-kilted-launch-xml
@@ -42923,20 +42208,19 @@ packages:
   - ros-kilted-ros2service
   - ros-kilted-ros2topic
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 26880
-  timestamp: 1769487321970
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h61f2ce4_15.conda
-  sha256: c314b70263bfcb318138fd72d3e202c73ecd7d69d0b10fb6f891ab30415e5495
-  md5: 586721074d3d9956d212b7132d3eae1c
+  size: 26956
+  timestamp: 1775604034634
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2cli-common-extensions-0.4.1-np2py312h61f2ce4_17.conda
+  sha256: dc0cfb8041f21554673416eed71e067ec3063f50203bf7b3deef61376dee6953
+  md5: 4d815be08d4158f08bd6c4e90545f120
   depends:
   - python
   - ros-kilted-launch-xml
@@ -42958,18 +42242,18 @@ packages:
   - ros-kilted-ros2service
   - ros-kilted-ros2topic
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 26844
-  timestamp: 1769487071341
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 78f773b80ba3cb4d0c893eb94141a688697bcfa94e8c8e7a99e14d24a6d4cfed
-  md5: 656f2964767e27d8cf966641ef1fae42
+  size: 27045
+  timestamp: 1775611423611
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2component-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 20efe3b862c34d2c5c2174efeca823c29b3a6150a14c01b3d89397c675db89cb
+  md5: 98a3e9a6ac667541c2c9e1e2e5eae04d
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -42982,20 +42266,19 @@ packages:
   - ros-kilted-ros2node
   - ros-kilted-ros2param
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 38297
-  timestamp: 1769486521193
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2component-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: d87c9a26ec03278dd06c508ab98535695a991ddee549686aef1259f57ccd7582
-  md5: 8243db65c26460382b08533678a5357d
+  size: 37886
+  timestamp: 1775603168404
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2component-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 142dbba4f9c204c1c4956b8f4b47ff974748d2eb0ccece6ce56213c9b0171f1a
+  md5: 7e5fde80273a28cb97655fe455512488
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43008,18 +42291,18 @@ packages:
   - ros-kilted-ros2node
   - ros-kilted-ros2param
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 38233
-  timestamp: 1769486429950
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 024d3173d9b396631fef798e11e392044b789705ac1f96a97ce4e631227d6c8c
-  md5: 347c995b1718be605216299c014c609e
+  size: 38063
+  timestamp: 1775610740629
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2doctor-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 42fb2904050b6af006c2aa2a0e6e7fac936d72038e60c7113c5e2ecaffcfe0c9
+  md5: 6e0d8793f76dad30197f1157066d4dd0
   depends:
   - catkin_pkg
   - psutil
@@ -43030,21 +42313,20 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - rosdistro
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 66142
-  timestamp: 1769485606208
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2doctor-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: 9bc339f7d1813846da49088fe2746e997ca5aa87d8923eac5d55ee5cb88b3559
-  md5: d6fdb2a6342e97018471ffc6fb54b35d
+  size: 66106
+  timestamp: 1775552009135
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2doctor-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: ca41b8bc7f975894c63804f2acc4ae9744e89934b48d9ec5c474502bfaddbdd3
+  md5: 0b7eb95ce1f60166ddb50f334e7d728c
   depends:
   - catkin_pkg
   - psutil
@@ -43055,19 +42337,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - rosdistro
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 66005
-  timestamp: 1769485641028
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 41c51b3389d8c703a3b93a5866680431638d0d5693ea75276376c1d0c17a4743
-  md5: 62e424ae8d06284a3e66aeda632319e5
+  size: 66266
+  timestamp: 1775551509346
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2interface-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 372bc038194c2ec230faee79045ee8434d551da2e3dcbb763d0fb4525544f83d
+  md5: f0c7924a5f0437efc6d3f3eaa1e9e412
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43075,19 +42357,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-adapter
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46167
-  timestamp: 1769485599797
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2interface-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: f1e867b7f34ed0496de2506dff9628a0b5445902d79bdb1a5d15acbd8b60d63f
-  md5: e96f39fdd1241718a1f42cc37f602730
+  size: 46151
+  timestamp: 1775552001968
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2interface-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: d4cd40989869f8392945392bf29a925c5305bf733576372a5eaa827f12ebd827
+  md5: 0b5996e66e74ea5a980d7c992e847d3c
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43095,18 +42377,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-adapter
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 45965
-  timestamp: 1769485632551
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_15.conda
-  sha256: 3c5e8ec32729c4577fec5ecd2c5d13b119c0c53e64bd72cdcc673724871d4775
-  md5: 5f67bf26a04af230f38a5c0a9d3549b8
+  size: 46233
+  timestamp: 1775551499727
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2launch-0.28.5-np2py312h2ed9cc7_17.conda
+  sha256: 091747592c074bab1adb3b79e3f7ba8bd23682c4eba2ae954cd3c4726719ee9d
+  md5: b648348a7223709182b773b40f8e8ed1
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43117,19 +42399,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 33758
-  timestamp: 1769485921112
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2launch-0.28.5-np2py312h61f2ce4_15.conda
-  sha256: b46797f0370d20494b4f13839866592ba4d04c4459211a2c2d3e65e982f495be
-  md5: f1d889aa0d560eec387fb24b46124b78
+  size: 33380
+  timestamp: 1775602440796
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2launch-0.28.5-np2py312h61f2ce4_17.conda
+  sha256: ec445ada5849a80eb186ddd3a27026549bacfa1203f1c1530b99aad3f4fbc9ae
+  md5: 64d08450fe8b99d0cad8d55ad3f34fac
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43140,18 +42422,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 33746
-  timestamp: 1769485903362
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 63f58180568ff4ef1257226bf704e153b75c8f29987827a8cc7ee4b590197551
-  md5: 8e3368e8ff5ac6b84a99d125c48fe962
+  size: 33551
+  timestamp: 1775602633637
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2lifecycle-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 0d9dc6616acf7c10b787cfba0211aaf7c37cc93271e88235d941f5e9e12cf599
+  md5: 050065b48e51a0ea877f3f1cde5c67a0
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -43160,19 +42442,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 44804
-  timestamp: 1769486251309
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2lifecycle-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: 1d8bc17173f47a59004a5733a3243c14b743adf5e279853281f5868240f25d8a
-  md5: 620ce4ae98d979ffd5b8ff22adbb2d3b
+  size: 44663
+  timestamp: 1775602772580
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2lifecycle-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 315799b53304b8e27eafba18a9fb422b7a7e747d8195738a392b64f75b115fc1
+  md5: a5cc8b8d71435e6ccaee22b7977822f6
   depends:
   - python
   - ros-kilted-lifecycle-msgs
@@ -43181,89 +42463,86 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 44664
-  timestamp: 1769486198854
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: d43c35fc8acb69cf62d056b1ed747f9bc26116e4a83ecee7aace7e2142913de1
-  md5: af75e9c6af7883502d0cc8932cd07dcf
+  size: 44933
+  timestamp: 1775610418690
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2multicast-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 11dd81f13ebaa46422e5be6d4501f245a9c533d3efe74be282f7342edbfe8548
+  md5: 37cbf0b93703581b10f16f9c537ea165
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 25816
-  timestamp: 1769485266939
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2multicast-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: f001d3fbb862feed5461bc0b13a5b9cd75e76df2b81601a226ec71a38a7b2cba
-  md5: a0860401419fcae9b2a09c7e313b9dc6
+  size: 25552
+  timestamp: 1775551645136
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2multicast-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: c11778592d2c22ca2d52de53b430fa27dff580cdd9afca36357a6d7e5a7f56bf
+  md5: 8cb66c9321d65dda61e914c81a1fdea0
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25811
-  timestamp: 1769485361937
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 87e04c7ea721df57d6b80c985658af94910e41558ae344e92293898ad9af3b26
-  md5: 76d3d697e3ac508f993c01ee0bee492d
+  size: 25673
+  timestamp: 1775551191188
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2node-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 72938863a9b4b9f49c4fcf7815aa92e96fd7e9bf741d3380c271c3a130d93f05
+  md5: f77af7e81cc80877a576e5c1b1d4dee1
   depends:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 42635
-  timestamp: 1769485582672
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2node-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: ce8440e12b5cc45f8bcd53f92bf4736bc7f7c365d89188ee861739fdda5bd713
-  md5: a64bd21f3ecd3bac5679fc081c57331a
+  size: 42554
+  timestamp: 1775551996263
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2node-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: f6969b7e0bab4966105ebc7df9df78fe85b21591c52e6b6ffbe72db6e430e70b
+  md5: 09a52fa9f9922286b4f8d4d74ea5e14c
   depends:
   - python
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 42443
-  timestamp: 1769485618146
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: d0e3f814ebd94d57eb1c622d0c940a872f55f85fa72722df7cdcce8a87e0d7ff
-  md5: f19cff95740d12bc70379b8958c90636
+  size: 42638
+  timestamp: 1775551504947
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2param-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 580b303ab05b1d01875fbf66282f979bd278d004899613d90d23d9dc44c8a2ba
+  md5: 6b0f5f21fee721918487846740d26589
   depends:
   - python
   - ros-kilted-rcl-interfaces
@@ -43272,19 +42551,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49844
-  timestamp: 1769486226351
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2param-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: 9d34e3f4ae4d052ce663a23c2dca95c8a878433e8e9b43ba645f8e8b6d2c47d6
-  md5: f40104a59bf732f1dec663a559caa1ba
+  size: 49895
+  timestamp: 1775602755295
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2param-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: c9d461d7db1185533fc3979cb7957d34af21f6393725ca25d8bed0ee86227d43
+  md5: 089e78eac1b62b71274c39bbee231d8c
   depends:
   - python
   - ros-kilted-rcl-interfaces
@@ -43293,18 +42572,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2node
   - ros-kilted-ros2service
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 49679
-  timestamp: 1769486175439
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 464c44f61d226c92acdfcaeb6e867154fa2007730112636c740b4eba92d97e3e
-  md5: 4266879b46d711461d81c4740c204ca2
+  size: 50003
+  timestamp: 1775610400715
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2pkg-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 41cf16ccb5dd3bf0a70febaf813c825aeccd9a7499407d7c7c2eefdf65f0dbca
+  md5: 4c7d4ce967901f9fc2c98e1606e4eaa2
   depends:
   - catkin_pkg
   - empy
@@ -43313,20 +42592,19 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 59365
-  timestamp: 1769485572826
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2pkg-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: a654fe6d9ddc8f3a84cef431a5d841a35d64fdb3b5e2dc3ab5c1850bcd1fe45e
-  md5: 8c7666168feb5281bf505942fa4fb94a
+  size: 59283
+  timestamp: 1775551969597
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2pkg-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 31bae3aa90d12b9bd07afe51074ae82f9b3a6a027d572d7a87d4e794dbbf1889
+  md5: 5d9366d68038336e2d2055095899fad9
   depends:
   - catkin_pkg
   - empy
@@ -43335,18 +42613,18 @@ packages:
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 59139
-  timestamp: 1769485605498
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_15.conda
-  sha256: b477dd5ba20c8dc9af43e1a51f268fa3e95d52ea4642c833728d73e894291605
-  md5: fdad45671c9fddf9535198b6e1a002ac
+  size: 59332
+  timestamp: 1775551463026
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2plugin-5.6.2-np2py312h2ed9cc7_17.conda
+  sha256: 5fb2574f1262d74d53bd4f4f87f42e51d35d9518cfde18d78fb521a9a4b833b1
+  md5: 0a70b22b8bee4d0f11521275c92b64dc
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43354,20 +42632,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25891
-  timestamp: 1769485914960
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2plugin-5.6.2-np2py312h61f2ce4_15.conda
-  sha256: f45a0eb0762e5858be4b500c58bd2a61c8985529675d0b9043d8714ac8c4e45b
-  md5: 47a5c5f12034d18f65f4154998dc39a7
+  size: 25516
+  timestamp: 1775602428516
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2plugin-5.6.2-np2py312h61f2ce4_17.conda
+  sha256: 23046cc5432e54b54db12124f2ab2c27c3750bbe9d4607505ecb168fe8cbbdad
+  md5: 4e6a847f53a6ae751fd434abf37bead0
   depends:
   - python
   - ros-kilted-ament-index-python
@@ -43375,55 +42652,53 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 25866
-  timestamp: 1769485898430
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 939e6b5b3c840b65d6c37a70d01f350f7996bf935238b6a709489c21c3b2934a
-  md5: 34f1040f292333448d2625641b91bab8
+  size: 25645
+  timestamp: 1775602621432
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2run-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 79181d8c6a4c471ddaed6bb021195508a3bc5e0f8bc0a5360b92a6167cdad22d
+  md5: 8917fd512603bbf4d80e2808673ca281
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 25358
-  timestamp: 1769485907598
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2run-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: a7dfb59bddd1cffc195e6757922e4c50ba9167b546e2ccdc5f27bccada970303
-  md5: db4fa1904d9a28dc6ffa90e34f2568aa
+  size: 24976
+  timestamp: 1775602502571
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2run-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 0b60b3fe4ab12cbc57844bd5ffebd660c20570f25cc2adf3e3b306c2c8b6a660
+  md5: 7a8e08c5baab90eeddad255ecfeadaac
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-ros2pkg
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 25326
-  timestamp: 1769485886346
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 969d313c0f263f0652933167ae681eacdc0b01e970c5dcf1a70dafde43ef6922
-  md5: b43cef1efe0aac90ccac3483e059ed70
+  size: 25129
+  timestamp: 1775602700408
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2service-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: 6c1efe40369da04b1ef1e82e685a7fdb7c11c66cabc72765ba5b9e7410d7d036
+  md5: d6356dc1004cf5a427dadfff0d0d038d
   depends:
   - python
   - pyyaml
@@ -43432,20 +42707,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51364
-  timestamp: 1769485927953
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2service-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: f933406be8a8a8dea040cebdbdf2aa49eed9925852cb846eddb2b01aec4d57d1
-  md5: d576694453045b05a569952b2215a183
+  size: 51215
+  timestamp: 1775602461911
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2service-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 13e4f7356ce6dc8d4a95f2fdc8d91070e779a9f25ec7eac9e291c8319d7d1a4e
+  md5: f258f72d00d07ce707d0b9ad31406309
   depends:
   - python
   - pyyaml
@@ -43454,18 +42728,18 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-ros2topic
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 51189
-  timestamp: 1769485898657
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.2-np2py312h2ed9cc7_15.conda
-  sha256: 9ec2b4ab4fb70f735b618a4065c8853eea36b9c813a1b5ef63918ec8691e95b0
-  md5: dce0445c1eb12ad7354b0f10c33f430e
+  size: 51353
+  timestamp: 1775602653423
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-ros2topic-0.38.3-np2py312h2ed9cc7_17.conda
+  sha256: e44b018d4a3b42d4974970d81690ae6bdd1ce3db0a286b1f474621ec4f0f4f45
+  md5: c999706429bc4828c3e83311c936bf36
   depends:
   - numpy
   - python
@@ -43474,20 +42748,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0 OR BSD-3-Clause
-  size: 79695
-  timestamp: 1769485574837
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2topic-0.38.2-np2py312h61f2ce4_15.conda
-  sha256: fed661ad144f098f46d926180efc5f838b1fdcff16f38f49a8745e834c3edd7f
-  md5: 0022ade8266c76ca359b9e9b7224adbf
+  size: 79674
+  timestamp: 1775551985552
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-ros2topic-0.38.3-np2py312h61f2ce4_17.conda
+  sha256: 4b245c7e783a24c0341cda22ecb3cca42053e285183a5c1eb56e310a8207d15b
+  md5: 758d389e3da31eecb1943ff46e156fee
   depends:
   - numpy
   - python
@@ -43496,18 +42769,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 79484
-  timestamp: 1769485609551
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 710e4357fcf1de50b91e81afacb2f5020fa939c4af9fc2f09a633cb1c00ac8c6
-  md5: b76c79ce74cf70c90224b3901efd5323
+  size: 79697
+  timestamp: 1775551489002
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: b173ac3446d881e3f2fdeb5171587a9b940174a8f6abf3602262fe1a034fddeb
+  md5: 69e160d8ea2d0e125f0f1ffd90bce663
   depends:
   - python
   - ros-kilted-ros-workspace
@@ -43519,19 +42792,19 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-rosbag2-storage-default-plugins
   - ros-kilted-rosbag2-transport
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 34186
-  timestamp: 1769492574998
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: b0e363a6dc44718811c5966189620cdda069a280a56427d30a233ae5abbde898
-  md5: 88017bcb52188f2a13ddbb08d4998caf
+  size: 34460
+  timestamp: 1775606721366
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 0edb5455579d19674d98e9813d0551b903129b86dd607bf871bacde7d8f5a990
+  md5: e77efb1c81aa3e01c42e73dc3975f784
   depends:
   - python
   - ros-kilted-ros-workspace
@@ -43543,19 +42816,18 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-rosbag2-storage-default-plugins
   - ros-kilted-rosbag2-transport
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 34114
-  timestamp: 1769489383656
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: d2cc21bb8aa9cdad13fb0450fccea0ce03f85f71450f8fcc74e3dff96f26017c
-  md5: 32932e8d48fd29eac807c49adce463fc
+  size: 34575
+  timestamp: 1775613699328
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: bab290c8f08487d8a26602f0293be55c76553738909d7862608e3b1ca34a0bd9
+  md5: d4aa57cb27996b7d02150734a53998b8
   depends:
   - python
   - ros-kilted-rcpputils
@@ -43563,20 +42835,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-cpp
   - ros-kilted-rosbag2-storage
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 203740
-  timestamp: 1769487327332
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 7e5534328b07a7da22f7a141dc1bbd5561913310cc29bee3baf7ea0b711bc554
-  md5: eba514afa500326f5ca7ab22d4f88703
+  size: 204042
+  timestamp: 1775604040495
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 8bcde791f0498f1a73f7fa2805de3da6e9a11222d3b9633762541db52dd00417
+  md5: 7715c1177bd1b70f7b43d8bad688842b
   depends:
   - python
   - ros-kilted-rcpputils
@@ -43584,18 +42855,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-cpp
   - ros-kilted-rosbag2-storage
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 198660
-  timestamp: 1769487076864
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: e3a2de0da11055cd01ca66742989679567567379c49fa424f0eb1bfa99ea9cec
-  md5: d436ea404ffa030e7c28234e501c9bb8
+  size: 199157
+  timestamp: 1775611431602
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 2a2a8f0913f48269959d81855af51b1f649e5cd53b70c3a4a6280589853a36f0
+  md5: 2fe85e883508c8093d9646d903c34c2b
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43603,20 +42874,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-compression
   - ros-kilted-zstd-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 69513
-  timestamp: 1769487688774
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: cd7faae51656d138a7e7968644cf7bdb4c21a0386c365af16b14e31e2a5ea821
-  md5: a495cff6974af9a78f0e534e1a61aea3
+  size: 69777
+  timestamp: 1775604374808
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-compression-zstd-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 05854a247752eb672bd12f27c605e08cd905cd2cc0380ef63bf012d8889ef862
+  md5: 10edba005009b193c4e2252a3f273e49
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43624,18 +42894,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-compression
   - ros-kilted-zstd-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 69188
-  timestamp: 1769487378411
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 597315613c8abc133ec23b8db6bda7e611e4a1e51564144f1bc99ec8d5a921ed
-  md5: e5d47847dade2657c6fcbcf194e7117d
+  size: 69612
+  timestamp: 1775611674692
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 7a413fd9663f93b86f77a7d42b868143c183d227beae9b1af4ab2943315de308
+  md5: 802a7206e50f3d210d9791c08c1b95d7
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -43651,20 +42921,19 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 355564
-  timestamp: 1769486527937
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 9fad21f7cea36a5b1ef41968ffab099b5d649484babd230aa1900bd3eec6e3b9
-  md5: 45304505a589924a6d74f344952434f4
+  size: 355849
+  timestamp: 1775603175842
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-cpp-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: aac0200b0a9d221e27e09445e949e591b69667866bfa0ecd95d563576913641e
+  md5: bd8d2871d0cc271abb47c677167efb44
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -43680,53 +42949,53 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-cpp
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 342850
-  timestamp: 1769486437546
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 58a5dde84fdafa6dbcaf0051110e7bdd3fdd31e675dc8b2d36d9b7008c1d2542
-  md5: cd22a774f3ad7c91c1af714ba92740b5
+  size: 343375
+  timestamp: 1775610749479
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: e40b25bec2f5f5e09412d8692664999b9dd131a8b7745a4162ab22cd07f10131
+  md5: 76f1dfb9dab26a728de2796567b8b9ee
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
+  - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 459627
-  timestamp: 1769483196429
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: f9bd6e4ae5507facbfc0f4b4de7f62c06becd742e6bb09e7fc47280b62f148a0
-  md5: 6be35ff8ceb38bba58b6f74be071292f
+  size: 466063
+  timestamp: 1775549418008
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-interfaces-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 767c3f3406bf3636067016265637f8ce2e8cb0a75ec546881f216c1dda38c44f
+  md5: d14fd4812052836fc9a7c9e4cbed39ef
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 458767
-  timestamp: 1769483482638
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 8f963d03f6cf67ebb192330f14bbc5489f485979bf2f1b0e56499d8e5df0b966
-  md5: dc2cc965348ea01cca8d0ca1dedf1f16
+  size: 465525
+  timestamp: 1775549427059
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-py-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: ba346da18276e98b3e4ee575db19881244b38ac62f89ca01f986334a0f25df80
+  md5: d5c27e2bad3897b48dacb721b46ed65e
   depends:
   - python
   - ros-kilted-pybind11-vendor
@@ -43737,20 +43006,19 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-rosbag2-transport
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 798968
-  timestamp: 1769491196170
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-py-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 4427674056587e5fae80047b0160d8cb5d2afd54480af769cfbfe186295e93c2
-  md5: 0990e4f1c19f4e36ee634398f21fe28c
+  size: 820312
+  timestamp: 1775605033345
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-py-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 54b15e9dcde6dde74db0ea82ea4ceeab8e8db78094128f78d6c5aed438b60c58
+  md5: e4b2970266778fca9589371a6558dfa8
   depends:
   - python
   - ros-kilted-pybind11-vendor
@@ -43761,18 +43029,18 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-rosbag2-transport
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 741265
-  timestamp: 1769488174226
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 6703aaec49337aa51bae52d3e98b0b67c8b3a22d79363831d22d8090dbf2ea1c
-  md5: 75130975716dab5451d53cbd8f328734
+  size: 759496
+  timestamp: 1775612329117
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 02bf69c93b3f48aa97c1010f623a6c3b520c9704971711c73b9d1427ff11aa06
+  md5: cd63779fe9c854ba4b4603177a8c58ea
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43781,20 +43049,19 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 277061
-  timestamp: 1769485626155
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 6d9147ec8c788d6725dd31f31840e6a46d0fe924723e9c1cc059482d97158818
-  md5: 79d20f35422ba1d84b33c6322e989d95
+  size: 277358
+  timestamp: 1775552015673
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 16fe647991956c107946f6c533f033fe1480ba7e9f88f0e4feb7c7fb641c0810
+  md5: 3a7ca1b3cb0bb4f86df8c6aa9e6ab817
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43803,53 +43070,53 @@ packages:
   - ros-kilted-rmw
   - ros-kilted-ros-workspace
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 277182
-  timestamp: 1769485663412
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 9305e8fe7d25d61f89b731b69a37f8c9e31d8c0385678fa9c5c55f5f5166ddca
-  md5: a4b2f5374f387b51038db28d265c603b
+  size: 277643
+  timestamp: 1775551520210
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 273004afde9a78777b9ed61a9a55f5f07173ff656196c976ad2089c9930e5d43
+  md5: 3c4824db799f179b26d97c12fa862195
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-storage-mcap
   - ros-kilted-rosbag2-storage-sqlite3
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 22408
-  timestamp: 1769486233995
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 4bd3fb9a663b94c11cce2fda5f5d15a2b8cba6458c7b2d34427f921b52763c97
-  md5: 0441d5bc795ba4499f87c7059ef78bae
+  size: 22375
+  timestamp: 1775602702290
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-default-plugins-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 783bb4357384f5242ed7e9f9a2f4c812d208a38dc20f21369a44debbcc3dfe29
+  md5: d4f10fff71aa8e30b6eb2ca604ad3e69
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-storage-mcap
   - ros-kilted-rosbag2-storage-sqlite3
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 22411
-  timestamp: 1769486184545
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: fd7aba5203ff0bcc83dd4c5d947c50db0bef3ffa61c65dde04f55b8fef4db0f2
-  md5: 8768b8332b21fd9a56138a69cedab965
+  size: 22519
+  timestamp: 1775610342530
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 564d951152fc0a76082cc572f793f463f10e3abaeeaf300c97908aef63ea9549
+  md5: cd66c807ee36c7d0592f6dfcde4b559d
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -43859,19 +43126,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-storage
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 197823
-  timestamp: 1769485981076
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 907382b66334f53c551e743eb6d3dacabe0d13089c4ac2e5529bc113cf70035d
-  md5: 6c59c10c9ea95fcd613ff7c420e44d5b
+  size: 198092
+  timestamp: 1775602428369
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-mcap-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: cf10cdee56fe860c62fcb51cdbe02850a6be4bbe478bbfffa805b46378ebc20a
+  md5: d2a5ad55f4ef17491f91cc84f3b9a85f
   depends:
   - python
   - ros-kilted-ament-index-cpp
@@ -43881,19 +43148,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosbag2-storage
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 200123
-  timestamp: 1769485956695
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 3b05411546bf93b0ed00f38568684e42f121c8e92d7f69e0f1982ae9da837234
-  md5: 62fc935058443f86f7ce95cba37f805a
+  size: 200529
+  timestamp: 1775602625808
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 9c414d91b0572e9297e64605aa720b821ba1a66ebb783a198bee712675e0eaef
+  md5: a597c098e02d55bbe46e91552440680f
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43903,20 +43169,19 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-sqlite3-vendor
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 244362
-  timestamp: 1769485962501
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 3801e5ee8187bcda5748de7f02dc556905309f5214260adbbeb0e1eb4e524ebb
-  md5: 7d4743c7add0eed4cc708442ae7fd4ec
+  size: 244590
+  timestamp: 1775602464882
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-storage-sqlite3-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 15483224426b0d178e8b0aabcc97ddcaef81114d4cc2a99c5ea23eacaedd4000
+  md5: 1c1a866ca32f5a26132116b7b9793186
   depends:
   - python
   - ros-kilted-pluginlib
@@ -43926,18 +43191,18 @@ packages:
   - ros-kilted-rosbag2-storage
   - ros-kilted-sqlite3-vendor
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 243957
-  timestamp: 1769485938158
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: fbfed64e55dee0d7ba5f0adc6982587feb1113e3acc61a24febf53fe833f0b1f
-  md5: 43e5be958f6576ea93b7f60e6a761cb3
+  size: 244420
+  timestamp: 1775602663163
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosbag2-transport-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 3f81df62d2e03bd76000bdd4d75a0d60633b2d15082c006a2a60a19e6d5794aa
+  md5: dc737f3e58d71c2c762c4c5df0088ef7
   depends:
   - python
   - ros-kilted-keyboard-handler
@@ -43953,20 +43218,19 @@ packages:
   - ros-kilted-rosbag2-interfaces
   - ros-kilted-rosbag2-storage
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 559105
-  timestamp: 1769488182041
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-transport-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 2505d3d02f173c6f4aec73f36b4220cc8136616afd082af00b48e888c8e96b55
-  md5: fc8413966f7705681cf947afd616b96f
+  size: 559220
+  timestamp: 1775604776514
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosbag2-transport-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 9cc22fc268be01e1bfd1c113ba58d1c921f21193593859302e1bb1db09f862d6
+  md5: da1e501e901707ca32e25ec03a409a56
   depends:
   - python
   - ros-kilted-keyboard-handler
@@ -43982,166 +43246,160 @@ packages:
   - ros-kilted-rosbag2-interfaces
   - ros-kilted-rosbag2-storage
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 546037
-  timestamp: 1769487814556
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: c5f933be110810b1d01142178b51518f174900b6d65280f2388f57d0aa790232
-  md5: 5cf7dd341916a47df0d161209efa5822
+  size: 546413
+  timestamp: 1775612060087
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: f0af66807d0730331561b9ba7c419f7d99c51396782d688f846a799945dd5097
+  md5: d19b7401588ce789c5d80dce598646a7
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 70760
-  timestamp: 1769483152399
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosgraph-msgs-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: 8505c4bf26caba2e91dadff0d2b6ffbd1a1e77da795c9fe0c9dbffbb83989767
-  md5: 93d5dd9e86e96543cf4208290767a25a
+  size: 72126
+  timestamp: 1775549353749
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosgraph-msgs-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 8c7c9b1d1eec618441c0979e9c05b6c14c85831d938cd3518dd44d8b3a9755fb
+  md5: 01363d763ae533f7823cd1c6de08e37b
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 73559
-  timestamp: 1769483442281
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: dc8d3b310ac0234484d25402236b65c266cd29b002e84d262dc4527df736589a
-  md5: ac468ffb8a3f1085fb43f14e7a6b8fc8
+  size: 75631
+  timestamp: 1775549369724
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-adapter-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: afa24d8dfa0e07970836392106741b353d07e1bf622473e84ba82bbce73e2289
+  md5: 954f036f738e4572c15fc1ef4ecdb3ef
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 67986
-  timestamp: 1769481881616
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-adapter-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: b3e54091e3577d7a2299e8c6c13cd9f43202abeff54c0c289ce45c5dceb965df
-  md5: 46102d8884df5cbb614e52363d22d7bf
+  size: 68058
+  timestamp: 1775548162761
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-adapter-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 62a8d57ec1646fe9b744444ed81ba7204e6e78249e1c7e2cf04a700549425aef
+  md5: 05ca9402b213e4ba3ac185f500074344
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake-core
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 67904
-  timestamp: 1769482198050
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 221734b04e8d9676d3c4391b22eef4c6b049367579df1af5e5cf0d94e110dbde
-  md5: d0bc37dcba0a8178a99c7b80234646c8
+  size: 68122
+  timestamp: 1775548240709
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cli-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: a75b74550cf32b76bea63a93887597b31eb71429c1a178ee63db2f5456ed78c8
+  md5: e8dc5116bb1a57913279a115098105c5
   depends:
   - argcomplete
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46623
-  timestamp: 1769481352265
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cli-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: b07f5a3802a0b302fda737b495bea6df8b8af701fa1a01421e5d77b2eca10186
-  md5: 912d98945d3597421dbfbd2dee12b209
+  size: 46323
+  timestamp: 1775547612547
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cli-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 8ca5543ed4ba2364fd550f2aa3445c68ade3ea4bc330401cfd5f1fdfb7b0cc76
+  md5: ce7a0ffb26a3747fd72b6af0f046efb6
   depends:
   - argcomplete
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46552
-  timestamp: 1769481674374
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 9106e7059f114c956f2d9fccc5cfde64d70ac812eab4ccafd7263319bc86e883
-  md5: 4c880fd84d6e7f450049e4a632733f59
+  size: 46407
+  timestamp: 1775547802325
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-cmake-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 2db7fa58d4e05fbaa1c2993615f3a35839fe991254ff840bdc9d9c6f8b71b681
+  md5: 290c6d215ae864b4dc91dc31e73684fa
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-pycommon
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 36308
-  timestamp: 1769482423899
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cmake-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 1b24716038374ca0e278fbfbf9fe62c1260f6d8b3040a2862217715a62ee6e1c
-  md5: ea8c29143d214e1707363e39634feb98
+  size: 36353
+  timestamp: 1775548703786
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-cmake-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 8e7b8a8d6832e24ab0bdb1416261915d70184c4c41490bde6b4f7bec24d8e12d
+  md5: 6643f1fbc01679c0a7a7a1305fbddddf
   depends:
   - empy
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-pycommon
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 36229
-  timestamp: 1769482653989
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: b9114145ae0ca04c4925ecb6790a5f61b6cda224957cd2edf2f78d91a006276d
-  md5: ed4a6fb067a7a8cbba259a0c2bf87a43
+  size: 36381
+  timestamp: 1775548683385
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h2ed9cc7_17.conda
+  sha256: 07fb9a95381b966ef435e7dde79cf7df789f7f21cf3c1effb831e91749b81e4a
+  md5: 42b12fd154aadf7e5fd9bcf4031f8592
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44150,6 +43408,7 @@ packages:
   - ros-kilted-rosidl-generator-c
   - ros-kilted-rosidl-generator-cpp
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-generator-type-description
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-cpp
@@ -44157,20 +43416,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 30831
-  timestamp: 1769482955528
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-generators-0.3.1-np2py312h61f2ce4_15.conda
-  sha256: dcafea7d2a4144c276e1f13ef45c4e225cca81866513c1a5a936f5b74de13094
-  md5: 957c89c46e3b931422e6ef408859bf8a
+  size: 31000
+  timestamp: 1775549160407
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-generators-0.3.2-np2py312h61f2ce4_17.conda
+  sha256: 9d373e89c43f7d3a7aa76efeb76e41d8f992a99141548a1242913115e3e7cba8
+  md5: 03f70c8a87867e5c1fbe64622d110d6a
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44179,6 +43437,7 @@ packages:
   - ros-kilted-rosidl-generator-c
   - ros-kilted-rosidl-generator-cpp
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-generator-type-description
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-cpp
@@ -44186,23 +43445,23 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30743
-  timestamp: 1769483231681
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: de43e8fcc1ef452938b354575c75477af87201eec68e2c664a6588e4bae45455
-  md5: 4489eef04cbcbdf18b44abb974fad63f
+  size: 31133
+  timestamp: 1775549159179
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h2ed9cc7_17.conda
+  sha256: 1e010f618fb959e825a612f5943852acb87e4b5d6bd5549637a9e4a5d6076ddc
+  md5: 2be81c9da2284ebf645a36ed66ae6fb1
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-c
@@ -44211,24 +43470,24 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 29832
-  timestamp: 1769482941167
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-runtime-0.3.1-np2py312h61f2ce4_15.conda
-  sha256: 2302893fb96cd48f38783a40f859ac782c17935d1be98fbf27c7778c1bfe99e3
-  md5: df8647bef272115a2b4ffa6aee5b1cc6
+  size: 30037
+  timestamp: 1775549143380
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-core-runtime-0.3.2-np2py312h61f2ce4_17.conda
+  sha256: 5197f62f0f848bb473e9d90d9066c0972cfadf57f62be86a391720aec0119ba1
+  md5: 0988c3db11d5d8621a23f6d9ba110d2f
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-generator-py
+  - ros-kilted-rosidl-generator-rs
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-c
@@ -44237,19 +43496,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-introspection-c
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 29786
-  timestamp: 1769483216241
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 1f682f3ef0e77ed8b3c42b006e5d8323238888e5a4ea71b900f7531fcf437613
-  md5: 1db32e38b3f14ff4c941151ce80428ae
+  size: 30102
+  timestamp: 1775549145969
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h2ed9cc7_17.conda
+  sha256: c7c950774a9b93b2362145676f939a2d479f8d6dd26a49a55957183ac4cf3fdc
+  md5: 271a94345f31731de1b29c64e4af736e
   depends:
   - python
   - ros-kilted-action-msgs
@@ -44257,19 +43515,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-generators
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 30970
-  timestamp: 1769483094357
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-generators-1.7.1-np2py312h61f2ce4_15.conda
-  sha256: a161c790e6b447df3a37e69a83fc39412f9927e61baf8b76e060324805ed21e2
-  md5: a3ada14b44294ef9a8a0a2af36a39b8d
+  size: 31187
+  timestamp: 1775549306536
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-generators-1.7.2-np2py312h61f2ce4_17.conda
+  sha256: 3f9b51d675318c8cb8a66789244d1ebd126bf712a643ba0a3df436f6699d00fc
+  md5: cf1eb516e4fff667a82c6f1ec6fc3157
   depends:
   - python
   - ros-kilted-action-msgs
@@ -44277,91 +43535,90 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-generators
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 30896
-  timestamp: 1769483386112
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h2ed9cc7_15.conda
-  sha256: 0fa246ff3721ce8aff2d4a08cfda89019dd24d3cd5c8e16e846004d412b0641a
-  md5: 628dc9bd7669b3f033f0a0767f759ccb
+  size: 31247
+  timestamp: 1775549316234
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h2ed9cc7_17.conda
+  sha256: 4b518e323e254550d38a6aa604742db25b083c5da5c6c37aa7d45c2193976d38
+  md5: 2195ee91e70e85a3f2e153484c11836f
   depends:
   - python
   - ros-kilted-action-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 30444
-  timestamp: 1769483080744
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-runtime-1.7.1-np2py312h61f2ce4_15.conda
-  sha256: b50ce02a736ee598ddf02499fd39e304689727abf87fb5037dd5f4d2a3cb2171
-  md5: 4bfd2dec15a62c854531942ac3aaf5c2
+  size: 30596
+  timestamp: 1775549294628
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-default-runtime-1.7.2-np2py312h61f2ce4_17.conda
+  sha256: abaee3bf0dfb5e3b883fecccd46da8703750c62708c8ab9e6cdfa2d1a43062b1
+  md5: f770ab09b9d552594fd41a5a14e8a89e
   depends:
   - python
   - ros-kilted-action-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 30326
-  timestamp: 1769483371073
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_15.conda
-  sha256: 97882153533d1b30bd831fcec3d645369e5fa02a4e73090f42948dacbd28e78f
-  md5: 0416db063f3c4e1ae812a19e4b2a6db4
+  size: 30645
+  timestamp: 1775549304379
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 4906df07d3114bae86c4bf26e33edc664cb8b51fdb5d57d31e2c48cbb2b06bdc
+  md5: 47c6032fc6973ff645c66ba07b13a123
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 60888
-  timestamp: 1769482443045
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h61f2ce4_15.conda
-  sha256: 831c3fc789319df43802ceb56da774bd1c8beba249ce0c382dd2cc37b8faf24d
-  md5: d5a505a50cd6edb73d9607ab5b7e7b20
+  size: 60857
+  timestamp: 1775548724987
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-0.3.1-np2py312h61f2ce4_17.conda
+  sha256: 9739e5ca5393bd899152112cd0fe93bcf16e83ced87de5160785b66e24280b8d
+  md5: d7f90da6eacebc9f7cd1153d9a8f3a70
   depends:
   - python
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 58798
-  timestamp: 1769482674197
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_15.conda
-  sha256: 1a0b327c2e27741ff020f1674a81f61753e64389e56dc9cb3b8e92a2ddc45e01
-  md5: 7cd31823c6ab1f3ddaf19c80f492b506
+  size: 58928
+  timestamp: 1775548703920
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h2ed9cc7_17.conda
+  sha256: 9fbbbfb5dca949c61f7ebdbab3ee9c11f141b1c83bcf1cc8350f88367960ae5a
+  md5: 3a0f7f051811a80734813a4145c6db8d
   depends:
   - python
   - ros-kilted-fastcdr
@@ -44370,19 +43627,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 82893
-  timestamp: 1769482516443
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h61f2ce4_15.conda
-  sha256: cb0a6493b95de42d6c97557c9905cbb5159b7b7a55c12e87c9ef490c56aaf68c
-  md5: c8f369f2442515bb9ecf9e08c1adb441
+  size: 82842
+  timestamp: 1775548797862
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-dynamic-typesupport-fastrtps-0.4.2-np2py312h61f2ce4_17.conda
+  sha256: e7ff49a81f8a476091dc410c8eb17e717dc55cb61dc1f321549c482cbf8a0a28
+  md5: 2141993e2a10e923ae58c10d269058a3
   depends:
   - python
   - ros-kilted-fastcdr
@@ -44391,18 +43648,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-dynamic-typesupport
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 77965
-  timestamp: 1769482759383
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 576e9638664b90b903ce2baa8434ad0042811b256877f9f2e7b99fffea1250a7
-  md5: d746b4b081a43de064518fd0001bb4ac
+  size: 78096
+  timestamp: 1775548774868
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 115e8c14df561db8378822746e2b0322830b8bbffe645b2124cbe4017ae23664
+  md5: a91a7a7411d06bab060699791f11617c
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44415,19 +43672,19 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 51989
-  timestamp: 1769482496349
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 4e1359d0e29b60d77ef3a694d9cd32d68b20306211391fe342d97d30809c359f
-  md5: 6ff04dd740fdeb90170d2acf52c95431
+  size: 52092
+  timestamp: 1775548776012
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-c-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: a7c155b366ea0003049a66f086e5374f4eaf6bd6945c45c3f583146ec9de210e
+  md5: 4eddfccef30d5adce1e26b27a5f84d45
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44440,19 +43697,18 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 51976
-  timestamp: 1769482737183
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: f9dc88dc1c0a2efeb640ded038320f879da2289253092bae47c8422c2a2314b1
-  md5: c2c2ff8062f7c730958b3b5f855424a5
+  size: 52146
+  timestamp: 1775548749491
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: e00fe1214d5e6525e734b0e66281fd907142780b5cb8d66a4bdd6e2a14c4e28d
+  md5: 3df7e60cd553d97e0824e98d53e3acde
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44465,20 +43721,19 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 50192
-  timestamp: 1769482607759
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 781628b2a42ed10f38ca742feeaec2ec4986afcc89a146efedbc5b52d8ae3745
-  md5: 652debce82fb81b6b41107960b1ee3dd
+  size: 50379
+  timestamp: 1775548863529
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-cpp-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 353d0190854ff8661f72937080419b1a55027a98edc0d0c404d2a165517cef80
+  md5: 4e7377858d49e099f9786eac7aeb160a
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44491,19 +43746,18 @@ packages:
   - ros-kilted-rosidl-parser
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 50215
-  timestamp: 1769482880792
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_15.conda
-  sha256: 7452bfa643e605accc386ebcaaac9d7fcec1bdf4cb15524860696004627f043d
-  md5: dbed13626bffb18928ce49738eec6458
+  size: 50402
+  timestamp: 1775548841253
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h2ed9cc7_17.conda
+  sha256: f63a6886e563102ec4dbd8fd2c6a1660434f4ff119ed6c5e836f6473c9f71f4b
+  md5: a7ee198e55aab0d19a3f644b3c2fb0a6
   depends:
   - numpy
   - python
@@ -44524,19 +43778,19 @@ packages:
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 59687
-  timestamp: 1769482913157
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h61f2ce4_15.conda
-  sha256: cc2e3ee62c24ea45f51180b7f7fa85d9da7b50873867f08bb38255b9422755d0
-  md5: d0569e389638ba31c43e551c18209806
+  size: 59865
+  timestamp: 1775549115024
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-py-0.24.2-np2py312h61f2ce4_17.conda
+  sha256: 6afbafd0eacdfd615bd7de503df2ec6f15416f33bd94c10b07360eea9d193f6a
+  md5: a5eef9f59bac165efb26f6899cbc20c8
   depends:
   - numpy
   - python
@@ -44557,19 +43811,63 @@ packages:
   - ros-kilted-rosidl-typesupport-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rpyutils
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 59623
-  timestamp: 1769483183621
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 766411c88737a7051a6b61d9b7637b0918ca683fe66942050b2a59150b58d328
-  md5: 0b79b46a6562a7f642aaae70000bc26a
+  size: 59912
+  timestamp: 1775549120360
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h2ed9cc7_17.conda
+  sha256: e7e8d714a79910176f7cdfcc28b48f4c3869aca380dea4e5c76297a139e03f4b
+  md5: 3926d41972bf349610e0eeef57a94e32
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 48181
+  timestamp: 1775549107872
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-rs-0.4.11-np2py312h61f2ce4_17.conda
+  sha256: 7d54ad750e812229d284268a4ccb5badb82d59a304d2379891d3b42bc938db65
+  md5: c66f08e0e5bd7b71687cb809b6309174
+  depends:
+  - python
+  - ros-kilted-ament-cmake
+  - ros-kilted-ros-environment
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-generator-c
+  - ros-kilted-rosidl-parser
+  - ros-kilted-rosidl-pycommon
+  - ros-kilted-rosidl-typesupport-c
+  - ros-kilted-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 48246
+  timestamp: 1775549112446
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: b55d73a44e05bc236f1318e6293310e54a1533be29fc08f0b096f6ef0475d486
+  md5: 0f1ca425d929ddcabed574353056843a
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44577,20 +43875,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 47033
-  timestamp: 1769482390164
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 47eef321e029bd650a5cf14db3c4019e5b1172037e3769b17e30d8a06c7621c9
-  md5: e935f1a1297634f9eb967079fd3be03d
+  size: 47000
+  timestamp: 1775548668462
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-generator-type-description-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: c5994a9dbe39459aba69ea8f71db4df84b52e50a97c4fc7291253d4f9b206ca0
+  md5: 496d55b823769779c986062872622916
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44598,203 +43895,195 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-cli
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 46863
-  timestamp: 1769482619182
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: c8b04339c7996b046507dbb059c1f246645ebdcc1e53fd414a2306d2de3f536c
-  md5: 250a81cbda88b524963f66c7322a9fcf
+  size: 47085
+  timestamp: 1775548641543
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-parser-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: bf910c6f7efff7b3c6a395241e5929fb14af35c4f641c5ee74c11a33c668321b
+  md5: 51e30b7f4ec7565d89353a3b3d97d557
   depends:
   - lark-parser
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-adapter
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 66098
-  timestamp: 1769482281599
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-parser-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: b3e834689493db80f665826948fbad0033ac4e4adf2d1bd42fc952983d182e82
-  md5: 938804f66ce90c4089cabcaef5c4f0b8
+  size: 66198
+  timestamp: 1775548572622
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-parser-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: b9960b7b0bd08bf0fe360b6e792fc9d740d1445e10a01d26df1204a78deba0a4
+  md5: e2f75837795ad18344543199ddddb76d
   depends:
   - lark-parser
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-adapter
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 66023
-  timestamp: 1769482510957
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 32b52b99ccb90c9c360ecf8360b7cd761786c7db488f7c029866446ac8eff3a1
-  md5: d3e370625987b7251b26cf1eead8c500
+  size: 66247
+  timestamp: 1775548540608
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 324b3cce6233c6265b8de0530723c8b4953f4d0e13f731958f1a27c352283b78
+  md5: 3e7348d8e981f3942dfbac76fe1143c2
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27110
-  timestamp: 1769482371986
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 539f0b61cfc7ad46fde4190cdfb31f604c2f58958a678643b7ffc94aa1ab99f9
-  md5: c2aa6a9f3a610ad879dfd1dd1ad56fd4
+  size: 26841
+  timestamp: 1775548648164
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-pycommon-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 76dc62081846c482323d1bc71c60c6fe1e931df52afcdc8426a771720e8df6a3
+  md5: 71e33632882074ea68787bc73bcdf653
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 27098
-  timestamp: 1769482600231
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 62971d039a7181c97bc3f6542d04f6dd77c1d3068c55fa57ba81e88633f13663
-  md5: cf6f96fdf32816b18b5517d9e81bd2fb
+  size: 26988
+  timestamp: 1775548619910
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 9895249f8bca1408fc40c1c2e8361b98f0ea50cd9d5bc419efe990cb850ff7d7
+  md5: df39d5771d57bed0dc7512dd020ead21
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 82676
-  timestamp: 1769482384701
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: dc91581c1d591cfcd1abff205582a444985804b1a3a062085140127b04590692
-  md5: e7e9fb0b747f82c4dbfca098988b09d6
+  size: 82792
+  timestamp: 1775548659989
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-c-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 9fccf276ad96fc095815cfcf73e251cf989c3691a2a99cc7f6919930aa266e38
+  md5: 1bbcfc3ebb12876a4df8a68f58f16c0e
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 86949
-  timestamp: 1769482614363
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 7facdef1c23941e809c1d77c46d108d71aab4a49ca582023674f754b1b892f7f
-  md5: 018a57582f5e73d052ffcae7925a9969
+  size: 87124
+  timestamp: 1775548632001
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 1e212a8663d153099ae8b42ef2bd86cbce5e42b166dcedf56438370717408aa5
+  md5: 925258be4a6502e45b177bf7a53e2ea2
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 41058
-  timestamp: 1769482438892
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 5ff3a98a9e4e9c592a17d6834bec45c17d490e9f287c95b602ae3796b5105f1a
-  md5: cf4effe0fbfd6babaf28bbc683f138bc
+  size: 41144
+  timestamp: 1775548717841
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-cpp-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: df7db1091c06a963912924cb0274fc6eccfd2f1722399ae88b37edd002374847
+  md5: 25e43e914a4d07ce7dad09d9bea84f25
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 40979
-  timestamp: 1769482668713
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_15.conda
-  sha256: 75d7ab0bf3fcb57830c79ba6f3dd3955046f623185030ec61b074a2e94adfa03
-  md5: 0e96c9b6ac2c491c3594d47965770190
+  size: 41223
+  timestamp: 1775548697389
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h2ed9cc7_17.conda
+  sha256: de70dfa132c4b75aab5af5383593d5342d60edce8de182d7e58a633efab5197f
+  md5: c110346daab2f2803d28adc964742268
   depends:
   - numpy
   - python
   - pyyaml
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 46767
-  timestamp: 1769483337887
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h61f2ce4_15.conda
-  sha256: 9e9c3ff9d2210ae549cebf1926272de189535249e2dafa63d3ee75c1c97447cd
-  md5: c3c2104eeaad03e7656084d5ea58cac3
+  size: 46744
+  timestamp: 1775549509587
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-runtime-py-0.14.1-np2py312h61f2ce4_17.conda
+  sha256: 9f3a412f272f26fbefeabfd8b142422012bdd2040e74c69c805a0a07689b9291
+  md5: 04a57c0c17b80bb837d2a80184e0a943
   depends:
   - numpy
   - python
   - pyyaml
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-parser
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 46633
-  timestamp: 1769483619292
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 4978b52e5dd277c80697b93c0ea5aefb843a96a7dd0a5255a0448d3ac6094eb4
-  md5: e5f7438e5838d1dc9b78208adb0950d0
+  size: 46813
+  timestamp: 1775549524645
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h2ed9cc7_17.conda
+  sha256: 746dec7dddaebe79eb1dca4250fcf0dd0942811d606310f28f6d0ea750bd311a
+  md5: 667a53c6d49455b75fcb31fd8f33563d
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44809,20 +44098,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 50776
-  timestamp: 1769482852546
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h61f2ce4_15.conda
-  sha256: b1503d3c87dead7f5d4d6912d21f2c836a79998c9fb6a0a7bfe89ca5f45fb3ac
-  md5: 92a8cb0d5c8577b3ee019f0b4b979b26
+  size: 50797
+  timestamp: 1775549027907
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-c-3.3.3-np2py312h61f2ce4_17.conda
+  sha256: b51a9ecadf30cd7fd4926481b9379144d2dcf37a4e10146467ec11e2f35feab8
+  md5: 0760ed170735437da04042a9b641d1e9
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44837,18 +44125,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-c
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 50753
-  timestamp: 1769483130112
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_15.conda
-  sha256: 43340b30c9ae136342ba941b2df8dcf9a9cb79a6f1de7efa04295544421709ea
-  md5: b60ed66dae675cc741a87fae3ac31dac
+  size: 50932
+  timestamp: 1775549025498
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h2ed9cc7_17.conda
+  sha256: f41bd9ba46669dfd98bf13caccbb944d009f854007b08ce09863f8938dd31905
+  md5: 81236956925f5028d838f80f5b33cb61
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44866,20 +44154,19 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 49871
-  timestamp: 1769482907754
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h61f2ce4_15.conda
-  sha256: d636f6137d88fa1d0aed8cf5a8e42d29ff088cda7f00768adfef3c810eb07783
-  md5: be2ff2f79201c63ab3c0f8aa63806450
+  size: 49934
+  timestamp: 1775549093601
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-cpp-3.3.3-np2py312h61f2ce4_17.conda
+  sha256: 58f59f36509e00a00bc5e679dd6e71cd81ff6186bce86462628195a211f55991
+  md5: 8e7e5cf39dd067bd8c489731fe21f0da
   depends:
   - python
   - ros-kilted-ament-cmake-core
@@ -44897,19 +44184,18 @@ packages:
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 49947
-  timestamp: 1769483177361
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_15.conda
-  sha256: 6bfffbb1b9ccf318bb6b140393371ed11f42b708e2694291c2872e8e2c90f0ac
-  md5: 7b7fa115106e75675e30b6b127c3c190
+  size: 50128
+  timestamp: 1775549094832
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 57fe83272bfa784aa6dac676af296ef4b2ce7508e185908c909f16f0b43f2397
+  md5: 52d1acb9c41365ae860755583f11bc7b
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -44924,20 +44210,19 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 51489
-  timestamp: 1769482816210
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h61f2ce4_15.conda
-  sha256: e09d8103545469219cf41ddd904e534cf8c33e993896e09d8edf3e7a2504aa90
-  md5: 53b807ed68dee3a89f7a1dd8e7ad9066
+  size: 51519
+  timestamp: 1775549000182
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-c-3.8.2-np2py312h61f2ce4_17.conda
+  sha256: 17452da1b83fad365a7afeee83ff1ac141e7f5454941ff367c5b25578d965efd
+  md5: c3c36ad1c47ebc6a0806b2b2e6ecbb16
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -44952,19 +44237,18 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-fastrtps-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 51766
-  timestamp: 1769483092287
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_15.conda
-  sha256: d45a2ca6c6cd2d9f02148ba480db02f69830fc96b3299dd1beb75187d0ea4815
-  md5: 1a2843a4d4325daa7a5fe3d5f83a71c6
+  size: 51880
+  timestamp: 1775548996080
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h2ed9cc7_17.conda
+  sha256: 68798d8d7a2abaa7c0c18cbb8469b0fbaea4c94a88fdbb9b101262d68ed00265
+  md5: 91f82320477325e3969f24d7cfebbb49
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -44979,20 +44263,19 @@ packages:
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 53533
-  timestamp: 1769482716985
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h61f2ce4_15.conda
-  sha256: 820186d9f0ec17d1460eddf80cc617b8fe886c038f99dbb40aed39f57a770e6a
-  md5: a7fe4f7413ae757848f7ea52c00bd54c
+  size: 53575
+  timestamp: 1775548946298
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-fastrtps-cpp-3.8.2-np2py312h61f2ce4_17.conda
+  sha256: 3cb4cd5b92611f4575b8bd23109cef744049df440a877844379b3e75cbc88b5b
+  md5: 9059c765df903189d0d8827741c063a2
   depends:
   - python
   - ros-kilted-ament-cmake-ros-core
@@ -45007,51 +44290,49 @@ packages:
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 53765
-  timestamp: 1769482996383
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 98774d0ef51368f0ef9f57d59a4d61e95443dc3f0f484de18e132e88f37acf0e
-  md5: 308c601ff98fdc30a46a589c65b9c754
+  size: 53905
+  timestamp: 1775548931713
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 1fab34e62e88ad7862e32a5be615730e6168e73c75396a73e07883a243f6f9e4
+  md5: e0db7d98c1123de149deae7183970f11
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 29404
-  timestamp: 1769481910931
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: cd5d53cc595b9d6e7600a5086cd701fa351e2096e871a3147cbc26fc859e5a1b
-  md5: f1ee9870b4ed44e9ff0fcff829d452ee
+  size: 29511
+  timestamp: 1775548197735
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-interface-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 86777a153ff126a2231b63d45f1bb8aca0589c04ff5aa0d3b96e77707101e02b
+  md5: 439383afa19adbbebad88b7706668220
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 29359
-  timestamp: 1769482247003
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: 8b619c01e76ac83e0ac2edcfa911cc823845c9f0931f2deff36f86a625e9300a
-  md5: 2a6f5e96388cdb7c8e0e836564833a84
+  size: 29527
+  timestamp: 1775548275347
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: f7265f55f768118f4c5342fad729a0afc18a0986d24d9fb5b0f068a88c62f1c4
+  md5: be8495e2538e03c4b023fd2fd2188f24
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -45064,20 +44345,19 @@ packages:
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 46962
-  timestamp: 1769482622127
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 01903b9f3ef9580201678c332466c5e69a9ef46ef74b4463cd6bc6e50cbe6150
-  md5: 67dbe4726e114dfb182b9f53432f0f48
+  size: 47093
+  timestamp: 1775548878046
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-c-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 3299be8d64f6f3df54b7f3b1da9af0bf498dd286c6edc5959fea4a71449fe34b
+  md5: c1669daec2b8c5ec72806075dd90460c
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -45090,18 +44370,18 @@ packages:
   - ros-kilted-rosidl-pycommon
   - ros-kilted-rosidl-runtime-c
   - ros-kilted-rosidl-typesupport-interface
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 47378
-  timestamp: 1769482900749
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_15.conda
-  sha256: a8cc5cd4b6591d3743fa6c9bf25d2d841c9ab1a27629d677ce8454d198b6374a
-  md5: eccb9878cf4c7c550f102be51a0cff31
+  size: 47601
+  timestamp: 1775548855789
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h2ed9cc7_17.conda
+  sha256: 2201ef93ab02874a424d0ade7a85b2105c8a32e6aad667f9407d65d0c11ee473
+  md5: 0e0bdcff89c23360de7dbb0050baba5b
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -45117,19 +44397,19 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 47249
-  timestamp: 1769482735677
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h61f2ce4_15.conda
-  sha256: 6d19f00a30f88f1990057abe0622ff956b2bc452727235c273e644cc4f39b4af
-  md5: 428f48c46a148c5bdbedf0008f63dc33
+  size: 47348
+  timestamp: 1775548959858
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rosidl-typesupport-introspection-cpp-4.9.6-np2py312h61f2ce4_17.conda
+  sha256: 405bde54cb05dc1a7e90dd6c7a4403856d7b1fda1d1c327ae9fc3f55159ba90f
+  md5: a7c71b1546b19004a557a8280a8df81b
   depends:
   - python
   - ros-kilted-ament-cmake
@@ -45145,167 +44425,162 @@ packages:
   - ros-kilted-rosidl-runtime-cpp
   - ros-kilted-rosidl-typesupport-interface
   - ros-kilted-rosidl-typesupport-introspection-c
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 47544
-  timestamp: 1769483013899
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_15.conda
-  sha256: 3a75d028d115e404d9e4bbddf3c5c3a3b1f3ff317eb3bf5c45aea4a95c62372e
-  md5: 3f46db697e7dd8933ddcc300bea39db1
+  size: 47721
+  timestamp: 1775548945769
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rpyutils-0.6.3-np2py312h2ed9cc7_17.conda
+  sha256: f2b57bf7c1c6ac318b46687afd7421eabaa0ff6cbe02edceeacef3750eface68
+  md5: 5fe497cec126cde31afc98eb26101c2b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 27556
-  timestamp: 1769481316939
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rpyutils-0.6.3-np2py312h61f2ce4_15.conda
-  sha256: 89180d8977272040121b7906edae7ee70ded5d653968cab0cf19a0648c3c3781
-  md5: 0acd806d0cb31daf6558f244c5596a7c
+  size: 27300
+  timestamp: 1775547588505
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rpyutils-0.6.3-np2py312h61f2ce4_17.conda
+  sha256: 1775683725620801f93a2731f37ed22229c7a7a63d24bff4a2652e500e4f0e2e
+  md5: bde7265d6d5f4a3597532f998417af36
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 27558
-  timestamp: 1769481643888
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.2.0-np2py312h88103e5_15.conda
-  sha256: 0d4ff5c202dd6344f83052da7f4e5cb474b425d62601becea01537c7109dc02f
-  md5: c561e5e0d4141c4dfbdf9985d0c93cf6
+  size: 27419
+  timestamp: 1775547763855
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rsl-1.3.0-np2py312h88103e5_17.conda
+  sha256: 08c83823f5ade2b30d0ca826c66c3efacc40c10fb1284d8bb945a324d679c733
+  md5: cfa88c39612642807286b4e6ea2331c6
   depends:
+  - cpp-expected
   - eigen
   - fmt
   - python
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
   - ros-kilted-tcb-span
-  - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - graphviz >=14.1.2,<15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - graphviz >=14.1.2,<15.0a0
   license: BSD-3-Clause
-  size: 61919
-  timestamp: 1769485052157
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.2.0-np2py312hcab10f8_15.conda
-  sha256: 0a52f3f7cf210f52139c1b5d88330f1bb7749700b7ce96a4113e0dd2129acce3
-  md5: 40bd39150cb6cb817718234dbd1757ee
+  size: 62114
+  timestamp: 1775551262782
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rsl-1.3.0-np2py312hcab10f8_17.conda
+  sha256: be5ccbd54000ec11bb78b83241c326826f6c69cde8ad72208a79cb53aa57ae37
+  md5: 1c1190188df5560dbefa9189975f7514
   depends:
+  - cpp-expected
   - eigen
   - fmt
   - python
   - ros-kilted-rclcpp
   - ros-kilted-ros-workspace
   - ros-kilted-tcb-span
-  - ros-kilted-tl-expected
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - graphviz >=14.1.2,<15.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
   - fmt >=12.1.0,<12.2.0a0
+  - graphviz >=14.1.2,<15.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 63140
-  timestamp: 1769485168194
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_15.conda
-  sha256: 7ee327a74010f94bbff865fe6442fdf272b645ef6220d98676ef5a66113a0139
-  md5: 0e85abfc01ee7d8bab1d9b5c72f2850e
+  size: 63375
+  timestamp: 1775551001826
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h2ed9cc7_17.conda
+  sha256: 702753c3e50332b0d5e66abfec0d5823d16cad05a73a263b7e93606d0ddb11a4
+  md5: e708387f4b1310725ef002e757a76c9e
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 31691
-  timestamp: 1769482237058
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h61f2ce4_15.conda
-  sha256: f7c27185b507287965927c94653318dc932b400015545d2da71372d262c9eda2
-  md5: 15ce3918dd4b4e14be29249f912f7cb1
+  size: 31800
+  timestamp: 1775548531328
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rti-connext-dds-cmake-module-1.1.1-np2py312h61f2ce4_17.conda
+  sha256: f1119bbd8d8da0bd8b67918ea893ec7cac9b55418308a321c60e0c1439eaa71f
+  md5: 8eba14442fbe6338b4449890e22bb3c6
   depends:
   - python
   - ros-kilted-ament-cmake
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 31715
-  timestamp: 1769482462231
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.11-np2py312h4f3ad64_15.conda
-  sha256: 2cdbf95d93c3e22bfea780c09dd077eefdb78746f787add90e7080e03a798ee8
-  md5: cecbf784ca526a012fd1892398679392
+  size: 31861
+  timestamp: 1775548490438
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-assimp-vendor-15.0.12-np2py312h4f3ad64_17.conda
+  sha256: 7af1f5df4d5f8b82ec2c50de401a11a9e7fc25e76dbdc7132bbcf5ded6a268a5
+  md5: 0797fd3b729f19ccc465b9a0577d344e
   depends:
   - assimp
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - assimp >=5.4.3,<5.4.4.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - assimp >=5.4.3,<5.4.4.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 25116
-  timestamp: 1769481815702
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.11-np2py312h617ce90_15.conda
-  sha256: 301c9650f95d58ea87a4a07edb0873ca7d4ff5638110c86e9ebd5ec5119bb4bd
-  md5: 1fae0e716af759bc2521aa5d2a14b439
+  size: 25163
+  timestamp: 1775547882799
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-assimp-vendor-15.0.12-np2py312h617ce90_17.conda
+  sha256: 0f69f9b64eca7a4a9fdc7d9c16771cbac856ddf1a21b186e64fdfe7f40ce6655
+  md5: ac386cecead361e7be07ac7026583171
   depends:
   - assimp
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - assimp >=5.4.3,<5.4.4.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0 OR BSD-3-Clause
-  size: 25140
-  timestamp: 1769482109103
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.11-np2py312h2ed9cc7_15.conda
-  sha256: 4e6ac5d844507ffdb696a9110b2931ad4427aa6978aa1df5208e585151c47b6e
-  md5: cc6c7710820a841882e4f1e9fa9f3070
+  size: 25229
+  timestamp: 1775548019516
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-common-15.0.12-np2py312h2ed9cc7_17.conda
+  sha256: 477b736114835674cbbc5fbb9dc5fdb0795e993460b98a332cdacd60b3ab84ea
+  md5: 53344dc0939ddb46c70c8385f76054b6
   depends:
   - libgl-devel
   - libopengl-devel
@@ -45327,23 +44602,22 @@ packages:
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libgl >=1.7.0,<2.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - libopengl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 891411
-  timestamp: 1769485931950
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.11-np2py312h61f2ce4_15.conda
-  sha256: 472d3eb122a88d5357941dc69a0aacee86c510d628b06d65324f8cabc3823e7c
-  md5: e453c2369d0a05e21fff077f3e738337
+  size: 893534
+  timestamp: 1775602484758
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-common-15.0.12-np2py312h61f2ce4_17.conda
+  sha256: 34533e64f423dff3e835c05068fbe7ebd53bf7b8f8e9d8634b59831e9f0e30a0
+  md5: 740ee3bfafd113e653a45147f6e48972
   depends:
   - libgl-devel
   - libopengl-devel
@@ -45365,22 +44639,21 @@ packages:
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
   - ros-kilted-yaml-cpp-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - qt-main >=5.15.15,<5.16.0a0
   - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   - libgl >=1.7.0,<2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - libopengl >=1.7.0,<2.0a0
   license: BSD-3-Clause
-  size: 881528
-  timestamp: 1769485912075
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.11-np2py312h2ed9cc7_15.conda
-  sha256: ce1397f88bcd43e2fdaff28e4334253bd37f3bc6ede4eb24c25fa5fd88e5873a
-  md5: a133e1ba3826f5f3337b4c4f69c04294
+  size: 884170
+  timestamp: 1775602685386
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-default-plugins-15.0.12-np2py312h2ed9cc7_17.conda
+  sha256: dfb3d00e2c69733b0edcb5d750f1fd75a90c5d013e4f85768098b060ccef3abc
+  md5: 1c76914ae2aa6d76a052005e399de7f6
   depends:
   - libgl-devel
   - libopengl-devel
@@ -45407,22 +44680,22 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-urdf
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libopengl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
   - numpy >=1.23,<3
   - libgl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 2319869
-  timestamp: 1769486777351
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.11-np2py312h61f2ce4_15.conda
-  sha256: a1148f5c4392ec7ffaff14e52110a94c5068470b18491b3797116addc84351d5
-  md5: 7ed39dc7dd97d2ec377565a4308ccf33
+  size: 2319924
+  timestamp: 1775603411794
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-default-plugins-15.0.12-np2py312h61f2ce4_17.conda
+  sha256: c03c64d94db4c4487f0961a8ae3bbba05cddf9ecfd94cc101f71dc1240615b91
+  md5: e5a690ca73e9512df66b2f1ae39e501b
   depends:
   - libgl-devel
   - libopengl-devel
@@ -45449,21 +44722,21 @@ packages:
   - ros-kilted-tf2-ros
   - ros-kilted-urdf
   - ros-kilted-visualization-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - libopengl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - python_abi 3.12.* *_cp312
   - libgl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 2347883
-  timestamp: 1769486629288
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.11-np2py312hf6702ba_15.conda
-  sha256: f168da3ec5892cee313414c2ce25f49a91025004b6dba1625f52006e14b16ca3
-  md5: a7e357a8f973321ba969a8ebe29c65fc
+  size: 2347372
+  timestamp: 1775610926188
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-ogre-vendor-15.0.12-np2py312hf6702ba_17.conda
+  sha256: d0792ab6e36b6d42b3aeb6731733d88d4c0276575bbed1dab128583bb3bd7d91
+  md5: d22ac5df1ab11402f3b85fa466eecdf1
   depends:
   - assimp
   - freetype
@@ -45472,36 +44745,36 @@ packages:
   - libopengl-devel
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - xorg-libx11
   - xorg-libxaw
   - xorg-libxrandr
   - xorg-xorgproto
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  - freeimage >=3.18.0,<3.19.0a0
-  - libgl >=1.7.0,<2.0a0
-  - libglu >=9.0.3,<9.1.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - pugixml >=1.15,<1.16.0a0
-  - zziplib >=0.13.69,<0.14.0a0
-  - libopengl >=1.7.0,<2.0a0
   - numpy >=1.23,<3
+  - libopengl >=1.7.0,<2.0a0
+  - libglu >=9.0.3,<9.1.0a0
+  - libgl >=1.7.0,<2.0a0
   - glew >=2.3.0,<2.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - libzlib >=1.3.2,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - pugixml >=1.15,<1.16.0a0
   - assimp >=5.4.3,<5.4.4.0a0
   license: Apache-2.0 OR MIT
-  size: 5378530
-  timestamp: 1769481564952
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.11-np2py312h4ccd639_15.conda
-  sha256: cab281dc1f3b3938976148ec9ab47d29296feceb9c51cb1993fb04fb99dec88a
-  md5: af55e1af5b4d122fc8e9b6370d36ffef
+  size: 5378720
+  timestamp: 1775547909771
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-ogre-vendor-15.0.12-np2py312h4ccd639_17.conda
+  sha256: 3d16703a15bc9a01abfbc69f0caf3b849d9a17b4126ae3868fb5bca3f3b12185
+  md5: 1a95f35890828e7fe383c75ee7feef28
   depends:
   - assimp
   - freetype
@@ -45510,35 +44783,35 @@ packages:
   - libopengl-devel
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - xorg-libx11
   - xorg-libxaw
   - xorg-libxrandr
   - xorg-xorgproto
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - libglu >=9.0.3,<9.1.0a0
-  - pugixml >=1.15,<1.16.0a0
-  - libgl >=1.7.0,<2.0a0
-  - zziplib >=0.13.69,<0.14.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - xorg-libxrandr >=1.5.5,<2.0a0
   - python_abi 3.12.* *_cp312
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libglu >=9.0.3,<9.1.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
   - assimp >=5.4.3,<5.4.4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.23,<3
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - pugixml >=1.15,<1.16.0a0
   - freeimage >=3.18.0,<3.19.0a0
   - glew >=2.3.0,<2.4.0a0
-  - libopengl >=1.7.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - zziplib >=0.13.69,<0.14.0a0
   license: Apache-2.0 OR MIT
-  size: 5261815
-  timestamp: 1769481931312
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.11-np2py312h2ed9cc7_15.conda
-  sha256: c28f467d2c6d9a18440d9799726baba66455dfaa5603c53162228f9867d8a052
-  md5: 24a3de4e5871813e10c4f3e8e6a18923
+  size: 5262146
+  timestamp: 1775548055287
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-rendering-15.0.12-np2py312h2ed9cc7_17.conda
+  sha256: 4cef0e3e6f4f9ba9c85f348204a6a5321d4bf16418fd6dcc054388d1a5b18bc0
+  md5: b26c638708295e8c8b9968d6d24c8975
   depends:
   - eigen
   - libgl-devel
@@ -45551,24 +44824,23 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rviz-assimp-vendor
   - ros-kilted-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgl >=1.7.0,<2.0a0
-  - numpy >=1.23,<3
-  - libopengl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - glew >=2.3.0,<2.4.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - glew >=2.3.0,<2.4.0a0
   license: BSD-3-Clause
-  size: 937776
-  timestamp: 1769484542579
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.11-np2py312h61f2ce4_15.conda
-  sha256: 9604c6b39963bf9ce943be45441aa0eea991fe1f1ac88dce041c02b29761583c
-  md5: bae796de94290e5be7dd7226ea8ddda1
+  size: 937971
+  timestamp: 1775550728717
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-rendering-15.0.12-np2py312h61f2ce4_17.conda
+  sha256: d126b3049475d45ad8aa800d736e02b222e980c4ac2abdf5281be107c0e05ecc
+  md5: b2e1d059995e605da716ec56697a4756
   depends:
   - eigen
   - libgl-devel
@@ -45581,102 +44853,98 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rviz-assimp-vendor
   - ros-kilted-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   - libgl >=1.7.0,<2.0a0
   - libopengl >=1.7.0,<2.0a0
-  - qt-main >=5.15.15,<5.16.0a0
-  - python_abi 3.12.* *_cp312
   - glew >=2.3.0,<2.4.0a0
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - qt-main >=5.15.15,<5.16.0a0
   license: BSD-3-Clause
-  size: 929577
-  timestamp: 1769484686514
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.11-np2py312h2ed9cc7_15.conda
-  sha256: 89e06e3a7e76c401ad80573043e0ab6708d9defac820d7d63127e5820b255f58
-  md5: efb2388da98750b313a493bb6bcffab0
+  size: 929684
+  timestamp: 1775550537978
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz-resource-interfaces-15.0.12-np2py312h2ed9cc7_17.conda
+  sha256: 4a0a616fa27d4837c5130a4a54796eda380f2d17475a076e6cdc5228319e268f
+  md5: 685a6d9c0014c513d774234785916cc3
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 127161
-  timestamp: 1769483122305
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.11-np2py312h61f2ce4_15.conda
-  sha256: ab9b2af60ba84e888bd7e4af9adaabbf83cdb910d758ead05df6601d40224d8d
-  md5: 266e93965e8f151b246eff962e09d2aa
+  size: 129596
+  timestamp: 1775549403248
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz-resource-interfaces-15.0.12-np2py312h61f2ce4_17.conda
+  sha256: 8fe8bf1873a838e5e33fc62837db176e4fe64f529bea3673dcde1ddff88bd34f
+  md5: 3750bff1b36ff299e53252eafcdb6511
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 129212
-  timestamp: 1769483413776
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.11-np2py312h2ed9cc7_15.conda
-  sha256: 2af30a99f9b24be947e54b3b57cc6220d84921ba37abb7516335e6b2fd9d081c
-  md5: 9105aa53d835de1fd816b4d239c86033
+  size: 133021
+  timestamp: 1775549413944
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-rviz2-15.0.12-np2py312h2ed9cc7_17.conda
+  sha256: a6d597c6d032a4750105199603b5d4db1938cb12cebc7f5ec14db050e12cd80d
+  md5: 453342a8fe71c545aead20a0d01bd229
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rviz-common
   - ros-kilted-rviz-default-plugins
   - ros-kilted-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopengl >=1.7.0,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - libgl >=1.7.0,<2.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 77255
-  timestamp: 1769487244691
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.11-np2py312h61f2ce4_15.conda
-  sha256: 1eff8354e5a8adc78f0838aafec64cd4f5e898b32ca862f54cbafcde12fd37c5
-  md5: 4ff2448927f31cf2a008f4be3b9e096b
+  size: 77609
+  timestamp: 1775604181319
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-rviz2-15.0.12-np2py312h61f2ce4_17.conda
+  sha256: 1a09ee481419d833a323752ed13207b28e4220b948345fd090fb962ffe098514
+  md5: f49f0ad82b4cda44d2380d2d42497bb0
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rviz-common
   - ros-kilted-rviz-default-plugins
   - ros-kilted-rviz-ogre-vendor
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - qt-main >=5.15.15,<5.16.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - libgl >=1.7.0,<2.0a0
-  - libopengl >=1.7.0,<2.0a0
   - python_abi 3.12.* *_cp312
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
   license: BSD-3-Clause
-  size: 78393
-  timestamp: 1769486994534
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h2ed9cc7_15.conda
-  sha256: 02ea8d8badaf199d4af414c51e47adc45503cd106fac6295cc5848d5b9306e25
-  md5: ceab1243f2c172f995e5a1b270e9b462
+  size: 78935
+  timestamp: 1775611543877
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-urdf-2.0.1-np2py312h9e410fd_17.conda
+  sha256: e95f3d6c7867fb17477fd103578f39bde2319d30242852e0eae7a7dcc48bd010
+  md5: a247e7519a474411db2b765106b58bb5
   depends:
   - python
   - ros-kilted-ament-cmake-ros
@@ -45687,20 +44955,22 @@ packages:
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
   - ros-kilted-urdf-parser-plugin
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - sdformat15
   - urdfdom_headers
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - libsdformat15 >=15.3.0,<16.0a0
   license: Apache-2.0
-  size: 86001
-  timestamp: 1769484825185
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h61f2ce4_15.conda
-  sha256: 7d1c77ee70af26b194f821cf97fdd1860d9da642ff2fbbd49cdbefb1fc09b6b2
-  md5: ed845fa389844a51da0c261bfea6a6b9
+  size: 86270
+  timestamp: 1775551016908
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-urdf-2.0.1-np2py312h14a8626_17.conda
+  sha256: 1d9db948773e57207a09ae2bf7bda2e360d7b653b2adb164bace7112f575a6d5
+  md5: 4d9e6ced5916c08b82148d4e0d896260
   depends:
   - python
   - ros-kilted-ament-cmake-ros
@@ -45711,19 +44981,21 @@ packages:
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdf
   - ros-kilted-urdf-parser-plugin
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - sdformat15
   - urdfdom_headers
   - libstdcxx >=14
   - libgcc >=14
+  - libsdformat15 >=15.3.0,<16.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 88968
-  timestamp: 1769484974671
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.6-np2py312h6021aa6_15.conda
-  sha256: 83ea5cf0b85b1a36f41bb4bc64c44c0bead898968728e867e92b87f993099719
-  md5: ffa5056a11fd063c91b420f554c171d1
+  size: 89414
+  timestamp: 1775550795369
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sdformat-vendor-0.2.7-np2py312h6021aa6_17.conda
+  sha256: 57b829303f1a5b1d811d3c4474d260b5b839fecb7953284194700760ccca4420
+  md5: 606de05eddaa923ee417dde1035b2bad
   depends:
   - pybind11
   - python
@@ -45733,25 +45005,25 @@ packages:
   - ros-kilted-gz-utils-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - sdformat15
   - tinyxml2
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libsdformat15 >=15.3.0,<16.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 32135
-  timestamp: 1769482448184
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.6-np2py312h287f2fd_15.conda
-  sha256: 4475eba5858c073b7331f19009a787c05ceefd7ff80dafa5a0974297ae0185f8
-  md5: cfaf6a93b75643b514a3b97c852a7b08
+  size: 32326
+  timestamp: 1775548731742
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sdformat-vendor-0.2.7-np2py312h287f2fd_17.conda
+  sha256: 6c4b8b6b3df04fb4b65599af934bbf2691c15c0d2cf3d679682e6a14a9b5a4fa
+  md5: e9bbedb36aefcf7e41be963111ff2cc2
   depends:
   - pybind11
   - python
@@ -45761,25 +45033,24 @@ packages:
   - ros-kilted-gz-utils-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - sdformat15
   - tinyxml2
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - tinyxml2 >=11.0.0,<11.1.0a0
   - libsdformat15 >=15.3.0,<16.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   - libxml2
   - libxml2-16 >=2.14.6
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 32030
-  timestamp: 1769482678839
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: c4926f585c45a84e1fbb67d9100c35205551a98d2c4eea20bd6814025a33c9af
-  md5: b722f712ccf4594e768b8d7cce61dabb
+  size: 32416
+  timestamp: 1775548711179
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 916ae0e718b4b379b109ebba85672388fc4019dbbbadb39f43e647250ce0ddf6
+  md5: 3d62cbc0fe34432ba29e0fac7bbe52cd
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -45787,19 +45058,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 547407
-  timestamp: 1769483569069
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: c442b7b256ecfdcf5fd893fc44d3a1d820bd64824117a9f23e8b27e989065efa
-  md5: 460b487d1c8a9d0052161aa7f75fff14
+  size: 559852
+  timestamp: 1775549739340
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 9324c0f5129e9fcdb786dba2143e3e459dc36971287144b64919a30bdb485430
+  md5: bf461750046085d815a17e2da083cac5
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -45807,209 +45078,199 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 555302
-  timestamp: 1769483822181
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 7d86ef63bc8c1b3ef4f4194cd44413f5796dd4fc7c4b1965a80816820c0ca9dc
-  md5: 8453b84560f657ba8943ea601d302dbb
+  size: 567726
+  timestamp: 1775549719341
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sensor-msgs-py-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: f5842f769f21a07d4781fb30b06e8abc46388ceb1797019a2e7b23cb96dce6f9
+  md5: 2303b4415f007393ecc8e414e9ab60ff
   depends:
   - numpy
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 31077
-  timestamp: 1769483816584
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 312b8408bc0737551d3adb13c31ce61b2362d669e5622557cf0ef7cd3b75c114
-  md5: 6df21aa53f2414ad6571ee0427187814
+  size: 30833
+  timestamp: 1775549948906
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sensor-msgs-py-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 74247fd74e651c9291a42c11787af6e98e4286d37a7858ff74aec6df8775a85d
+  md5: 581eb52e32b30df580ee3864a35a6e12
   depends:
   - numpy
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 31102
-  timestamp: 1769484068854
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: d296a9850fea6bc2bd3b0311cb650f15995088585737d7d65b0640aa4a727d75
-  md5: 062fe0b07be95d751d788a904d7458c8
+  size: 30927
+  timestamp: 1775549899618
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-service-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: be21a42f1d0f20b707137a5c49aba972a2a8f3e19b43f9fa6908bb6d49713350
+  md5: 4244444b56603cd22565e4131e90b46a
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 78656
-  timestamp: 1769483003435
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-service-msgs-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: a2cf216606ed0932f92fe967e689aef2c7d502216554f736006e1c5aa3d23533
-  md5: 727da4e66da3e5a94bc515d737e22668
+  size: 80039
+  timestamp: 1775549210336
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-service-msgs-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 70ffced02b325103cc628ba22dc161812e2d8fa4e2ce584985ebfe70af7c4576
+  md5: 52340aae2b7f380aa0071e45982e3ca6
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 81489
-  timestamp: 1769483279881
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 41f673feff322149bf69a1068a5bb016f5cfff907d54b08280f1f29ad7703e8a
-  md5: b4ea50e647448df92d0cde15a0a13c4a
+  size: 83643
+  timestamp: 1775549203973
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-shape-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 73e1e7fd0a38ecd4a38f5d0b44e1ba12cb95615ac4d71ff7661e8ff7f26d650e
+  md5: 0e4b7c26fae15dfe21a957d732933c97
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 125384
-  timestamp: 1769483539253
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-shape-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 0de83effccedd8881d30d1f5251044abd81c8a678ea4e1daa6e5cc364d3e3f53
-  md5: b8b1ba36f1521b0a536a9f1d6f13721a
+  size: 128975
+  timestamp: 1775549715986
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-shape-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: f1fad34e24739f42df1019051b6e42ca2d651c18f75c92364f104310953eed48
+  md5: 9847a06dd6d73fd91c931382413e3a57
   depends:
   - python
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 130031
-  timestamp: 1769483806680
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_15.conda
-  sha256: b33654e8fa4bc61d1badfbbd2610106aa5b930553b3ea3f208fc4352dcf59df9
-  md5: 29394bc532205f32ff9281e2ac4d39bc
+  size: 134215
+  timestamp: 1775549699892
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-spdlog-vendor-1.7.0-np2py312h918b84f_17.conda
+  sha256: 6ce4e9d274ba5b92d4d8207604143bb48072836e2668743e3ead339abf3d2e1f
+  md5: db38ceaef47d42c992bdb986aae6eeb1
   depends:
   - fmt
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - spdlog >=1.17.0,<1.18.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - spdlog >=1.17.0,<1.18.0a0
   license: Apache-2.0 OR MIT
-  size: 27438
-  timestamp: 1769482254517
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-spdlog-vendor-1.7.0-np2py312ha677571_15.conda
-  sha256: 52ed3edf250a31a63000e91b4c71a29e2a7d796da0e5bac94dc532ff4db624ed
-  md5: 88cfeeb93df4c3bf4ce72812a970054e
+  size: 27520
+  timestamp: 1775548550496
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-spdlog-vendor-1.7.0-np2py312ha677571_17.conda
+  sha256: 9705fbdf55ed0aecd0802affd5124f8e13f5a0cdbbf229803de6b9a2ee3ea1ce
+  md5: 640cb527f178d4c2a32dca966850dbc6
   depends:
   - fmt
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - spdlog
-  - libstdcxx >=14
   - libgcc >=14
-  - fmt >=12.1.0,<12.2.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - spdlog >=1.17.0,<1.18.0a0
+  - python_abi 3.12.* *_cp312
+  - fmt >=12.1.0,<12.2.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR MIT
-  size: 27424
-  timestamp: 1769482478145
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 1ce028014630756b0e680b72e94a0346cc947c20b440c19bc637cc72bad522b3
-  md5: a8471f8940184b8522024ecdfecb2925
+  size: 27659
+  timestamp: 1775548511899
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 028470d7e690c91e37118a9146f5115d25bf3819a87ad11512cd7eaad24a7beb
+  md5: 9d7e47a08cb65439d2deaa22fddd00cc
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - sqlite
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - libsqlite >=3.51.2,<4.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - libsqlite >=3.52.0,<4.0a0
   license: Apache-2.0
-  size: 24533
-  timestamp: 1769481208705
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 31b751e0875fc12472d0ba0824bd41172a0fa4ee43b931d42bb01defb3cd59c4
-  md5: 0aea817fbe61f892bd18d5a2a6843dad
+  size: 24514
+  timestamp: 1775547440563
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sqlite3-vendor-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: b8c1b39f05e69afcdca1f4ce1eaad4f6345373f4261cf299c92d70530dbdbf03
+  md5: ecdd5f1b1df2d4c5f5a4f576e3cd0e93
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - sqlite
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - libsqlite >=3.52.0,<4.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - libsqlite >=3.51.2,<4.0a0
   license: Apache-2.0
-  size: 24524
-  timestamp: 1769481545061
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.4-np2py312h2ed9cc7_15.conda
-  sha256: 72316caa2d04a7fe7097f9a95b468d9243e5a751a184cd3133d1d8df351b4623
-  md5: d9ff57e62399a9c8acdb7d5893df56cf
+  size: 24595
+  timestamp: 1775547675108
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-0.15.5-np2py312h2ed9cc7_17.conda
+  sha256: 487cd97d6dd5944aa22a0e49b34f6ce886dbfc97a2b5ba7a6a8ff1b85d79c512
+  md5: 3a486c2d5c53aa9238e0fb40614a4bf3
   depends:
   - argcomplete
   - cryptography
@@ -46019,20 +45280,19 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 74456
-  timestamp: 1769486240589
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-0.15.4-np2py312h61f2ce4_15.conda
-  sha256: c58d1b87d23b23e06ebc9defdb082fb5a8551875786074dfd67761b4801c7435
-  md5: 2a94ce74d08ae84910ec9d437da8b6c0
+  size: 74553
+  timestamp: 1775602764502
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-0.15.5-np2py312h61f2ce4_17.conda
+  sha256: ac16d8c28649258989171490338ac374607dc2cc0d6e6bb9045b999a1e126989
+  md5: 69bc5c91ac187bdf3899fd9631c669a8
   depends:
   - argcomplete
   - cryptography
@@ -46042,228 +45302,224 @@ packages:
   - ros-kilted-rclpy
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0
-  size: 74357
-  timestamp: 1769486191440
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.4-np2py312h2ed9cc7_15.conda
-  sha256: c2bedf4db0bfdcc102d6c8b1b275ef9bdfab66e28ae451f97788bb31709f0100
-  md5: 3c8c59485dbb9ee1154a7e83bff8dfd7
+  size: 74599
+  timestamp: 1775610410396
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-sros2-cmake-0.15.5-np2py312h2ed9cc7_17.conda
+  sha256: f651799c27d41bdedeaa0ffac152dddc14419f614b16d74f8f0d4bc5cc7564e3
+  md5: 20b2702d5bab44c11f4bea5a54d2f80f
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 36917
-  timestamp: 1769486535351
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-cmake-0.15.4-np2py312h61f2ce4_15.conda
-  sha256: 4d7af99c11073f7ae195d511aca76ec01ded29d65ddc4ed194f40855cbeb6128
-  md5: 95cd9d47ad94e99ced3e6a2e119093d2
+  size: 37168
+  timestamp: 1775603172427
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-sros2-cmake-0.15.5-np2py312h61f2ce4_17.conda
+  sha256: 4ac61c393c8152add743ca26e7b8c9b4842c6029599552c610f7ed279bd619b0
+  md5: ce65f1756db681ad995955e750f4455a
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-ros2cli
   - ros-kilted-sros2
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 36790
-  timestamp: 1769486447034
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 64f8240a1b5e5d59babcf099b19c671524a79e849b915be271333d204c30ace6
-  md5: 34c83ff7f48c1a8ee741273663c282fe
+  size: 37238
+  timestamp: 1775610743983
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-statistics-msgs-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 13f723839f97ef913c8f7f9e4030d7d1b20535639d008e76469e78b1802852c2
+  md5: beb39a19ee3bce988c9b73b732a2ad6d
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  size: 108998
-  timestamp: 1769483297417
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-statistics-msgs-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: add9caa7c8f979a991703171201e4bac4c59f66a764ebe67514d0fe3e2f5f161
-  md5: 47e91f17a7e78ad7cd65cee44e5b300e
-  depends:
-  - python
-  - ros-kilted-builtin-interfaces
-  - ros-kilted-ros-workspace
-  - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 111945
-  timestamp: 1769483575573
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 42c4c74ec8da4d3a445d53b15282b0619a8aaaa90bf052530ee1431149ecd6c1
-  md5: b43fa15f4a99e3262b5dd1f3fb36c0fb
+  size: 111690
+  timestamp: 1775549474470
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-statistics-msgs-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: 2c6fead7286f9a9ef7cc301e20e23ed84e0bbe011b2e965216790283a37002d8
+  md5: 7ee0a21c9d130d85a4d901ad144252ee
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  license: Apache-2.0
+  size: 115291
+  timestamp: 1775549487144
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 45cdf7dafbfbea19445011ec1ec28c7abb348418e7eb62b215789c50d61a1131
+  md5: ea31fec6f7573829595007b1f584a588
+  depends:
+  - python
+  - ros-kilted-builtin-interfaces
+  - ros-kilted-ros-workspace
+  - ros-kilted-rosidl-default-runtime
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 339229
-  timestamp: 1769483254088
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 30edda955017030af89eaefdb5529f501aa260689d07d914daf8a7d0798232c1
-  md5: 8ef631037b33e5ceb06ca5884e3a1412
+  size: 346071
+  timestamp: 1775549436612
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 609e2e1a55b68094fa6cee34e05dbe27aa3eb9dff0f155223d25a672084cb197
+  md5: faf9f768a77c9a88f4c294838ec95ead
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 344023
-  timestamp: 1769483545
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: b86b61ebdfb8f479d8a1c44b011deb4bfdccba6b09f3c6ed1b61cc91ef42b8bb
-  md5: 1898d1ab56a921fbe9f09921d5ab952f
+  size: 351002
+  timestamp: 1775549453009
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-std-srvs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 81b13f1c7681c1856c139a4018f58ac384eb47622f80b69224261a49a96ef401
+  md5: cde75201099bd1f2904b9b15be072d50
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 168026
-  timestamp: 1769483160456
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-srvs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 2459664a3387ab1a82f1fd38dd69b0e16ca41bfbfc52bf1eb62b04e3f36ef517
-  md5: 9e6c76fd77002a8a6d97c3ac442ce14f
+  size: 170866
+  timestamp: 1775549362675
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-std-srvs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 855bd96f6a2900b796928480a07e7a463845e5ad2ef371bc7e37dee59d46b7be
+  md5: 22d3b55fe9f474a6dacd8ba27a4aaceb
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 172351
-  timestamp: 1769483451251
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 393187a5ee7a567f0ef673cfb847b5ad1716aa7064fee0c5cd23a2d2468c1041
-  md5: e93999a96851bf91e74537effb4591e1
+  size: 175257
+  timestamp: 1775549378537
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-stereo-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 5449b1de2dd5adccbf3c6b304d6bdb97e74860d026e2a114c1241f7700793173
+  md5: e2daa3ce82eb5223db9c7f0f6fb8cabb
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 81773
-  timestamp: 1769483909956
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-stereo-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 75b38fe05c78b31974f3bc1f139f07abd23c464263e776733d4004d3079529c2
-  md5: f683a7b4e4e44cbc242c317cd1f0854d
+  size: 83956
+  timestamp: 1775550103727
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-stereo-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: a7124656fe117d4d8b8386b83e8e3e2b3ecd6695534321dadc5596bffb68d736
+  md5: b1ea9077907d5b2b24b4bd5feba54790
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 84996
-  timestamp: 1769484152793
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.2.0-np2py312h2ed9cc7_15.conda
-  sha256: f05fcdb2627c08ad03b59def4cae366378ce6ef85f489dd210a8d4cdc58e176f
-  md5: 3fb69513707574d2c4266608f61265b9
+  size: 87725
+  timestamp: 1775550009640
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tcb-span-1.2.0-np2py312h2ed9cc7_17.conda
+  sha256: 2aa56971ec964f2d6242d27a29c01812d40daf166da9db9b4e120a02082c66ee
+  md5: 457ef30678251144048deacf3903e562
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - libgcc >=14
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSL-1.0
-  size: 28041
-  timestamp: 1769481225608
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.2.0-np2py312h61f2ce4_15.conda
-  sha256: 8866fd7628b1cd5b11a7417222f379b7df2d1b0397999f27b5aff0741eefcf2e
-  md5: b3bb9e430520b1e23b93ee6c55bd8bf5
+  size: 28049
+  timestamp: 1775547433202
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tcb-span-1.2.0-np2py312h61f2ce4_17.conda
+  sha256: ee44257bceea9ad00eb9698d620ca1ee08c42f3bbe294634dcbe0343c0b2977b
+  md5: 79e676cdb92988b323a80f3fe70dffec
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSL-1.0
-  size: 28001
-  timestamp: 1769481548497
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 4426db48ff1533b7fd9c336ebb0d2ccaa0280631d00523e454ca683621a5bb47
-  md5: d75437970e2934dc81eaf091e5cc4ec2
+  size: 28142
+  timestamp: 1775547660539
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 6f8996909cccea8c4fa2c980aab2578770b96c832165dbb135aecc71aacc89b8
+  md5: 31b570b9d2f30aa2cb2ced390d130bcd
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46271,19 +45527,19 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 136669
-  timestamp: 1769484361363
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 5da054f2122b34df074a5b2ff8dd27a3b87cbef48b37b78a768b83b7d95be5e4
-  md5: 3e0b6463c7704e48ae2a3efff148280d
+  size: 136865
+  timestamp: 1775550549013
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 2177f2583ea47c9f69d9d25d968e606e47d438a7a84ad1a539965b4bd976a688
+  md5: adc5744f6b9ad4f091ec6d8c609fbdee
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46291,18 +45547,18 @@ packages:
   - ros-kilted-rcutils
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-runtime-cpp
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 134241
-  timestamp: 1769484524403
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 892b5a21916faeaf8a60ed7c192c9fb931af1b2c373be9c6c627d1cbb2036689
-  md5: bbd67a362b1d20dd102da07a7e7d9e62
+  size: 134592
+  timestamp: 1775550391846
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-bullet-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 09a73e8b65952b81e676db42e6c5ec4ed4fe9cb1985da17e786b33e6fe0964a0
+  md5: 3300395a12d51201a8a310551c25b7e2
   depends:
   - bullet
   - python
@@ -46310,20 +45566,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 43531
-  timestamp: 1769485892697
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-bullet-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: f89261eec00fb2f1cd1eb44b66da5209ddedc4c9395cd1025cc4f90c13b0fd56
-  md5: 2fb4c2e48190d1a778bd3286c29d9d75
+  size: 43799
+  timestamp: 1775602428936
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-bullet-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: f3fde653f28df17e8c01ab08b51ab6136181af757ea769992bf5340be0d679df
+  md5: bee371b6e45532c94c5316b9a037680f
   depends:
   - bullet
   - python
@@ -46331,18 +45586,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 43355
-  timestamp: 1769485864293
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 41b82055be98cf9095259709026feb30f982031f8ec22be83da4d494eaf3719c
-  md5: 11a2c6d7e3ac5ff2bb43b28a1147ef7f
+  size: 43814
+  timestamp: 1775602624900
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 2f7af3bdc59ed6d982cff145ca6957cc20679fe7aeb638da0ca2bb03c7c7190b
+  md5: db37fc25cd60566fd7806f5c5a97cd01
   depends:
   - eigen
   - python
@@ -46350,20 +45605,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 44882
-  timestamp: 1769485926480
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: d73aa35aba32b05d77c02316fafb59991bbbb6e38ae75f3c4f6c6f0cd1bce5e1
-  md5: 3f559291e2a0a49ccc1daff2fcc5b197
+  size: 45182
+  timestamp: 1775602477779
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 43f061191dcae03fbf124adf35d260847ffcfa955cdaa11397c0fd08f5f268b1
+  md5: 8edba065d48dfb080284d48e92083ea4
   depends:
   - eigen
   - python
@@ -46371,56 +45625,57 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 44692
-  timestamp: 1769485906897
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 33d6a0c9a15a0239c848a2f78decf30701a8a3a71864ca40d6b634cc0b0b09ca
-  md5: 05f44148df40ba4765a36315067eeb11
+  size: 45184
+  timestamp: 1775602678617
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h3ba0a76_17.conda
+  sha256: 9ed693d1a2e6c0bc55085b6e144b6a15413a3effaab37847dee69b247072cea8
+  md5: 1dc755b508ee8bbf9a2f80033219dc4f
   depends:
   - eigen
   - python
   - ros-kilted-orocos-kdl-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 40285
-  timestamp: 1769484587939
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 4a18d106ed5728db4ae6f2371e2844d2d59c7c2d1449850782c63fb8ba4633cb
-  md5: f1b7738ad7f04a8ed4a98d29cae1422f
+  size: 40803
+  timestamp: 1775550771418
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-eigen-kdl-0.41.6-np2py312h78fd680_17.conda
+  sha256: 60e074e57ad9b1c09a99fb613476b1c2297d1e46db3856a0161fe90dda53d59b
+  md5: 7ef4b965af3514ef95098470ae4b67ba
   depends:
   - eigen
   - python
   - ros-kilted-orocos-kdl-vendor
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=14
+  - eigen-abi >=3.4.0.100,<3.4.0.101.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 40451
-  timestamp: 1769484722807
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: f36d26f0573b94b786099867a4cc6aa1fe2847b2fe0aa92f814f606be15ae092
-  md5: d5bf6c47bc8765751665629a54cf7edd
+  size: 41146
+  timestamp: 1775550570491
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 3422dc2ab17e5d3592986f63be0cf47b4f75fa609f2bc30a1c9cd3ae73c97328
+  md5: a0064a5f44443ae7f4939edbe9fc0ab9
   depends:
   - numpy
   - python
@@ -46430,20 +45685,19 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 57521
-  timestamp: 1769485919963
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: f9081932a003c7d2ecc92edaa762fcc3e466041919ef61b3132b018651eded1f
-  md5: 84dd795e1c77962aae003058c3fdb700
+  size: 57730
+  timestamp: 1775602469490
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-geometry-msgs-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 42089a08f1c18725d683e406f6422466f325733e75dc1b9db2e30ff9d235e019
+  md5: 73e04d76f44d839714b9923ebb4c471b
   depends:
   - numpy
   - python
@@ -46453,19 +45707,18 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 57398
-  timestamp: 1769485897123
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 71806f564e4ab1193ca8d50b65cf255c52d1c37358fe0871a60ba383178a8c01
-  md5: b55c7d74a8db391a777f80868a783df1
+  size: 57732
+  timestamp: 1775602670868
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-kdl-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 1a9553d7e3a582e45b214ef824e6591f665b46137f3a68afaddf8ee65302ba71
+  md5: 7cfa7fa4b91e75880eadcd2d6bae6d1f
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46476,20 +45729,19 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 46345
-  timestamp: 1769485910296
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: dd21a5dba0d66ccb9cc4aa8d9383645e4483d57503b6da1009c19bfcad1178da
-  md5: 44726ed46440b5c1cf6ccd5864f84ff3
+  size: 46641
+  timestamp: 1775602459236
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-kdl-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 06041c2db7f767314e2a4d9019430878966f42a068846828eb41ca32058a5f07
+  md5: 0c7b3bb7d77b301c300427dc562b5c9b
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46500,57 +45752,55 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 44962
-  timestamp: 1769485888614
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 0353225b0e0b525f2dbf60e0a0c1c18823027ef3fa83ceb9637a9776a4453a48
-  md5: fefa2ba2abaac62c628ef300196e9b57
+  size: 45378
+  timestamp: 1775602661203
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: dfde05dff89a0ef8b4768fbb8ba09ddd67fca0d8dbb78e38960b81096a655c36
+  md5: 3a0c11422932906d44c3c0f8b606868a
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 257119
-  timestamp: 1769483520948
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: e90401689ba3b5edf3cd678dd5f65a4266224f1fb72305c2ad70a5f216596bef
-  md5: 6faeca1e7bb09cdc89053dd047498097
+  size: 262647
+  timestamp: 1775549695165
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-msgs-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: f76424c238c620b468bba3b9dbf28277ad28e473b755abebca797c2643bfd19c
+  md5: 20767822e9f9059fa6cea4a4b1cef7b5
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-geometry-msgs
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 261854
-  timestamp: 1769483789932
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: e7024c02667f385a4fafc75217786cab04c54a1b045a09631c11757841f6795c
-  md5: bb5308a0a66ce79c3b0228e68e1adf22
+  size: 267501
+  timestamp: 1775549683081
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-py-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: aa7905ea35c876fcef47ade40f5657d94794e4b32eaa78aed9cbd85e23c90ab3
+  md5: 59ed4f9799d5240026f86e0863541cec
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46559,20 +45809,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 58183
-  timestamp: 1769485080772
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 06c9f6bc9183eb2535901315b1f4094a2dd05f7b5a147565938e3d8ea92e77d5
-  md5: b550aef204e73d239276d02e97db4e3e
+  size: 58402
+  timestamp: 1775551287371
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-py-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 9854acf8e67f6e0d7a5134babc748ba299bcd12b52c14223c343eead8194f98d
+  md5: e9dc8cde802ab4d1a7dc18429935b1ef
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46581,19 +45830,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rpyutils
   - ros-kilted-tf2
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 56499
-  timestamp: 1769485200375
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 7df967525743aa81ceede8ca3094e25903fb1c9b273f4aed81c0bad7e362c16e
-  md5: 41520013813a7dd61d019521a2cffda0
+  size: 56776
+  timestamp: 1775551028071
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 5756d1a1b0f0fe143b0628f9c8d96f2e9ad599b3cf1aa118e876591b9a77e57e
+  md5: 08c78fda72d7110881b9b3618d132dba
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46606,20 +45854,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 467234
-  timestamp: 1769485587108
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 9f8f26db6e6ebb6c49e67a2742d410b319de6968705444f3f185abdd7085ac78
-  md5: 1cb1ee195409dd8be53109116bf5a00a
+  size: 467561
+  timestamp: 1775552002735
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 2fc546f854be5e85c7d4df82558495e1501597695cf5deff824ed0c0cd120c90
+  md5: 51ad71a17a79ec7b172f0853f70161a3
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46632,19 +45879,18 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tf2
   - ros-kilted-tf2-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 475440
-  timestamp: 1769485624030
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 06152bb6e22f1cf6300417e08388b475bb2bfed72869bcdfd072e63453c32c19
-  md5: 3ec772c6a3b77ac5ca62a0ca0a9c2a64
+  size: 475943
+  timestamp: 1775551515252
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-ros-py-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 0e3f08946eb176f09efdfebaf563fb08832daf2898eeab71e0d3f5c792e3c872
+  md5: ab6931a9db4f86fe526f1b1f838f9a10
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46655,19 +45901,19 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 49085
-  timestamp: 1769485272336
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: f3cb94fc6d2010051a22689ec912560f47041bb9863d24acb490fe12603220be
-  md5: d34781a75060770fb857cace35940fc0
+  size: 49143
+  timestamp: 1775551655268
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-ros-py-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 59f9140db9e36f320d17d71781f3a8e7ebc84b61601857bc63b7ca100a4ae891
+  md5: 2c91e7611ba9b398450b0db07d65a678
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46678,18 +45924,18 @@ packages:
   - ros-kilted-std-msgs
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 49006
-  timestamp: 1769485371194
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: 8a262055e6abfb19ebf445fe224711d93b4274adf5525437dc00296881f2dd29
-  md5: e1da88141bf6740e9c2b05bf2ff4b3aa
+  size: 49142
+  timestamp: 1775551196900
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: c1062447c9a08ff1282d78bb2e11be9a767bc2f7b3732317b22e3ed2bc5629fe
+  md5: 461b16370f116479dabf54036a15179c
   depends:
   - eigen
   - numpy
@@ -46703,19 +45949,19 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 51083
-  timestamp: 1769486263738
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 5d6a18ab60fbb3ad49485026a197cba104db4e9e1a5ca3005604416b0b1613b1
-  md5: ece90a5b4a121b6a363105c9695ef864
+  size: 51247
+  timestamp: 1775602758853
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-sensor-msgs-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 182204378f8277cf5e69258d3f03701305f2a727d301903d1754568d9c876927
+  md5: 2861d13b51066b1fba8375ce5841ab2a
   depends:
   - eigen
   - numpy
@@ -46729,19 +45975,18 @@ packages:
   - ros-kilted-tf2
   - ros-kilted-tf2-ros
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 50911
-  timestamp: 1769486197079
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.6-np2py312h2ed9cc7_15.conda
-  sha256: d27474658c4d645315348d6c84b884fe797c59c2ea097f2a60805584cdd58a1d
-  md5: d658132bdd621b9a814d9e395741a9a9
+  size: 51303
+  timestamp: 1775610392027
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tf2-tools-0.41.6-np2py312h2ed9cc7_17.conda
+  sha256: 2a7ceec62b7eb646c125cf7e01c3256e10a5d3d9bdd25d645b898cd75ad33fc8
+  md5: 636046a6ff6d4915d4e6fd1a9525b582
   depends:
   - graphviz
   - python
@@ -46751,20 +45996,19 @@ packages:
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 24863
-  timestamp: 1769485661381
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-tools-0.41.6-np2py312h61f2ce4_15.conda
-  sha256: 5617942d2f76542730785ed2df1c70d31978bf12d11f0f4ebd9762446ec1f3ce
-  md5: 186d1af1d968ba74576f7754a8164343
+  size: 24466
+  timestamp: 1775602403543
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tf2-tools-0.41.6-np2py312h61f2ce4_17.conda
+  sha256: 3b033f8639ee5bc0b77e246ba20e3e6adb8a1c9b267a093e481e8bd4d26f00ee
+  md5: f9216cc62bd06dc9b51d7d5788e93c2c
   depends:
   - graphviz
   - python
@@ -46774,85 +46018,84 @@ packages:
   - ros-kilted-tf2-msgs
   - ros-kilted-tf2-py
   - ros-kilted-tf2-ros-py
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: BSD-3-Clause
-  size: 24836
-  timestamp: 1769485679464
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_15.conda
-  sha256: 9a380496ccb6bcd409ed31aed29d922540edf334da9582ced959ba4dbaf4c056
-  md5: 3e60e3276f0e46cdbcf2cdc8af8ba9bb
+  size: 24608
+  timestamp: 1775602597326
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h2ed9cc7_17.conda
+  sha256: 08c70fa04422722a87f2419126983f9a398230238047be913cf86a6ed51ba25b
+  md5: a473818310e452e8e9863ac2855e6360
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - tinyxml2
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24855
-  timestamp: 1769481229257
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h61f2ce4_15.conda
-  sha256: 5967a87f50a953865e388ebe8fbae51405536a60ae76ffcac90da19a87522d76
-  md5: 2bd82eb56c990bff8ef01fd896beeabe
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
   - libstdcxx >=14
   - libgcc >=14
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  license: Apache-2.0
-  size: 24810
-  timestamp: 1769481551862
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.2.0-np2py312h2ed9cc7_15.conda
-  sha256: f5ffb98e8fb05dc49c515bfbccf88b14a873d127767957c4fd3c56650d6c9cf8
-  md5: fe33b5044c85fa53fd4aec5addb787f7
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  license: CC0-1.0
-  size: 33904
-  timestamp: 1769481221467
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.2.0-np2py312h61f2ce4_15.conda
-  sha256: 6279788b2c19a7c55272b120c9d8666134e918c994cf71667b1427c3d63ff872
-  md5: 007883280d7e3b48d08c3f5d36dfa179
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24783
+  timestamp: 1775547438429
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tinyxml2-vendor-0.10.1-np2py312h61f2ce4_17.conda
+  sha256: adfa4935899f320707cc3a5d45d6e0a82362a6cc29f4f509e02196432f26c475
+  md5: b6ae87e2b14974971289eda7d39f2984
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - tinyxml2
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
+  - tinyxml2 >=11.0.0,<11.1.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0
+  size: 24939
+  timestamp: 1775547665507
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.2.0-np2py312h2ed9cc7_17.conda
+  sha256: a0169254656029bf137f856bf58b761709a2df58c024e42dd8b3d301a469b7fa
+  md5: 6303a35bee2766903718b466f1cc098f
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
   license: CC0-1.0
-  size: 33948
-  timestamp: 1769481544626
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-1.4.2-np2py312h2ed9cc7_15.conda
-  sha256: a7bb9d7898ba7bc9d0ef691d9824c3abd60e30b0d67a259b09f18248247f2984
-  md5: f2862d19246f90b970f574713e64d064
+  size: 33911
+  timestamp: 1775547443736
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.2.0-np2py312h61f2ce4_17.conda
+  sha256: 9f8f24e1ebe814d4518a5b8c2bf603e3858fae000ac58e99432c245cfe518138
+  md5: fb9f8875549cb6d4a3c9ae613d75aec0
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: CC0-1.0
+  size: 34084
+  timestamp: 1775547670382
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-1.4.2-np2py312h2ed9cc7_17.conda
+  sha256: 50ea9585a7a60448c690f762d8d3aef8c6c1305f643ed2d23724a6cbb44ed788
+  md5: e651dae4514eafb42719ea307750dbfb
   depends:
   - python
   - ros-kilted-rclcpp
@@ -46862,20 +46105,19 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
   - ros-kilted-topic-tools-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 279933
-  timestamp: 1769485279835
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-1.4.2-np2py312h61f2ce4_15.conda
-  sha256: 60a452cf13b628a1f775b60751868d0040bfd281373cb4e09290c2a2161302d7
-  md5: f7175c082be95af37aa0df09c76af0b3
+  size: 280278
+  timestamp: 1775551666898
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-1.4.2-np2py312h61f2ce4_17.conda
+  sha256: 6c6264e7670ac9d2a6055ffa3c1767d9ace4bcee1d895c37bfe564abea54d905
+  md5: 4e4a55479fce259b8cb6f71e411cf149
   depends:
   - python
   - ros-kilted-rclcpp
@@ -46885,92 +46127,88 @@ packages:
   - ros-kilted-ros2cli
   - ros-kilted-rosidl-runtime-py
   - ros-kilted-topic-tools-interfaces
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 281867
-  timestamp: 1769485379146
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h2ed9cc7_15.conda
-  sha256: 7fd9592f877858a24a25fd9aaccde26fcbf90e7250ba22ad27b13ffe8e0458d9
-  md5: 6790882401463c19df912e65e668949e
+  size: 282342
+  timestamp: 1775551205161
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h2ed9cc7_17.conda
+  sha256: 392d9c4e19c1c40a39d06228c132fa32e41175be1a4c85141af804e4559b849b
+  md5: 67c5d988a019abfc27353e4c683cd8b2
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 317824
-  timestamp: 1769483164249
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h61f2ce4_15.conda
-  sha256: a19ed5104f7a2ea955ce9f689fc0674776f40537d5552e188818b148cd82eab0
-  md5: e1da1f9c85d45033f613961f1c9df3be
+  size: 322077
+  timestamp: 1775549326215
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-topic-tools-interfaces-1.4.2-np2py312h61f2ce4_17.conda
+  sha256: 9029a4b75bc0d91ff72608837d083f6bf68f4586ca18b03c0c7bb99179301395
+  md5: 01eed32b6bbb06fd773fda543e4d7307
   depends:
   - python
   - ros-kilted-builtin-interfaces
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libgcc >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 321808
-  timestamp: 1769483452277
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_15.conda
-  sha256: cd49380f0231563273d7b2b74ae3235dabe64d2cbc1a83b4e67785c34afdbce5
-  md5: 9ce955faabad6097ffd847b986c313a6
+  size: 326350
+  timestamp: 1775549345621
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_17.conda
+  sha256: 9f48c07d31ae6b3006380b496457b53d1b99b5d12cd7378be48d585a20315634
+  md5: c3e695824ffe01938410661abea237b7
   depends:
   - lttng-ust
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - lttng-ust >=2.13.9,<2.14.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - lttng-ust >=2.13.9,<2.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 76254
-  timestamp: 1769482314136
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h61f2ce4_15.conda
-  sha256: 7601ae9d245413a134eea42492b6875366c1c7000a003edc092827f8377c10ae
-  md5: fb67367b5e5149c3689a902295b111b5
+  size: 76346
+  timestamp: 1775548593677
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h61f2ce4_17.conda
+  sha256: 8876ccdadb601887855b21140118b93bde5a1d13fd4ffc880ed1e99e23c7f81a
+  md5: cc0cc7649bd6bf7eb4499f4aaac5ccb2
   depends:
   - lttng-ust
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - lttng-ust >=2.13.9,<2.14.0a0
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - lttng-ust >=2.13.9,<2.14.0a0
   license: Apache-2.0
-  size: 75511
-  timestamp: 1769482535348
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: f4be2ab368049eb4e1daa33efc8303e23222a4937a96a952e27090290424cbaa
-  md5: 21993146f7a41ca3e0fc104635c3dce6
+  size: 75715
+  timestamp: 1775548564251
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: fe6ebb7b00093a6c8999df0db06d06e0098c51a0d3fc879c2b7d53294a3ea6c8
+  md5: 6ac65657c02fa4898618dc8dc48b0c72
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46978,19 +46216,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
-  size: 148135
-  timestamp: 1769483622608
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: c15a7941507fe8eec3e746291be8f32f1cf0a58f8671f1d60ee55d9fb659e726
-  md5: da322a1986861d9d5bf670c6c06ce836
+  size: 151655
+  timestamp: 1775549794297
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: cd8a6f666624a0889da995bdbd9652287865046c9f76cce674fe9f90d6178b07
+  md5: b97b572a57b6555741d06040fbfa5f64
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -46998,126 +46236,121 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: Apache-2.0
-  size: 151778
-  timestamp: 1769483863964
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
-  sha256: 3f95072511a525047578375234c3294e68cf4cbda58f11399102fad56278f328
-  md5: 06d29b78a2456161e1885c8f6a516027
+  size: 154981
+  timestamp: 1775549760995
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.1-np2py312h2ed9cc7_17.conda
+  sha256: 9512668d66b1e0199575324e44521f2df06d34f0449379f4c1734b28a02e33ef
+  md5: f778a5a8f1f134b668307f49c514da49
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
   license: Apache-2.0
-  size: 231650
-  timestamp: 1769483041168
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.0-np2py312h61f2ce4_15.conda
-  sha256: a2a4f49c2d523e36fa737bee854ef4f5a452294090ac95873e9cbcbf1eb67350
-  md5: 9a232f188f550199e97a4443724eb717
+  size: 238904
+  timestamp: 1775549253022
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.1-np2py312h61f2ce4_17.conda
+  sha256: de81d022d2355e0ae83536cd76891f95027a896ade9156b3903be1d5220a1415
+  md5: 59edb328662de03d199ba637b4a9c777
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
   - ros-kilted-service-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
-  - libstdcxx >=14
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
+  - libstdcxx >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 235713
-  timestamp: 1769483323541
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_15.conda
-  sha256: 5f16f44a386f76d3f19f53e3c7fba9b725ea0da9d112301ffdea4a31fb5e4319
-  md5: b11182b2740e933097cd1c47567c4468
+  size: 240936
+  timestamp: 1775549259164
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_17.conda
+  sha256: f98e582d0075803efd6abd804e9bf878ad1e73f022da697e80c650fe91c61f78
+  md5: f4482bcc85149c765462a18568586813
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - uncrustify
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
   - uncrustify >=0.81.0,<0.82.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   license: Apache-2.0 OR GPL-2.0-only
-  size: 23220
-  timestamp: 1769481210362
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h61f2ce4_15.conda
-  sha256: b9253326bade6d30c112f775176ca8aabe86deb5ed9790f125b07366c00136a5
-  md5: 693db053ceeac95109fd796de26738b8
+  size: 23181
+  timestamp: 1775547450582
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h61f2ce4_17.conda
+  sha256: 5476275d7a471f697697e06859d74731f721e311ea2a4382a8a502e075655ee1
+  md5: 6b33824278733c6d88e3a797c0585000
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - uncrustify
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - uncrustify >=0.81.0,<0.82.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - uncrustify >=0.81.0,<0.82.0a0
   license: Apache-2.0 OR GPL-2.0-only
-  size: 23223
-  timestamp: 1769481543027
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_15.conda
-  sha256: 26ded34629a4c8fb6f99716c6de6fee16b937f20e27b4da1274ca36c555db5e9
-  md5: d38d14edffcf6cab6090a4e4d4686856
+  size: 23308
+  timestamp: 1775547662814
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_17.conda
+  sha256: a6dd7b813f2c78f105123fed06a430e8035b0cc2dc47852d96b30d8a8fc7484b
+  md5: 62c529c0ddeffa4946a095f4a044bacb
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 72136
-  timestamp: 1769482969283
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h61f2ce4_15.conda
-  sha256: 017bc38bc1d49a5acf9a4a4797304df3e9d2921b42db0b413771b9c14e3b5562
-  md5: 959c6949137ac1dcfad9e3bbb47df185
+  size: 74256
+  timestamp: 1775549179433
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h61f2ce4_17.conda
+  sha256: f18da512e284e064e4febb19e1a56911caa33e9fa46ce28bb87aefe39e2642d7
+  md5: d3f7755bb085011c82267996b89459f6
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-rosidl-core-runtime
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 75349
-  timestamp: 1769483244717
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.3-np2py312h2ed9cc7_15.conda
-  sha256: 3104ffeccf3f84350bf47d365eb80d8c818dab66bbac50f437023e61bcdd4285
-  md5: 423a2ea3c4ed766b0829a9d03b157206
+  size: 77216
+  timestamp: 1775549177306
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-2.12.3-np2py312h2ed9cc7_17.conda
+  sha256: eff2ee8e0f345de92220f159822a9e08cabe454327356a8c990517911d8ddc8c
+  md5: 5934bd9126719774478a96fad66c16b9
   depends:
   - python
   - ros-kilted-pluginlib
@@ -47127,20 +46360,19 @@ packages:
   - ros-kilted-urdf-parser-plugin
   - ros-kilted-urdfdom
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 158382
-  timestamp: 1769484643634
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.3-np2py312h61f2ce4_15.conda
-  sha256: a37d2057f451baf368c3ce989d043f6e26d2a886a6c80d717478a612e247a631
-  md5: 2dd323048440eda560de585fb3c460fd
+  size: 158488
+  timestamp: 1775550842696
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-2.12.3-np2py312h61f2ce4_17.conda
+  sha256: ea6d7ee625c33bb403e0abde0db45fc1972b301a87356f17752f2b42ff91b20d
+  md5: 4738a787a2fe8b7fda0921043e6e9484
   depends:
   - python
   - ros-kilted-pluginlib
@@ -47150,52 +46382,51 @@ packages:
   - ros-kilted-urdf-parser-plugin
   - ros-kilted-urdfdom
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 157128
-  timestamp: 1769484789973
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h2ed9cc7_15.conda
-  sha256: 575ecde79595eebbbe98fce0e97a47274fe58c15c50d5542ebce637eb424ddce
-  md5: 3073eb50936e6a9c236ac58a8e0e92b2
+  size: 157321
+  timestamp: 1775550634538
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h2ed9cc7_17.conda
+  sha256: 352f7236608601196c23f28d9155db14a5ea4c4d649c34c0c1602ad092a5a181
+  md5: a3651113dc4733dd8471f8b37c998e65
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 33154
-  timestamp: 1769484356718
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h61f2ce4_15.conda
-  sha256: 030d5a4cf7f2b59427a5e39b642cc2b52f8a5cff732c076beeb0733b5b6ab9a6
-  md5: 70bd0543d6d3e4c875f21d218d39988f
+  size: 33229
+  timestamp: 1775550543412
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdf-parser-plugin-2.12.3-np2py312h61f2ce4_17.conda
+  sha256: b50d9d11992d7ab50ddc3591f4261dfd8121c5c66727171c861fec7e3e2ba59e
+  md5: d576339394e538dd2cbf00ab359af247
   depends:
   - python
   - ros-kilted-ros-workspace
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
-  size: 33109
-  timestamp: 1769484519638
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_15.conda
-  sha256: 6092d7caa2d0be547644533afe7fa731cd42b997b371e7d6066dfe21e7fc3dfe
-  md5: b419a072b2e525f4e17fc48d0dcde939
+  size: 33274
+  timestamp: 1775550385805
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-4.0.1-py312h24bf083_17.conda
+  sha256: 4d9ad97fd0373f52347d0fc90b92d13c9daa6b324e0b9c29774321449ba94859
+  md5: ac54b723de8c723cc4c070021e5c1574
   depends:
   - console_bridge
   - python
@@ -47203,19 +46434,19 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
   - urdfdom >=4.0.1,<4.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - tinyxml2 >=11.0.0,<11.1.0a0
-  - console_bridge >=1.0.2,<1.1.0a0
   - python_abi 3.12.* *_cp312
+  - console_bridge >=1.0.2,<1.1.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
   license: BSD-3-Clause
-  size: 8295
-  timestamp: 1769482401161
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_15.conda
-  sha256: df58b9946e8afe2778e2e4e0c44601594eaef339a891b0c83bcf2a5d83c47418
-  md5: ccc2a0a30be03d67eef54211446d9580
+  size: 8174
+  timestamp: 1775548680943
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-4.0.1-py312h9804fc4_17.conda
+  sha256: 587ba2e02ac28b6f17a5ed461e4ee8ad2b78582bc62999c814db37b5a7b21260
+  md5: a3ab45b1daa438a66b7fd38470907e06
   depends:
   - console_bridge
   - python
@@ -47223,45 +46454,45 @@ packages:
   - ros-kilted-ros-workspace
   - ros-kilted-tinyxml2-vendor
   - ros-kilted-urdfdom-headers
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - tinyxml2
   - urdfdom >=4.0.1,<4.1.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.12.* *_cp312
   - tinyxml2 >=11.0.0,<11.1.0a0
   license: BSD-3-Clause
-  size: 8169
-  timestamp: 1769482628645
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_15.conda
-  sha256: c02a1b50448587108941939219fcc2ac964ca791a95c706d7492f28026d3bdc9
-  md5: 6cf80d57b78931f11da1c126e6671494
+  size: 8168
+  timestamp: 1775548654083
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-urdfdom-headers-1.1.2-py312h24bf083_17.conda
+  sha256: e954d6abcc92e25e43285de99114662315a6ca28b8266001c8c9222eb55df92d
+  md5: c41b6369f26e4aad1643929256fbd423
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - urdfdom_headers >=1.1.2,<1.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 7430
-  timestamp: 1769480718175
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_15.conda
-  sha256: 125aa9f652eb71537961c4f5f2d09d91d8b74fb7790aa9783f5575f61f684f4d
-  md5: c66367e189131dd0cee923e3627df0e9
+  size: 7301
+  timestamp: 1775546891156
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-urdfdom-headers-1.1.2-py312h9804fc4_17.conda
+  sha256: fd79593505aa1eaebeb6b747f0d453302a81381ca0a11756eaa004db20a9369a
+  md5: e42e6a3ce21276caf3e76e9087ba6c1b
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - urdfdom_headers >=1.1.2,<1.2.0a0
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 7316
-  timestamp: 1769481005939
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.1-np2py312h2ed9cc7_15.conda
-  sha256: 388a00d4daa1d8c276665ffb65397926551a113ab41e63d89a82f4472945df84
-  md5: e6fe410aaceb38dca2d90880c05a55fd
+  size: 7272
+  timestamp: 1775547141691
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-visualization-msgs-5.5.2-np2py312h2ed9cc7_17.conda
+  sha256: 1dcc37fcb6d2310c46d39b3c60c425f7dc98a0ad213465318023fc775cb135b2
+  md5: 827644d6ac0e61684b4560c96a808e12
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -47270,20 +46501,19 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 373668
-  timestamp: 1769483881721
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-visualization-msgs-5.5.1-np2py312h61f2ce4_15.conda
-  sha256: 9bb8b2cfe3e656aa571e56489c0d6b10b9dd8619a68fdf04033cf86445cb3663
-  md5: c59b619249d0ed1a08ae9b88f10d921c
+  size: 381360
+  timestamp: 1775550068206
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-visualization-msgs-5.5.2-np2py312h61f2ce4_17.conda
+  sha256: 87105b8f6486458cb606f394bffc38836f4899b88ae16da501c67af3cdc3e3d7
+  md5: 8b054b4d5f86d6c271f50f99cafbf83a
   depends:
   - python
   - ros-kilted-builtin-interfaces
@@ -47292,123 +46522,120 @@ packages:
   - ros-kilted-rosidl-default-runtime
   - ros-kilted-sensor-msgs
   - ros-kilted-std-msgs
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0
-  size: 379395
-  timestamp: 1769484127070
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-xacro-2.1.1-np2py312h2ed9cc7_15.conda
-  sha256: 9c6f4c38de861f82ac9fc10a8a6c62eb360c9937420881123c57f193d9329db7
-  md5: 6c087347d75dd58f4a72a1bce1a24273
+  size: 387367
+  timestamp: 1775549983577
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-xacro-2.1.1-np2py312h2ed9cc7_17.conda
+  sha256: c7d8dd6adbc299f73f48b37a5325c70942640c21c48b464f829e34b5d84983b1
+  md5: bc0f83b671738b3adabc340ce3dbe007
   depends:
   - python
   - pyyaml
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: BSD-3-Clause
-  size: 76339
-  timestamp: 1769481484977
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-xacro-2.1.1-np2py312h61f2ce4_15.conda
-  sha256: 92f159614115edd971196ca29039a6a44b6412dc13b23f2d5bf723cfc48a9f83
-  md5: 52321d70a65127b3f3a02e88c7d0887d
+  size: 76296
+  timestamp: 1775547792994
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-xacro-2.1.1-np2py312h61f2ce4_17.conda
+  sha256: c5f53b8ce8dd2a851eb321f2d86632f7a134cb2a6aa134edd6d6316182857b51
+  md5: 81372c51d25e300e6ef250f572ee37ad
   depends:
   - python
   - pyyaml
   - ros-kilted-ament-index-python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - libstdcxx >=14
   - libgcc >=14
-  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  size: 76286
-  timestamp: 1769481817359
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h2ed9cc7_15.conda
-  sha256: dcdb8712c487184fa884109e66f5e39d22729d2f05bfb69235a8672729ae560e
-  md5: c2a25b0a03b980493f9e6a79082c8a36
+  size: 76393
+  timestamp: 1775547936581
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h2ed9cc7_17.conda
+  sha256: 832858b2289d3a5fb48e5a87319acb206eb50459bac57653ad38860974053e0e
+  md5: 6b470ae56af642560c4431cddf398789
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
-  - yaml-cpp
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - yaml-cpp >=0.8.0,<0.9.0a0
-  - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
-  license: Apache-2.0 OR MIT
-  size: 23161
-  timestamp: 1769481208517
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h61f2ce4_15.conda
-  sha256: 70ad975e36d83f3c92bc6ccf875a5ccfadec5c3c8fe75382dab0bba171c723dd
-  md5: c7bc0c48281ad3c368df53170e55ba3a
-  depends:
-  - python
-  - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - yaml-cpp
   - libstdcxx >=14
   - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
-  - numpy >=1.23,<3
+  - __glibc >=2.17,<3.0.a0
   - yaml-cpp >=0.8.0,<0.9.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   license: Apache-2.0 OR MIT
-  size: 23107
-  timestamp: 1769481545115
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_15.conda
-  sha256: 4663aafaec3ab42c4f2d497cf9ccd982309b208461421656ede91057d532d7b6
-  md5: 936e17890917944e06f61be5123e13c5
+  size: 23136
+  timestamp: 1775547438484
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-yaml-cpp-vendor-9.1.0-np2py312h61f2ce4_17.conda
+  sha256: c1bb76e7669e901a7bf9b606af66f992fbe4d03c1f5f82850252d6aee618e1c6
+  md5: 310d3dd6fe844150a2c3e337f28880e9
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
+  - yaml-cpp
+  - libgcc >=14
+  - libstdcxx >=14
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
+  - python_abi 3.12.* *_cp312
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - numpy >=1.23,<3
+  license: Apache-2.0 OR MIT
+  size: 23216
+  timestamp: 1775547676665
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_17.conda
+  sha256: 15fbdb389dd78aea7e3dc26354535f0d8d5a7d854254a401398eecafe807d1ad
+  md5: d023688f21c83f92abd19a49a78f2303
+  depends:
+  - python
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.14.* kilted_*
   - zstd
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
   - numpy >=1.23,<3
-  - zstd >=1.5.7,<1.6.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - python_abi 3.12.* *_cp312
+  - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 24045
-  timestamp: 1769481212852
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_15.conda
-  sha256: 3ad4df18443f79d33480c5f1035003296b6e92800b05aa03ffecc309a586c48a
-  md5: c987f9a3d319647cc37541fc09c2b26e
+  size: 24032
+  timestamp: 1775547443831
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_17.conda
+  sha256: 0344dd44c02c1ca4cd70e4bfae76944ee20983e2fee29d18872ec2b94cbae17f
+  md5: a839583400f6c6db3e304821b1337a9e
   depends:
   - python
   - ros-kilted-ros-workspace
-  - ros2-distro-mutex 0.13.* kilted_*
+  - ros2-distro-mutex 0.14.* kilted_*
   - zstd
   - libstdcxx >=14
   - libgcc >=14
   - python_abi 3.12.* *_cp312
-  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - ros2-distro-mutex >=0.14.0,<0.15.0a0
   - numpy >=1.23,<3
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 OR BSD-3-Clause
-  size: 24030
-  timestamp: 1769481549917
+  size: 24128
+  timestamp: 1775547682168
 - conda: https://prefix.dev/robostack-humble/linux-64/ros2-distro-mutex-0.8.0-humble_15.conda
   sha256: 947f8cfc4190688120ded27672652f0ea7ff93f340a025efe2fa6ba507499111
   md5: 2eb1988691481e22fd565034d988a3bb
@@ -47463,32 +46690,32 @@ packages:
   license: BSD-3-Clause
   size: 2334
   timestamp: 1771181488082
-- conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
-  sha256: 601514ec30473279742045a389ca0fabaa1374dd9101a472fc675894078f53e5
-  md5: c651abe39b40eb47c091c4ad2c922cf7
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.14.0-kilted_17.conda
+  sha256: a873b2e7941451eca28a3e21709fed27f2e1c459d161926d19d216ff6be7b6a6
+  md5: 88effae5298227990e25f078da06b982
   constrains:
   - libboost 1.88.*
   - libboost-devel 1.88.*
   - pcl 1.15.1.*
   - gazebo 11.*
-  - libprotobuf 6.31.1.*
-  - vtk 9.5.2.*
+  - libprotobuf 6.33.5.*
+  - vtk 9.6.0.*
   license: BSD-3-Clause
-  size: 2338
-  timestamp: 1769480640069
-- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.13.0-kilted_15.conda
-  sha256: 898683793feac9162552ff07bbe83ef3dee82edd9e8d9e7b9256740308834e58
-  md5: d8ade4fba910f25a090d7d0bcdb13e20
+  size: 2372
+  timestamp: 1775546815643
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.14.0-kilted_17.conda
+  sha256: 0f318c75b8a8c89484bb908b2be21b1c241e89549796fae16aaf625860a01972
+  md5: ea912d86315bdac21dcaefe7bf94e006
   constrains:
   - libboost 1.88.*
   - libboost-devel 1.88.*
   - pcl 1.15.1.*
   - gazebo 11.*
-  - libprotobuf 6.31.1.*
-  - vtk 9.5.2.*
+  - libprotobuf 6.33.5.*
+  - vtk 9.6.0.*
   license: BSD-3-Clause
-  size: 2343
-  timestamp: 1769480922749
+  size: 2369
+  timestamp: 1775547071835
 - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
   sha256: bff3b2fe7afe35125669ffcb7d6153db78070a753e1e4ac3b3d8d198eb6d6982
   md5: b7ed380a9088b543e06a4f73985ed03a
@@ -47518,30 +46745,6 @@ packages:
   - pkg:pypi/rospkg?source=hash-mapping
   size: 31852
   timestamp: 1766125246079
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-3.4.8-h498564d_0.conda
-  sha256: 2e5fddb76b71217ee81f43a97cdad2fdeaf6e46ca4b51106677f6f30ddee2dfc
-  md5: 10d1bec841bb5ae68b053387d48f7f07
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gdbm >=1.18,<1.19.0a0
-  - gmp >=6.3.0,<7.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.4,<4.0a0
-  - readline >=8.3,<9.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  constrains:
-  - __glibc >=2.17
-  track_features:
-  - rb34
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 13095624
-  timestamp: 1765964101082
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-4.0.2-h95e6935_0.conda
   sha256: b3ce64914afc96a2744c0715292e107970521e0cc0384d32d75bc1792201314d
   md5: 9c491e375ff5da48f9ec10f02d5b9d73
@@ -47563,28 +46766,6 @@ packages:
   purls: []
   size: 17293778
   timestamp: 1773939984132
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-3.4.8-h3df7994_0.conda
-  sha256: cd495abae996e5da856e966f799a52f08295d8150334629e07ef8e286dfd5c2e
-  md5: 8994f0f9c528bbde9a2809d7a7f04b42
-  depends:
-  - gmp >=6.3.0,<7.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.4,<4.0a0
-  - readline >=8.3,<9.0a0
-  - yaml >=0.2.5,<0.3.0a0
-  constrains:
-  - __glibc >=2.17
-  track_features:
-  - rb34
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 10221801
-  timestamp: 1765964015229
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-4.0.2-h706e587_0.conda
   sha256: f4ae2c25a0995f0d01309faf6d1f7600727355d0336744af6acb1816312dbb3a
   md5: c16b4794ee25cb5dbb79bf8e50226489
@@ -47652,7 +46833,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   size: 17109648
   timestamp: 1771880675810
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312he5b0e10_0.conda
@@ -47871,21 +47052,6 @@ packages:
   purls: []
   size: 195699
   timestamp: 1767781668042
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-h04a0ce9_0.conda
-  sha256: c9af81e7830d9c4b67a7f48e512d060df2676b29cac59e3b31f09dbfcee29c58
-  md5: 7d9d7efe9541d4bb71b5934e8ee348ea
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libsqlite 3.52.0 hf4e2dac_0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  license: blessing
-  purls: []
-  size: 203641
-  timestamp: 1772818888368
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-h04a0ce9_0.conda
   sha256: a0e35087ebf0720fa758cb261583bee0a328143238524ea47625b37108280291
   md5: dc540e5bd5616d83a1ec46af8315ff98
@@ -47901,20 +47067,6 @@ packages:
   purls: []
   size: 205091
   timestamp: 1775753763547
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.52.0-hf1c7be2_0.conda
-  sha256: 4f8523f5341f0d9e1547085206c6c1f71f9fc7c277443ca363a8cf98add8fc01
-  md5: d9634079df93a65ee045b3c75f35cae1
-  depends:
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libsqlite 3.52.0 h10b116e_0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - readline >=8.3,<9.0a0
-  license: blessing
-  purls: []
-  size: 209416
-  timestamp: 1772818891689
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.0-he8854b5_0.conda
   sha256: ed918d33e068538d94e46f853441673b3b67f08f882ca7fba90288e7c34e83ff
   md5: ad8164bdeece883b825c50639c0c4725
@@ -48280,18 +47432,6 @@ packages:
   purls: []
   size: 724597
   timestamp: 1776377875913
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.81.0-h5888daf_0.conda
-  sha256: f0b3ad46b173de03c45134b16d7be0b5bdaff344cccb6a4d205850809c1a4dca
-  md5: c2310445798370fe622fc6b03d79a3a4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 650318
-  timestamp: 1747514389910
 - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.82.0-h54a6638_0.conda
   sha256: 68d2f4f7ab552bd3fa666dd2df647da263fcfc255ecb77f791bb2555a37a5ec7
   md5: e4c0008ee8608dcb18e59163312d5124
@@ -48304,17 +47444,6 @@ packages:
   purls: []
   size: 724865
   timestamp: 1776382105316
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h5ad3122_0.conda
-  sha256: d886da4b98a0b38eebcfc80a0818def69d4d735c98f548d678dcac1f1e859c4c
-  md5: 0a56cd95bc8308d26db08135328b4f62
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 636572
-  timestamp: 1747514438016
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.81.0-h7ac5ae9_2.conda
   sha256: f7adc3903f22bd0d721a56f0e2f69a132a5e33f03850994e1f19c0e01b61201e
   md5: bb06b4af7f8cb9781a5ee00957586e2d
@@ -49131,6 +48260,23 @@ packages:
   purls: []
   size: 64726
   timestamp: 1769445214628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.19-hb03c661_0.conda
+  sha256: 35ab3940a4722b09270cbdb24db9fe1115989a1813911691504aa6c3cadd0a96
+  md5: 53e0ca6ba7254ca3a5e3048c84f63655
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext
+  - libasprintf >=0.25.1,<1.0a0
+  - libgcc >=14
+  - libgettextpo >=0.25.1,<1.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 64386
+  timestamp: 1776789976572
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.18-he30d5cf_0.conda
   sha256: 0edac6d4458debe8d395ebab554fc830f9f074bfa2b7ec34bbdbe231beb4999a
   md5: dc247d942ba0e512897e9dfc03d86a65
@@ -49147,6 +48293,22 @@ packages:
   purls: []
   size: 70967
   timestamp: 1769445217455
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.19-he30d5cf_0.conda
+  sha256: 23dc8dc2daf94defdd38ff1743b8a7630ea321b4ee24ed547870fff9f513bf68
+  md5: e8250ed7c292f7c2fe1ca91def81e558
+  depends:
+  - gettext
+  - libasprintf >=0.25.1,<1.0a0
+  - libgcc >=14
+  - libgettextpo >=0.25.1,<1.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 71037
+  timestamp: 1776789996073
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
   sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
   md5: e192019153591938acf7322b6459d36e
@@ -49403,18 +48565,6 @@ packages:
   - pkg:pypi/zipp?source=compressed-mapping
   size: 24461
   timestamp: 1776131454755
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
-  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib 1.3.1 hb9d3cd8_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 92286
-  timestamp: 1727963153079
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a
@@ -49426,17 +48576,6 @@ packages:
   purls: []
   size: 95931
   timestamp: 1774072620848
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
-  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
-  md5: bc230abb5d21b63ff4799b0e75204783
-  depends:
-  - libgcc >=13
-  - libzlib 1.3.1 h86ecc28_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 95582
-  timestamp: 1727963203597
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
   sha256: d651731b45f2d84591881da3ce3e4107a9ba6709fe790dbd5f7b8d9c89a02ed7
   md5: 493587274c81b34d198b085b46a86eaa

--- a/roboplan_ros_cpp/CMakeLists.txt
+++ b/roboplan_ros_cpp/CMakeLists.txt
@@ -33,6 +33,14 @@ target_link_libraries(roboplan_ros_cpp
     ${trajectory_msgs_TARGETS}
     ${builtin_interfaces_TARGETS}
 )
+# Temp fix for: https://github.com/RoboStack/ros-kilted/issues/76
+# Manually link against python to ensure it is loaded in the process.
+find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+target_link_libraries(roboplan_ros_cpp PRIVATE
+  "-Wl,--no-as-needed"
+  Python::Python
+  "-Wl,--as-needed"
+)
 set_property(TARGET roboplan_ros_cpp PROPERTY CXX_STANDARD 20)
 ament_export_dependencies(
   roboplan
@@ -52,7 +60,6 @@ install(
 install(DIRECTORY include/ DESTINATION include)
 
 # For nanobind python bindings
-find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
 find_package(roboplan_bindings REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(builtin_interfaces REQUIRED)


### PR DESCRIPTION
In regards to #35 

### To Reproduce

I updated the kilted environment to build _17 in robostack (was on _15 before)

1. checkout this branch in a clean workspace (`rm -r build/* install/* log/*`)
2. install deps `pixi install -e kilted --frozen`
3. build it `pixi run -e kilted build`
4. test it in a shell:
  ```
  $ pixi shell -e kilted
  $ ./build/roboplan_ros_cpp/test/test_type_conversions_cpp 
./build/roboplan_ros_cpp/test/test_type_conversions_cpp: symbol lookup error: /home/parallels/ROS/seabass/roboplan-ros/.pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so: undefined symbol: PyObject_GetAttrString
  ```


### The Issue

The pixi lockfile update bumped all kilted message packages from build _15 to build _17. The issue is that now `_rosidl_generator_py.so` files that are static-pie linked with no dynamic dependencies — including no linkage to libpython. Any C++ binary that transitively loads these libraries crashes, as we see above.

On this branch (build _17):

```
# Kilted _17 — static-pie, no dependencies
$  file .pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so
.pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), static-pie linked, not stripped

# crickets....
$  readelf -d .pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so | grep NEEDED
```

On main (build _15):

```
# kilted _15, note it is dynamically linked
 $  file .pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so
.pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, not stripped

# with the dep as expected
$  readelf -d .pixi/envs/kilted/lib/libunique_identifier_msgs__rosidl_generator_py.so | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libpython3.12.so.1.0]
```

I believe this is an issue in robostack... will ask