### PR TITLE
Allow visualizing joint groups

### DIFF
--- a/roboplan_ros_examples/roboplan_ros_franka/scripts/plan_and_execute_node.py
+++ b/roboplan_ros_examples/roboplan_ros_franka/scripts/plan_and_execute_node.py
@@ -255,6 +255,7 @@ class PlanAndExecuteNode(Node):
         # IK determined target pose in blue
         self._ik_visualizer = RoboplanVisualizer(
             scene=self._scene,
+            group_name=self._joint_group,
             urdf_xml=urdf_xml,
             frame_id="world",
             ns="roboplan_ik",
@@ -268,6 +269,7 @@ class PlanAndExecuteNode(Node):
         # published in green.
         self._traj_visualizer = RoboplanVisualizer(
             scene=self._scene,
+            group_name=self._joint_group,
             urdf_xml=urdf_xml,
             frame_id="world",
             ns="roboplan_traj",

--- a/roboplan_ros_visualization/bindings/python/roboplan_ros/visualization/_visualization_ext.pyi
+++ b/roboplan_ros_visualization/bindings/python/roboplan_ros/visualization/_visualization_ext.pyi
@@ -11,10 +11,17 @@ class RoboplanVisualizer:
     Tool to build RViz MarkerArray messages from a RoboPlan scene and joint configuration.
     """
 
-    def __init__(self, scene: roboplan.core._core_ext.Scene, urdf_xml: str, frame_id: str = 'world', ns: str = '/roboplan', color: object | None = None) -> None: ...
+    def __init__(self, scene: roboplan.core._core_ext.Scene, urdf_xml: str, frame_id: str = 'world', ns: str = '/roboplan', group_name: str = '', color: object | None = None) -> None: ...
 
     def markers_from_configuration(self, q: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]) -> object:
-        """Compute marker array for the given joint configuration."""
+        """
+        Compute marker array for the given joint configuration, restricted to the currently selected joint group (see the constructor and set_group).
+        """
+
+    def set_group(self, group_name: str) -> None:
+        """
+        Select the joint group whose links are rendered. Pass an empty string for the whole scene. Raises if the group name is not found in the scene.
+        """
 
     def clear_markers(self) -> object:
         """Return a MarkerArray that deletes all previously published markers."""

--- a/roboplan_ros_visualization/bindings/src/roboplan_ros_visualization_bindings.cpp
+++ b/roboplan_ros_visualization/bindings/src/roboplan_ros_visualization_bindings.cpp
@@ -48,7 +48,8 @@ NB_MODULE(_visualization_ext, m) {
           "__init__",
           [](roboplan_ros_visualization::RoboplanVisualizer* self,
              std::shared_ptr<const roboplan::Scene> scene, const std::string& urdf_xml,
-             const std::string& frame_id, const std::string& ns, nb::handle py_color) {
+             const std::string& frame_id, const std::string& ns, const std::string& group_name,
+             nb::handle py_color) {
             std::optional<std_msgs::msg::ColorRGBA> color = std::nullopt;
             if (!py_color.is_none()) {
               color = pyToCppMsg<std_msgs::msg::ColorRGBA>(py_color);
@@ -56,18 +57,23 @@ NB_MODULE(_visualization_ext, m) {
             // nanobind will pre-allocate memory for the object, so we just construct the object
             // directly there in this lambda. This is messy but ensures no duplication and correct
             // ownership.
-            new (self) roboplan_ros_visualization::RoboplanVisualizer(std::move(scene), urdf_xml,
-                                                                      frame_id, ns, color);
+            new (self) roboplan_ros_visualization::RoboplanVisualizer(
+                std::move(scene), urdf_xml, frame_id, ns, group_name, color);
           },
           "scene"_a, "urdf_xml"_a, "frame_id"_a = "world", "ns"_a = "/roboplan",
-          "color"_a = nb::none())
+          "group_name"_a = "", "color"_a = nb::none())
       .def(
           "markers_from_configuration",
           [MarkerArray](roboplan_ros_visualization::RoboplanVisualizer& self,
                         const Eigen::VectorXd& q) {
             return cppToPyMsg(self.markers_from_configuration(q), MarkerArray);
           },
-          "q"_a, "Compute marker array for the given joint configuration.")
+          "q"_a,
+          "Compute marker array for the given joint configuration, restricted to the currently "
+          "selected joint group (see the constructor and set_group).")
+      .def("set_group", &roboplan_ros_visualization::RoboplanVisualizer::set_group, "group_name"_a,
+           "Select the joint group whose links are rendered. Pass an empty string for the whole "
+           "scene. Raises if the group name is not found in the scene.")
       .def(
           "clear_markers",
           [MarkerArray](roboplan_ros_visualization::RoboplanVisualizer& self) {

--- a/roboplan_ros_visualization/bindings/test/roboplan_visualizer_test.py
+++ b/roboplan_ros_visualization/bindings/test/roboplan_visualizer_test.py
@@ -29,6 +29,58 @@ EMPTY_SRDF = """<?xml version="1.0"?>
 """
 
 
+TWO_LINK_URDF = """<?xml version="1.0"?>
+<robot name="two_link_robot">
+  <link name="world"/>
+  <link name="link1">
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+  <link name="link2">
+    <visual>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+  <joint name="joint1" type="revolute">
+    <parent link="world"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.25" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.25" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+
+TWO_LINK_SRDF = """<?xml version="1.0"?>
+<robot name="two_link_robot">
+  <group name="first">
+    <joint name="joint1"/>
+  </group>
+</robot>
+"""
+
+
 def test_import():
     from roboplan_ros import visualization
 
@@ -49,3 +101,42 @@ def test_visualize_configuration():
     assert (
         len(marker_array.markers) == 1
     ), f"Expected 1 marker, got {len(marker_array.markers)}"
+
+
+def test_visualize_joint_group():
+    scene = Scene(name="test", urdf=TWO_LINK_URDF, srdf=TWO_LINK_SRDF)
+    viz = RoboplanVisualizer(scene=scene, urdf_xml=TWO_LINK_URDF)
+
+    q = scene.getCurrentJointPositions()
+
+    # The whole scene has two visual geometries.
+    all_markers = viz.markers_from_configuration(q)
+    assert (
+        len(all_markers.markers) == 2
+    ), f"Expected 2 markers, got {len(all_markers.markers)}"
+
+    # The "first" group only drives link1, so a single marker should be returned.
+    viz.set_group("first")
+    group_markers = viz.markers_from_configuration(q)
+    assert (
+        len(group_markers.markers) == 1
+    ), f"Expected 1 marker, got {len(group_markers.markers)}"
+
+    # Switching back to the whole scene renders both geometries again.
+    viz.set_group("")
+    all_markers = viz.markers_from_configuration(q)
+    assert (
+        len(all_markers.markers) == 2
+    ), f"Expected 2 markers, got {len(all_markers.markers)}"
+
+
+def test_constructor_group_name():
+    scene = Scene(name="test", urdf=TWO_LINK_URDF, srdf=TWO_LINK_SRDF)
+    # Configure the group at construction time.
+    viz = RoboplanVisualizer(scene=scene, urdf_xml=TWO_LINK_URDF, group_name="first")
+
+    q = scene.getCurrentJointPositions()
+
+    # The constructor's group ("first") is used.
+    markers = viz.markers_from_configuration(q)
+    assert len(markers.markers) == 1, f"Expected 1 marker, got {len(markers.markers)}"

--- a/roboplan_ros_visualization/include/roboplan_ros_visualization/roboplan_visualizer.hpp
+++ b/roboplan_ros_visualization/include/roboplan_ros_visualization/roboplan_visualizer.hpp
@@ -28,17 +28,30 @@ public:
   ///                 since Scene only holds the collision geometry model).
   /// @param frame_id The frame_id written into every marker header.
   /// @param ns Marker namespace prefix.
+  /// @param group_name Default joint group to render. When empty, the entire scene is rendered.
+  ///                   Otherwise, only the geometries of to the named group's links are emitted.
   /// @param color Optional override color applied to every marker.
   RoboplanVisualizer(std::shared_ptr<const roboplan::Scene> scene, const std::string& urdf_xml,
                      const std::string& frame_id = "world", const std::string& ns = "/roboplan",
+                     const std::string& group_name = "",
                      const std::optional<std_msgs::msg::ColorRGBA>& color = std::nullopt);
 
   /// @brief Compute visualization markers for the given joint configuration.
-  /// @details Runs Pinocchio geometry placement updates and returns a MarkerArray that
-  /// the caller can publish however they like.
+  /// @details Runs Pinocchio geometry placement updates and returns a MarkerArray that the caller
+  /// can publish however they like. Only the geometry belonging to the currently selected group
+  /// (see the constructor and set_group) is emitted, which is useful for cutting down on visual
+  /// noise. The group's geometry selection is cached, so this is cheap to call repeatedly.
   /// @param q Joint positions (size must match the scene model's nq).
-  /// @return MarkerArray with one marker per supported visual geometry.
+  /// @return MarkerArray with one marker per supported visual geometry in the selection.
   visualization_msgs::msg::MarkerArray markers_from_configuration(const Eigen::VectorXd& q) const;
+
+  /// @brief Select the joint group whose links should be rendered.
+  /// @details Recomputes and caches the geometry selection for the given group. Pass an empty
+  /// string to render the entire scene. A group's links are derived from the scene's
+  /// JointGroupInfo.
+  /// @param group_name The joint group name, or an empty string for the whole scene.
+  /// @throws std::runtime_error if the group name is not found in the scene.
+  void set_group(const std::string& group_name);
 
   /// @brief Build a MarkerArray containing a single DELETEALL marker.
   static visualization_msgs::msg::MarkerArray clear_markers();
@@ -50,6 +63,12 @@ public:
   void clear_color();
 
 private:
+  /// @brief Determine which visual geometry objects belong to a joint group.
+  /// @param group_name The joint group name, or an empty string for the whole scene.
+  /// @return The indices into visual_model_.geometryObjects that should be rendered.
+  /// For an empty group name, every geometry index in the model is returned.
+  std::vector<std::size_t> geometry_indices_for_group(const std::string& group_name) const;
+
   /// @brief Create a visualization marker for a single geometry object.
   /// @param marker_id Unique marker ID.
   /// @param geom_obj The Pinocchio geometry object to visualize.
@@ -70,6 +89,13 @@ private:
 
   /// @brief Namespace for the generated markers
   std::string ns_;
+
+  /// @brief Currently selected joint group to render. Empty means render the entire scene.
+  std::string group_name_;
+
+  /// @brief Cached geometry indices for the selected group. Recomputed only when the group
+  /// changes (construction or set_group), so rendering does not redo the selection each call.
+  std::vector<std::size_t> geometry_indices_;
 
   /// @brief Optionally set to override colors of all markers before rendering
   std::optional<std_msgs::msg::ColorRGBA> color_;

--- a/roboplan_ros_visualization/src/roboplan_visualizer.cpp
+++ b/roboplan_ros_visualization/src/roboplan_visualizer.cpp
@@ -1,3 +1,7 @@
+#include <numeric>
+#include <stdexcept>
+#include <unordered_set>
+
 #include <pinocchio/algorithm/geometry.hpp>
 #include <pinocchio/parsers/urdf.hpp>
 
@@ -25,14 +29,19 @@ namespace roboplan_ros_visualization {
 
 RoboplanVisualizer::RoboplanVisualizer(std::shared_ptr<const roboplan::Scene> scene,
                                        const std::string& urdf_xml, const std::string& frame_id,
-                                       const std::string& ns,
+                                       const std::string& ns, const std::string& group_name,
                                        const std::optional<std_msgs::msg::ColorRGBA>& color)
-    : scene_(std::move(scene)), frame_id_(frame_id), ns_(ns), color_(color) {
+    : scene_(std::move(scene)), frame_id_(frame_id), ns_(ns), group_name_(group_name),
+      color_(color) {
   // Build a visual GeometryModel from the URDF.
   // Scene only holds the collision model, so we need this for rendering.
   const auto& model = scene_->getModel();
   std::istringstream urdf_stream(urdf_xml);
   pinocchio::urdf::buildGeom(model, urdf_stream, pinocchio::VISUAL, visual_model_);
+
+  // Resolve the group's geometry selection once up front. It is recomputed only when the group
+  // changes via set_group, so rendering never redoes the selection on the hot path.
+  geometry_indices_ = geometry_indices_for_group(group_name_);
 }
 
 visualization_msgs::msg::MarkerArray
@@ -45,7 +54,8 @@ RoboplanVisualizer::markers_from_configuration(const Eigen::VectorXd& q) const {
   pinocchio::GeometryData visual_data(visual_model_);
   pinocchio::updateGeometryPlacements(model, data, visual_model_, visual_data, q);
 
-  for (std::size_t idx = 0; idx < visual_model_.geometryObjects.size(); ++idx) {
+  // Only emit markers for the geometry objects that belong to the selected group.
+  for (const std::size_t idx : geometry_indices_) {
     const auto& geom_obj = visual_model_.geometryObjects.at(idx);
     const pinocchio::SE3& placement = visual_data.oMg.at(idx);
 
@@ -56,6 +66,44 @@ RoboplanVisualizer::markers_from_configuration(const Eigen::VectorXd& q) const {
   }
 
   return marker_array;
+}
+
+void RoboplanVisualizer::set_group(const std::string& group_name) {
+  // Compute the new selection first so a bad group name leaves the visualizer unchanged.
+  geometry_indices_ = geometry_indices_for_group(group_name);
+  group_name_ = group_name;
+}
+
+std::vector<std::size_t>
+RoboplanVisualizer::geometry_indices_for_group(const std::string& group_name) const {
+  std::vector<std::size_t> indices;
+
+  // An empty group name means "the whole scene", so render every geometry object.
+  if (group_name.empty()) {
+    indices.resize(visual_model_.geometryObjects.size());
+    std::iota(indices.begin(), indices.end(), std::size_t{0});
+    return indices;
+  }
+
+  const auto maybe_info = scene_->getJointGroupInfo(group_name);
+  if (!maybe_info) {
+    throw std::runtime_error("RoboplanVisualizer: " + maybe_info.error());
+  }
+  const auto& link_names = maybe_info.value().link_names;
+  const std::unordered_set<std::string> link_set(link_names.begin(), link_names.end());
+
+  // A geometry object belongs to the group when the link (body frame) it is attached to is one
+  // of the group's links.
+  const auto& model = scene_->getModel();
+  for (std::size_t idx = 0; idx < visual_model_.geometryObjects.size(); ++idx) {
+    const auto& geom_obj = visual_model_.geometryObjects.at(idx);
+    if (geom_obj.parentFrame < model.frames.size() &&
+        link_set.count(model.frames.at(geom_obj.parentFrame).name) > 0) {
+      indices.push_back(idx);
+    }
+  }
+
+  return indices;
 }
 
 visualization_msgs::msg::MarkerArray RoboplanVisualizer::clear_markers() {

--- a/roboplan_ros_visualization/test/roboplan_visualizer_test.cpp
+++ b/roboplan_ros_visualization/test/roboplan_visualizer_test.cpp
@@ -1,5 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
 #include <Eigen/Core>
 
 #include <roboplan/core/scene.hpp>
@@ -54,6 +58,64 @@ static const std::string EMPTY_SRDF = R"(<?xml version="1.0"?>
 </robot>
 )";
 
+// A two-link robot, each link carrying a distinct visual geometry, used to exercise filtering
+// the published markers down to a single joint group.
+static const std::string TWO_LINK_URDF = R"(<?xml version="1.0"?>
+<robot name="two_link_robot">
+  <link name="world"/>
+  <link name="link1">
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+  <link name="link2">
+    <visual>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+    </visual>
+    <inertial>
+      <mass value="1.0"/>
+      <inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+  <joint name="joint1" type="revolute">
+    <parent link="world"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.25" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.25" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14" effort="10" velocity="1"/>
+  </joint>
+</robot>
+)";
+
+// Defines a group containing only the first joint/link, plus a group that lists the second
+// joint and additionally pulls in the first link via an explicit <link> element.
+static const std::string TWO_LINK_SRDF = R"(<?xml version="1.0"?>
+<robot name="two_link_robot">
+  <group name="first">
+    <joint name="joint1"/>
+  </group>
+  <group name="second_plus">
+    <joint name="joint2"/>
+    <link name="link1"/>
+  </group>
+</robot>
+)";
+
 class RoboplanVisualizerTest : public ::testing::Test {};
 
 TEST_F(RoboplanVisualizerTest, VisualizeFixedJointConfiguration) {
@@ -87,6 +149,82 @@ TEST_F(RoboplanVisualizerTest, VisualizeRevoluteJointConfiguration) {
   const auto marker_array_new = viz.clear_markers();
   ASSERT_EQ(marker_array_new.markers.size(), 1u);
   EXPECT_EQ(marker_array_new.markers[0].action, visualization_msgs::msg::Marker::DELETEALL);
+}
+
+TEST_F(RoboplanVisualizerTest, VisualizeFullSceneByDefault) {
+  const auto scene = std::make_shared<roboplan::Scene>("test", TWO_LINK_URDF, TWO_LINK_SRDF);
+  RoboplanVisualizer viz(scene, TWO_LINK_URDF);
+
+  const Eigen::VectorXd q = scene->getCurrentJointPositions();
+
+  // With no group selected, both links' geometry should be rendered.
+  const auto all_markers = viz.markers_from_configuration(q);
+  ASSERT_EQ(all_markers.markers.size(), 2u);
+
+  // Selecting the empty group explicitly is equivalent to the whole scene.
+  viz.set_group("");
+  ASSERT_EQ(viz.markers_from_configuration(q).markers.size(), 2u);
+}
+
+TEST_F(RoboplanVisualizerTest, VisualizeSingleJointGroupViaSetGroup) {
+  const auto scene = std::make_shared<roboplan::Scene>("test", TWO_LINK_URDF, TWO_LINK_SRDF);
+  RoboplanVisualizer viz(scene, TWO_LINK_URDF);
+
+  const Eigen::VectorXd q = scene->getCurrentJointPositions();
+
+  // The "first" group only drives link1, which carries the box geometry.
+  viz.set_group("first");
+  const auto first_markers = viz.markers_from_configuration(q);
+  ASSERT_EQ(first_markers.markers.size(), 1u);
+  EXPECT_EQ(first_markers.markers[0].type, visualization_msgs::msg::Marker::CUBE);
+
+  // Switching back to the whole scene takes effect immediately.
+  viz.set_group("");
+  ASSERT_EQ(viz.markers_from_configuration(q).markers.size(), 2u);
+}
+
+TEST_F(RoboplanVisualizerTest, VisualizeGroupWithExplicitLink) {
+  const auto scene = std::make_shared<roboplan::Scene>("test", TWO_LINK_URDF, TWO_LINK_SRDF);
+  // The "second_plus" group drives link2 (sphere) and additionally lists link1 (box) explicitly,
+  // so both geometries should be rendered.
+  RoboplanVisualizer viz(scene, TWO_LINK_URDF, "world", "/roboplan", "second_plus");
+
+  const Eigen::VectorXd q = scene->getCurrentJointPositions();
+  const auto markers = viz.markers_from_configuration(q);
+  ASSERT_EQ(markers.markers.size(), 2u);
+
+  std::vector<decltype(visualization_msgs::msg::Marker::type)> types;
+  for (const auto& marker : markers.markers) {
+    types.push_back(marker.type);
+  }
+  EXPECT_NE(std::find(types.begin(), types.end(), visualization_msgs::msg::Marker::CUBE),
+            types.end());
+  EXPECT_NE(std::find(types.begin(), types.end(), visualization_msgs::msg::Marker::SPHERE),
+            types.end());
+}
+
+TEST_F(RoboplanVisualizerTest, ConstructorGroupIsUsed) {
+  const auto scene = std::make_shared<roboplan::Scene>("test", TWO_LINK_URDF, TWO_LINK_SRDF);
+  // Configure the visualizer with the "first" group as its selection.
+  RoboplanVisualizer viz(scene, TWO_LINK_URDF, "world", "/roboplan", "first");
+
+  const Eigen::VectorXd q = scene->getCurrentJointPositions();
+
+  // The constructor's group is used (link1, the box).
+  const auto markers = viz.markers_from_configuration(q);
+  ASSERT_EQ(markers.markers.size(), 1u);
+  EXPECT_EQ(markers.markers[0].type, visualization_msgs::msg::Marker::CUBE);
+}
+
+TEST_F(RoboplanVisualizerTest, UnknownGroupThrows) {
+  const auto scene = std::make_shared<roboplan::Scene>("test", TWO_LINK_URDF, TWO_LINK_SRDF);
+
+  // An unknown group is rejected both at construction and via set_group.
+  EXPECT_THROW(RoboplanVisualizer(scene, TWO_LINK_URDF, "world", "/roboplan", "does_not_exist"),
+               std::runtime_error);
+
+  RoboplanVisualizer viz(scene, TWO_LINK_URDF);
+  EXPECT_THROW(viz.set_group("does_not_exist"), std::runtime_error);
 }
 
 }  // namespace roboplan_ros_visualization


### PR DESCRIPTION
This PR accompanies https://github.com/open-planning/roboplan/pull/253 to support subgroups of the entire model in `RoboplanVisualizer`. This can be made clear by looking at the NASA CLR model. All the distractors are gone!

[roboplan_ros_clr_visualize_group.webm](https://github.com/user-attachments/assets/3851ad97-38e9-4ec8-8173-bac961f8a2b8)

(note btw that we could add the finger links to the SRDF group to render them should we want to, but that's beyond this PR)

Closes https://github.com/open-planning/roboplan-ros/issues/48