### PR TITLE
Fix ament_cmake dependency in roboplan_ros_examples

### DIFF
--- a/roboplan_ros_examples/roboplan_ros_examples/package.xml
+++ b/roboplan_ros_examples/roboplan_ros_examples/package.xml
@@ -12,6 +12,7 @@
   <url type="repository">https://github.com/open-planning/roboplan-ros</url>
   <url type="bugtracker">https://github.com/open-planning/roboplan-ros/issues</url>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>control_msgs</exec_depend>


### PR DESCRIPTION
Found when building for RoboStack